### PR TITLE
Add config settings tests

### DIFF
--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,503 @@
+"""Tests for valence.core.config - CoreSettings and global config management.
+
+Tests cover:
+- Settings loading with defaults
+- Environment variable overrides
+- Singleton behavior (get_config / clear_config_cache)
+- Computed properties (database_url, connection_params, pool_config)
+- All setting categories: db, embedding, logging, cache, federation/seed
+- Federation config protocol and management
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from valence.core.config import (
+    CoreSettings,
+    FederationConfig,
+    FederationConfigProtocol,
+    clear_config_cache,
+    clear_federation_config,
+    get_config,
+    get_federation_config,
+    get_federation_config_or_none,
+    set_federation_config,
+)
+
+
+# ============================================================================
+# CoreSettings - Default Values
+# ============================================================================
+
+
+class TestCoreSettingsDefaults:
+    """Test that CoreSettings loads with correct default values."""
+
+    def test_database_defaults(self, clean_env):
+        """Test database settings have correct defaults."""
+        clear_config_cache()
+        settings = CoreSettings()
+
+        assert settings.db_host == "localhost"
+        assert settings.db_port == 5432
+        assert settings.db_name == "valence"
+        assert settings.db_user == "valence"
+        assert settings.db_password == ""
+        assert settings.db_pool_min == 5
+        assert settings.db_pool_max == 20
+
+    def test_embedding_defaults(self, clean_env):
+        """Test embedding settings have correct defaults."""
+        settings = CoreSettings()
+
+        assert settings.embedding_provider == "local"
+        assert settings.embedding_model_path == "BAAI/bge-small-en-v1.5"
+        assert settings.embedding_device == "cpu"
+        assert settings.openai_api_key == ""
+
+    def test_logging_defaults(self, clean_env):
+        """Test logging settings have correct defaults."""
+        settings = CoreSettings()
+
+        assert settings.log_level == "INFO"
+        assert settings.log_format == ""
+        assert settings.log_file is None
+
+    def test_cache_defaults(self, clean_env):
+        """Test cache settings have correct defaults."""
+        settings = CoreSettings()
+
+        assert settings.cache_max_size == 1000
+
+    def test_seed_node_defaults(self, clean_env):
+        """Test seed node settings have correct defaults."""
+        settings = CoreSettings()
+
+        assert settings.seed_host is None
+        assert settings.seed_port == 8470
+        assert settings.seed_id is None
+        assert settings.seed_peers is None
+
+    def test_federation_identity_defaults(self, clean_env):
+        """Test federation identity settings have correct defaults."""
+        settings = CoreSettings()
+
+        assert settings.federation_private_key is None
+        assert settings.federation_public_key is None
+        assert settings.federation_did is None
+        assert settings.trust_registry_path is None
+
+
+# ============================================================================
+# CoreSettings - Environment Variable Overrides
+# ============================================================================
+
+
+class TestCoreSettingsEnvOverrides:
+    """Test that environment variables properly override settings."""
+
+    def test_database_env_overrides(self, monkeypatch, clean_env):
+        """Test database settings from VKB_ prefixed env vars."""
+        monkeypatch.setenv("VKB_DB_HOST", "db.example.com")
+        monkeypatch.setenv("VKB_DB_PORT", "5433")
+        monkeypatch.setenv("VKB_DB_NAME", "test_db")
+        monkeypatch.setenv("VKB_DB_USER", "test_user")
+        monkeypatch.setenv("VKB_DB_PASSWORD", "secret123")
+
+        clear_config_cache()
+        settings = CoreSettings()
+
+        assert settings.db_host == "db.example.com"
+        assert settings.db_port == 5433
+        assert settings.db_name == "test_db"
+        assert settings.db_user == "test_user"
+        assert settings.db_password == "secret123"
+
+    def test_pool_env_overrides(self, monkeypatch, clean_env):
+        """Test connection pool settings from VALENCE_ prefixed env vars."""
+        monkeypatch.setenv("VALENCE_DB_POOL_MIN", "10")
+        monkeypatch.setenv("VALENCE_DB_POOL_MAX", "50")
+
+        settings = CoreSettings()
+
+        assert settings.db_pool_min == 10
+        assert settings.db_pool_max == 50
+
+    def test_embedding_env_overrides(self, monkeypatch, clean_env):
+        """Test embedding settings from env vars."""
+        monkeypatch.setenv("VALENCE_EMBEDDING_PROVIDER", "openai")
+        monkeypatch.setenv("VALENCE_EMBEDDING_MODEL_PATH", "custom/model")
+        monkeypatch.setenv("VALENCE_EMBEDDING_DEVICE", "cuda")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+
+        settings = CoreSettings()
+
+        assert settings.embedding_provider == "openai"
+        assert settings.embedding_model_path == "custom/model"
+        assert settings.embedding_device == "cuda"
+        assert settings.openai_api_key == "sk-test-key"
+
+    def test_logging_env_overrides(self, monkeypatch, clean_env):
+        """Test logging settings from env vars."""
+        monkeypatch.setenv("VALENCE_LOG_LEVEL", "DEBUG")
+        monkeypatch.setenv("VALENCE_LOG_FORMAT", "json")
+        monkeypatch.setenv("VALENCE_LOG_FILE", "/var/log/valence.log")
+
+        settings = CoreSettings()
+
+        assert settings.log_level == "DEBUG"
+        assert settings.log_format == "json"
+        assert settings.log_file == "/var/log/valence.log"
+
+    def test_cache_env_overrides(self, monkeypatch, clean_env):
+        """Test cache settings from env vars."""
+        monkeypatch.setenv("VALENCE_CACHE_MAX_SIZE", "5000")
+
+        settings = CoreSettings()
+
+        assert settings.cache_max_size == 5000
+
+    def test_seed_node_env_overrides(self, monkeypatch, clean_env):
+        """Test seed node settings from env vars."""
+        monkeypatch.setenv("VALENCE_SEED_HOST", "seed.example.com")
+        monkeypatch.setenv("VALENCE_SEED_PORT", "9000")
+        monkeypatch.setenv("VALENCE_SEED_ID", "seed-node-1")
+        monkeypatch.setenv("VALENCE_SEED_PEERS", "peer1:8470,peer2:8470")
+
+        settings = CoreSettings()
+
+        assert settings.seed_host == "seed.example.com"
+        assert settings.seed_port == 9000
+        assert settings.seed_id == "seed-node-1"
+        assert settings.seed_peers == "peer1:8470,peer2:8470"
+
+    def test_federation_identity_env_overrides(self, monkeypatch, clean_env):
+        """Test federation identity settings from env vars."""
+        monkeypatch.setenv("VALENCE_FEDERATION_PRIVATE_KEY", "abcd1234")
+        monkeypatch.setenv("VALENCE_FEDERATION_PUBLIC_KEY", "z6Mk...")
+        monkeypatch.setenv("VALENCE_FEDERATION_DID", "did:key:z6Mk...")
+        monkeypatch.setenv("VALENCE_TRUST_REGISTRY", "/etc/valence/trust.json")
+
+        settings = CoreSettings()
+
+        assert settings.federation_private_key == "abcd1234"
+        assert settings.federation_public_key == "z6Mk..."
+        assert settings.federation_did == "did:key:z6Mk..."
+        assert settings.trust_registry_path == "/etc/valence/trust.json"
+
+
+# ============================================================================
+# CoreSettings - Computed Properties
+# ============================================================================
+
+
+class TestCoreSettingsComputedProperties:
+    """Test computed properties on CoreSettings."""
+
+    def test_database_url(self, clean_env):
+        """Test database_url property constructs correct URL."""
+        settings = CoreSettings()
+        expected = "postgresql://valence:@localhost:5432/valence"
+        assert settings.database_url == expected
+
+    def test_database_url_with_password(self, monkeypatch, clean_env):
+        """Test database_url includes password when set."""
+        monkeypatch.setenv("VKB_DB_PASSWORD", "secret")
+        settings = CoreSettings()
+        expected = "postgresql://valence:secret@localhost:5432/valence"
+        assert settings.database_url == expected
+
+    def test_database_url_custom_values(self, monkeypatch, clean_env):
+        """Test database_url with fully custom settings."""
+        monkeypatch.setenv("VKB_DB_HOST", "db.prod.example.com")
+        monkeypatch.setenv("VKB_DB_PORT", "5433")
+        monkeypatch.setenv("VKB_DB_NAME", "prod_db")
+        monkeypatch.setenv("VKB_DB_USER", "prod_user")
+        monkeypatch.setenv("VKB_DB_PASSWORD", "prod_pass")
+
+        settings = CoreSettings()
+        expected = "postgresql://prod_user:prod_pass@db.prod.example.com:5433/prod_db"
+        assert settings.database_url == expected
+
+    def test_connection_params(self, clean_env):
+        """Test connection_params returns correct dict."""
+        settings = CoreSettings()
+        params = settings.connection_params
+
+        assert params == {
+            "host": "localhost",
+            "port": 5432,
+            "dbname": "valence",
+            "user": "valence",
+            "password": "",
+        }
+
+    def test_connection_params_custom(self, monkeypatch, clean_env):
+        """Test connection_params with custom values."""
+        monkeypatch.setenv("VKB_DB_HOST", "custom.host")
+        monkeypatch.setenv("VKB_DB_PORT", "6543")
+        monkeypatch.setenv("VKB_DB_NAME", "custom_db")
+        monkeypatch.setenv("VKB_DB_USER", "custom_user")
+        monkeypatch.setenv("VKB_DB_PASSWORD", "custom_pass")
+
+        settings = CoreSettings()
+        params = settings.connection_params
+
+        assert params == {
+            "host": "custom.host",
+            "port": 6543,
+            "dbname": "custom_db",
+            "user": "custom_user",
+            "password": "custom_pass",
+        }
+
+    def test_pool_config(self, clean_env):
+        """Test pool_config returns correct dict."""
+        settings = CoreSettings()
+        config = settings.pool_config
+
+        assert config == {
+            "minconn": 5,
+            "maxconn": 20,
+        }
+
+    def test_pool_config_custom(self, monkeypatch, clean_env):
+        """Test pool_config with custom values."""
+        monkeypatch.setenv("VALENCE_DB_POOL_MIN", "2")
+        monkeypatch.setenv("VALENCE_DB_POOL_MAX", "100")
+
+        settings = CoreSettings()
+        config = settings.pool_config
+
+        assert config == {
+            "minconn": 2,
+            "maxconn": 100,
+        }
+
+
+# ============================================================================
+# Singleton Behavior - get_config / clear_config_cache
+# ============================================================================
+
+
+class TestGetConfigSingleton:
+    """Test singleton behavior of get_config."""
+
+    def test_get_config_returns_settings(self, clean_env):
+        """Test get_config returns a CoreSettings instance."""
+        clear_config_cache()
+        config = get_config()
+        assert isinstance(config, CoreSettings)
+
+    def test_get_config_returns_same_instance(self, clean_env):
+        """Test get_config returns the same instance on repeated calls."""
+        clear_config_cache()
+        config1 = get_config()
+        config2 = get_config()
+        assert config1 is config2
+
+    def test_clear_config_cache_resets_singleton(self, clean_env):
+        """Test clear_config_cache allows new instance creation."""
+        clear_config_cache()
+        config1 = get_config()
+        clear_config_cache()
+        config2 = get_config()
+        assert config1 is not config2
+
+    def test_get_config_picks_up_env_changes_after_clear(self, monkeypatch, clean_env):
+        """Test that env changes are picked up after clearing cache."""
+        clear_config_cache()
+        config1 = get_config()
+        assert config1.log_level == "INFO"
+
+        monkeypatch.setenv("VALENCE_LOG_LEVEL", "DEBUG")
+        clear_config_cache()
+        config2 = get_config()
+        assert config2.log_level == "DEBUG"
+
+    def test_get_config_ignores_env_changes_without_clear(self, monkeypatch, clean_env):
+        """Test that env changes are NOT picked up without clearing cache."""
+        clear_config_cache()
+        config1 = get_config()
+        assert config1.log_level == "INFO"
+
+        monkeypatch.setenv("VALENCE_LOG_LEVEL", "DEBUG")
+        config2 = get_config()
+        # Same instance, no reload
+        assert config2.log_level == "INFO"
+        assert config1 is config2
+
+
+# ============================================================================
+# FederationConfig and Protocol
+# ============================================================================
+
+
+class TestFederationConfig:
+    """Test FederationConfig dataclass and protocol."""
+
+    def test_federation_config_defaults(self):
+        """Test FederationConfig has correct defaults."""
+        config = FederationConfig()
+
+        assert config.federation_node_did is None
+        assert config.federation_private_key is None
+        assert config.federation_sync_interval_seconds == 300
+        assert config.port == 8420
+
+    def test_federation_config_custom_values(self):
+        """Test FederationConfig with custom values."""
+        config = FederationConfig(
+            federation_node_did="did:key:z6Mk...",
+            federation_private_key="abcd1234",
+            federation_sync_interval_seconds=600,
+            port=9000,
+        )
+
+        assert config.federation_node_did == "did:key:z6Mk..."
+        assert config.federation_private_key == "abcd1234"
+        assert config.federation_sync_interval_seconds == 600
+        assert config.port == 9000
+
+    def test_federation_config_implements_protocol(self):
+        """Test FederationConfig implements FederationConfigProtocol."""
+        config = FederationConfig()
+        assert isinstance(config, FederationConfigProtocol)
+
+
+class TestFederationConfigManagement:
+    """Test global federation config management functions."""
+
+    def setup_method(self):
+        """Clear federation config before each test."""
+        clear_federation_config()
+
+    def teardown_method(self):
+        """Clear federation config after each test."""
+        clear_federation_config()
+
+    def test_get_federation_config_raises_when_not_set(self):
+        """Test get_federation_config raises RuntimeError when not set."""
+        with pytest.raises(RuntimeError) as exc_info:
+            get_federation_config()
+
+        assert "Federation config not initialized" in str(exc_info.value)
+
+    def test_get_federation_config_or_none_returns_none(self):
+        """Test get_federation_config_or_none returns None when not set."""
+        result = get_federation_config_or_none()
+        assert result is None
+
+    def test_set_and_get_federation_config(self):
+        """Test setting and getting federation config."""
+        config = FederationConfig(
+            federation_node_did="did:key:test",
+            federation_private_key="testkey",
+        )
+        set_federation_config(config)
+
+        retrieved = get_federation_config()
+        assert retrieved is config
+        assert retrieved.federation_node_did == "did:key:test"
+        assert retrieved.federation_private_key == "testkey"
+
+    def test_get_federation_config_or_none_returns_config(self):
+        """Test get_federation_config_or_none returns config when set."""
+        config = FederationConfig()
+        set_federation_config(config)
+
+        retrieved = get_federation_config_or_none()
+        assert retrieved is config
+
+    def test_clear_federation_config(self):
+        """Test clear_federation_config clears the global config."""
+        config = FederationConfig()
+        set_federation_config(config)
+
+        # Verify it's set
+        assert get_federation_config_or_none() is not None
+
+        # Clear and verify
+        clear_federation_config()
+        assert get_federation_config_or_none() is None
+
+    def test_set_federation_config_replaces_existing(self):
+        """Test that setting federation config replaces existing one."""
+        config1 = FederationConfig(port=8001)
+        config2 = FederationConfig(port=8002)
+
+        set_federation_config(config1)
+        assert get_federation_config().port == 8001
+
+        set_federation_config(config2)
+        assert get_federation_config().port == 8002
+
+
+# ============================================================================
+# Extra Configuration
+# ============================================================================
+
+
+class TestCoreSettingsExtraIgnored:
+    """Test that extra/unknown settings are ignored."""
+
+    def test_unknown_env_vars_ignored(self, monkeypatch, clean_env):
+        """Test that unknown VALENCE_ env vars don't cause errors."""
+        monkeypatch.setenv("VALENCE_UNKNOWN_SETTING", "some_value")
+        monkeypatch.setenv("VKB_RANDOM_THING", "another_value")
+
+        # Should not raise
+        settings = CoreSettings()
+        assert settings.db_host == "localhost"  # defaults still work
+
+    def test_model_config_extra_ignore(self, clean_env):
+        """Test that model_config has extra='ignore' set."""
+        settings = CoreSettings()
+        model_config = settings.model_config
+
+        assert model_config.get("extra") == "ignore"
+
+
+# ============================================================================
+# Type Coercion
+# ============================================================================
+
+
+class TestCoreSettingsTypeCoercion:
+    """Test that environment variables are coerced to correct types."""
+
+    def test_int_coercion_db_port(self, monkeypatch, clean_env):
+        """Test that db_port string is coerced to int."""
+        monkeypatch.setenv("VKB_DB_PORT", "5433")
+        settings = CoreSettings()
+        assert settings.db_port == 5433
+        assert isinstance(settings.db_port, int)
+
+    def test_int_coercion_pool_settings(self, monkeypatch, clean_env):
+        """Test that pool settings are coerced to int."""
+        monkeypatch.setenv("VALENCE_DB_POOL_MIN", "3")
+        monkeypatch.setenv("VALENCE_DB_POOL_MAX", "25")
+
+        settings = CoreSettings()
+        assert settings.db_pool_min == 3
+        assert settings.db_pool_max == 25
+        assert isinstance(settings.db_pool_min, int)
+        assert isinstance(settings.db_pool_max, int)
+
+    def test_int_coercion_cache_size(self, monkeypatch, clean_env):
+        """Test that cache_max_size is coerced to int."""
+        monkeypatch.setenv("VALENCE_CACHE_MAX_SIZE", "2000")
+        settings = CoreSettings()
+        assert settings.cache_max_size == 2000
+        assert isinstance(settings.cache_max_size, int)
+
+    def test_int_coercion_seed_port(self, monkeypatch, clean_env):
+        """Test that seed_port is coerced to int."""
+        monkeypatch.setenv("VALENCE_SEED_PORT", "9000")
+        settings = CoreSettings()
+        assert settings.seed_port == 9000
+        assert isinstance(settings.seed_port, int)


### PR DESCRIPTION
## Summary
Comprehensive test coverage for `CoreSettings` in `valence.core.config`.

## Tests Added (40 total)
- **Defaults** (6 tests): All setting categories have correct default values
- **Env Overrides** (7 tests): VKB_/VALENCE_/OPENAI_ env vars work correctly
- **Computed Properties** (7 tests): database_url, connection_params, pool_config
- **Singleton Behavior** (5 tests): get_config() returns same instance, clear_config_cache() resets
- **FederationConfig** (3 tests): Dataclass defaults, custom values, protocol compliance
- **Federation Management** (6 tests): set/get/clear federation config functions
- **Extra Ignored** (2 tests): Unknown env vars don't cause errors
- **Type Coercion** (4 tests): String env vars coerced to correct types

Partial fix for #155