### PR TITLE
docs: fix OpenAPI contact URL

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -38,7 +38,7 @@ info:
   version: 1.0.0
   contact:
     name: Valence
-    url: https://github.com/valence-dev/valence
+    url: https://github.com/orobobos/valence
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT


### PR DESCRIPTION
Fixes #182

Updates the contact URL in `docs/openapi.yaml` from the old `valence-dev` org to the current `orobobos` org.

- Changes `https://github.com/valence-dev/valence` → `https://github.com/orobobos/valence`
- Verified no other stale valence-dev references exist in the repo