### PR TITLE
fix: escape ILIKE metacharacters in search functions

### DIFF
--- a/src/valence/core/utils.py
+++ b/src/valence/core/utils.py
@@ -1,0 +1,17 @@
+"""Core utilities for Valence."""
+
+
+def escape_ilike(s: str) -> str:
+    """Escape ILIKE metacharacters for safe SQL pattern matching.
+
+    PostgreSQL ILIKE treats '%' as wildcard (any chars) and '_' as wildcard
+    (single char). This function escapes these characters so user input is
+    matched literally.
+
+    Args:
+        s: The string to escape.
+
+    Returns:
+        The escaped string safe for use in ILIKE patterns.
+    """
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/src/valence/substrate/tools.py
+++ b/src/valence/substrate/tools.py
@@ -15,6 +15,7 @@ from mcp.types import Tool
 from ..core.db import get_cursor
 from ..core.models import Belief, Entity, Tension
 from ..core.confidence import DimensionalConfidence
+from ..core.utils import escape_ilike
 
 logger = logging.getLogger(__name__)
 
@@ -704,7 +705,7 @@ def entity_search(
             WHERE (name ILIKE %s OR %s = ANY(aliases))
             AND canonical_id IS NULL
         """
-        params: list[Any] = [f"%{query}%", query]
+        params: list[Any] = [f"%{escape_ilike(query)}%", query]
 
         if type:
             sql += " AND type = %s"

--- a/src/valence/vkb/tools.py
+++ b/src/valence/vkb/tools.py
@@ -16,6 +16,7 @@ from mcp.types import Tool
 from ..core.db import get_cursor
 from ..core.models import Session, Exchange, Pattern
 from ..core.confidence import DimensionalConfidence
+from ..core.utils import escape_ilike
 
 logger = logging.getLogger(__name__)
 
@@ -722,7 +723,7 @@ def pattern_search(
             ORDER BY confidence DESC
             LIMIT %s
             """,
-            (f"%{query}%", limit),
+            (f"%{escape_ilike(query)}%", limit),
         )
         rows = cur.fetchall()
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,0 +1,64 @@
+"""Tests for core utilities."""
+
+import pytest
+
+from valence.core.utils import escape_ilike
+
+
+class TestEscapeIlike:
+    """Tests for escape_ilike function."""
+
+    def test_plain_text_unchanged(self):
+        """Plain text without metacharacters passes through unchanged."""
+        assert escape_ilike("hello world") == "hello world"
+        assert escape_ilike("simple query") == "simple query"
+        assert escape_ilike("") == ""
+
+    def test_escapes_percent(self):
+        """Percent signs are escaped."""
+        assert escape_ilike("100%") == "100\\%"
+        assert escape_ilike("%match%") == "\\%match\\%"
+        assert escape_ilike("50% off") == "50\\% off"
+
+    def test_escapes_underscore(self):
+        """Underscores are escaped."""
+        assert escape_ilike("snake_case") == "snake\\_case"
+        assert escape_ilike("_prefix") == "\\_prefix"
+        assert escape_ilike("suffix_") == "suffix\\_"
+        assert escape_ilike("a_b_c") == "a\\_b\\_c"
+
+    def test_escapes_backslash(self):
+        """Backslashes are escaped."""
+        assert escape_ilike("path\\to\\file") == "path\\\\to\\\\file"
+        assert escape_ilike("\\start") == "\\\\start"
+        assert escape_ilike("end\\") == "end\\\\"
+
+    def test_escapes_combined_metacharacters(self):
+        """Multiple metacharacters are all escaped."""
+        assert escape_ilike("100% of _all_") == "100\\% of \\_all\\_"
+        assert escape_ilike("%_\\") == "\\%\\_\\\\"
+        assert escape_ilike("a_b%c\\d") == "a\\_b\\%c\\\\d"
+
+    def test_backslash_escaped_before_others(self):
+        """Backslash must be escaped first to avoid double-escaping.
+
+        If we escaped % before \\, then "\\%" would become "\\\\%" (wrong).
+        Correct order: \\ -> \\\\ first, then % -> \\%.
+        """
+        # Input: \%  (backslash followed by percent)
+        # Correct: \\% -> \\\\\\% (escaped backslash + escaped percent)
+        assert escape_ilike("\\%") == "\\\\\\%"
+        assert escape_ilike("\\_") == "\\\\\\_"
+
+    def test_preserves_safe_special_chars(self):
+        """Characters that aren't ILIKE metacharacters are preserved."""
+        assert escape_ilike("user@email.com") == "user@email.com"
+        assert escape_ilike("hello! (test)") == "hello! (test)"
+        assert escape_ilike("[brackets]") == "[brackets]"
+        assert escape_ilike("a*b+c?") == "a*b+c?"
+
+    def test_unicode_preserved(self):
+        """Unicode characters pass through unchanged."""
+        assert escape_ilike("日本語") == "日本語"
+        assert escape_ilike("émoji 🎉") == "émoji 🎉"
+        assert escape_ilike("100% 日本語") == "100\\% 日本語"


### PR DESCRIPTION
## Summary

Fixes #171 - Security: Escape ILIKE metacharacters in search functions

## Changes

- Add `escape_ilike()` helper function in `core/utils.py` to escape SQL ILIKE metacharacters (`%`, `_`, `\\`) in user input
- Apply escaping to `pattern_search()` in `vkb/tools.py`
- Apply escaping to `entity_search()` in `substrate/tools.py`
- Add comprehensive test suite in `tests/core/test_utils.py`

## Security

This prevents:
- Pattern injection attacks where user input could alter query behavior
- Unexpected wildcard matching (e.g., searching for `100%` would match anything starting with `100`)

## Testing

All 8 new tests pass, covering:
- Plain text passthrough
- Percent sign escaping
- Underscore escaping
- Backslash escaping (done first to avoid double-escaping)
- Combined metacharacters
- Safe special characters preserved
- Unicode support