### PR TITLE
fix: use constant-time comparison for OAuth credentials (closes #169)

### DIFF
--- a/src/valence/server/oauth.py
+++ b/src/valence/server/oauth.py
@@ -235,8 +235,9 @@ async def _handle_authorize_post(
     username = form.get("username", "")
     password = form.get("password", "")
 
-    # Validate credentials
-    if username != settings.oauth_username or password != settings.oauth_password:
+    # Validate credentials using constant-time comparison to prevent timing attacks
+    if not (secrets.compare_digest(username, settings.oauth_username or "") and
+            secrets.compare_digest(password, settings.oauth_password or "")):
         # Re-show login with error
         params = dict(request.query_params)
         return HTMLResponse(_login_page(params, "Valence", error="Invalid username or password"))


### PR DESCRIPTION
## Summary
Fixes #169 - Security: Timing attack in OAuth password comparison

## Changes
- Replace direct string comparison with `secrets.compare_digest()` for username and password validation in the OAuth authorization flow
- This prevents timing attacks that could leak information about valid credentials
- Added defensive `or ""` handling for potentially None settings values

## Testing
- Added `test_authorize_uses_timing_safe_comparison` that verifies:
  - `secrets.compare_digest` is called for credential validation
  - Both username and password are compared using constant-time algorithm
  - Login still works with valid credentials

All 28 oauth tests pass.