### PR TITLE
feat(privacy): Persist privacy budget across restarts

### DIFF
--- a/migrations/014-privacy-budget.sql
+++ b/migrations/014-privacy-budget.sql
@@ -1,0 +1,160 @@
+-- ============================================================================
+-- Migration 014: Privacy Budget Persistence
+-- ============================================================================
+-- Persists differential privacy budget state across restarts.
+-- Closes #144
+--
+-- Tables:
+--   - privacy_budgets: Federation privacy budget state
+-- ============================================================================
+
+-- ============================================================================
+-- PHASE 1: PRIVACY_BUDGETS TABLE
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS privacy_budgets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    
+    -- Federation identifier (string for flexibility with different ID formats)
+    federation_id TEXT UNIQUE NOT NULL,
+    
+    -- Budget configuration
+    daily_epsilon_budget REAL NOT NULL DEFAULT 10.0,
+    daily_delta_budget REAL NOT NULL DEFAULT 0.0001,
+    budget_period_hours INTEGER NOT NULL DEFAULT 24,
+    
+    -- Current spend
+    spent_epsilon REAL NOT NULL DEFAULT 0.0,
+    spent_delta REAL NOT NULL DEFAULT 0.0,
+    queries_today INTEGER NOT NULL DEFAULT 0,
+    
+    -- Period tracking
+    period_start TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    
+    -- Full state (JSONB for topic_budgets and requester_budgets)
+    -- Stores serialized state for complex nested structures
+    topic_budgets JSONB NOT NULL DEFAULT '{}',
+    requester_budgets JSONB NOT NULL DEFAULT '{}',
+    
+    -- Schema version for future migrations
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for fast lookup by federation_id
+CREATE INDEX IF NOT EXISTS idx_privacy_budgets_federation_id 
+    ON privacy_budgets(federation_id);
+
+-- Index for finding budgets that need period reset
+CREATE INDEX IF NOT EXISTS idx_privacy_budgets_period_start 
+    ON privacy_budgets(period_start);
+
+-- ============================================================================
+-- PHASE 2: TRIGGERS
+-- ============================================================================
+
+-- Trigger to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_privacy_budgets_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS privacy_budgets_updated ON privacy_budgets;
+CREATE TRIGGER privacy_budgets_updated
+    BEFORE UPDATE ON privacy_budgets
+    FOR EACH ROW
+    EXECUTE FUNCTION update_privacy_budgets_timestamp();
+
+-- ============================================================================
+-- PHASE 3: HELPER FUNCTIONS
+-- ============================================================================
+
+-- Get budget for a federation, creating if not exists
+CREATE OR REPLACE FUNCTION get_or_create_privacy_budget(
+    p_federation_id TEXT,
+    p_daily_epsilon REAL DEFAULT 10.0,
+    p_daily_delta REAL DEFAULT 0.0001
+)
+RETURNS privacy_budgets AS $$
+DECLARE
+    v_budget privacy_budgets;
+BEGIN
+    -- Try to get existing
+    SELECT * INTO v_budget
+    FROM privacy_budgets
+    WHERE federation_id = p_federation_id;
+    
+    -- Create if not exists
+    IF NOT FOUND THEN
+        INSERT INTO privacy_budgets (
+            federation_id,
+            daily_epsilon_budget,
+            daily_delta_budget
+        ) VALUES (
+            p_federation_id,
+            p_daily_epsilon,
+            p_daily_delta
+        )
+        RETURNING * INTO v_budget;
+    END IF;
+    
+    RETURN v_budget;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Reset budget period if needed
+CREATE OR REPLACE FUNCTION maybe_reset_budget_period(
+    p_federation_id TEXT,
+    p_period_hours INTEGER DEFAULT 24
+)
+RETURNS BOOLEAN AS $$
+DECLARE
+    v_budget privacy_budgets;
+    v_hours_elapsed REAL;
+BEGIN
+    SELECT * INTO v_budget
+    FROM privacy_budgets
+    WHERE federation_id = p_federation_id;
+    
+    IF NOT FOUND THEN
+        RETURN FALSE;
+    END IF;
+    
+    -- Calculate hours since period start
+    v_hours_elapsed := EXTRACT(EPOCH FROM (NOW() - v_budget.period_start)) / 3600;
+    
+    IF v_hours_elapsed > p_period_hours THEN
+        UPDATE privacy_budgets
+        SET spent_epsilon = 0.0,
+            spent_delta = 0.0,
+            queries_today = 0,
+            topic_budgets = '{}',
+            period_start = NOW()
+        WHERE federation_id = p_federation_id;
+        
+        RETURN TRUE;
+    END IF;
+    
+    RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- PHASE 4: COMMENTS
+-- ============================================================================
+
+COMMENT ON TABLE privacy_budgets IS 'Persisted differential privacy budget state for federations';
+COMMENT ON COLUMN privacy_budgets.federation_id IS 'Unique federation identifier (UUID as string)';
+COMMENT ON COLUMN privacy_budgets.daily_epsilon_budget IS 'Maximum epsilon consumption per period';
+COMMENT ON COLUMN privacy_budgets.daily_delta_budget IS 'Maximum delta consumption per period';
+COMMENT ON COLUMN privacy_budgets.spent_epsilon IS 'Epsilon consumed in current period';
+COMMENT ON COLUMN privacy_budgets.spent_delta IS 'Delta consumed in current period';
+COMMENT ON COLUMN privacy_budgets.topic_budgets IS 'Per-topic query tracking (JSONB: topic_hash -> TopicBudget)';
+COMMENT ON COLUMN privacy_budgets.requester_budgets IS 'Per-requester rate limiting (JSONB: requester_id -> RequesterBudget)';
+COMMENT ON COLUMN privacy_budgets.period_start IS 'Start of current budget period';

--- a/src/valence/federation/__init__.py
+++ b/src/valence/federation/__init__.py
@@ -194,6 +194,11 @@ from .privacy import (
     TopicBudget,
     RequesterBudget,
     PrivacyBudget,
+    # Budget storage (Issue #144 - Persist privacy budget)
+    BudgetStore,
+    InMemoryBudgetStore,
+    FileBudgetStore,
+    DatabaseBudgetStore,
     # Temporal smoothing
     MembershipEvent,
     TemporalSmoother,
@@ -569,6 +574,11 @@ __all__ = [
     "TopicBudget",
     "RequesterBudget",
     "PrivacyBudget",
+    # Budget storage (Issue #144 - Persist privacy budget)
+    "BudgetStore",
+    "InMemoryBudgetStore",
+    "FileBudgetStore",
+    "DatabaseBudgetStore",
     "MembershipEvent",
     "TemporalSmoother",
     "add_laplace_noise",


### PR DESCRIPTION
Closes #144

## Summary
Privacy budgets (differential privacy epsilon consumption) are currently lost on restart. This PR adds persistence to the database so budgets survive restarts.

## Changes
1. **New migration** (`migrations/014-privacy-budget.sql`):
   - Creates `privacy_budgets` table to store budget state
   - Includes helper functions for budget management
   - Indexes for efficient lookup by federation_id

2. **DatabaseBudgetStore** (`src/valence/federation/privacy.py`):
   - PostgreSQL implementation of `BudgetStore` protocol
   - Supports both asyncpg (async) and psycopg2 (sync) connections
   - Full serialization of topic_budgets and requester_budgets
   - Auto-saves on `consume()` when attached to a PrivacyBudget

3. **Module exports**:
   - Added `BudgetStore`, `InMemoryBudgetStore`, `FileBudgetStore`, `DatabaseBudgetStore` to federation module exports

## Usage
```python
from valence.federation import DatabaseBudgetStore, PrivacyBudget

# With asyncpg pool
store = DatabaseBudgetStore(pool)
budget = PrivacyBudget.load_or_create(federation_id, store=store)

# With psycopg2 connection
store = DatabaseBudgetStore.from_sync_connection(conn)
budget = PrivacyBudget.load_or_create(federation_id, store=store)

# Budget now persists automatically on consume()
```

## Testing
- Syntax verified with py_compile
- Follows existing patterns in FileBudgetStore and InMemoryBudgetStore