### PR TITLE
fix: use secrets module for security-sensitive randomness

### DIFF
--- a/src/valence/federation/privacy.py
+++ b/src/valence/federation/privacy.py
@@ -13,8 +13,11 @@ from __future__ import annotations
 import hashlib
 import json
 import math
-import random
+import secrets
 from abc import ABC, abstractmethod
+
+# Use cryptographically secure RNG for privacy-sensitive decisions
+_secure_random = secrets.SystemRandom()
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -1288,7 +1291,8 @@ class TemporalSmoother:
         weight = 1.0 - (hours_since_departure / self.smoothing_hours)
 
         # Probabilistic inclusion for additional privacy
-        if random.random() > weight:
+        # Use cryptographically secure RNG for privacy-sensitive decisions
+        if _secure_random.random() > weight:
             return 0.0
 
         return weight

--- a/src/valence/network/config.py
+++ b/src/valence/network/config.py
@@ -17,7 +17,10 @@ Issue #120 - Traffic Analysis Mitigations
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, List, Dict, Any
-import random
+import secrets
+
+# Use cryptographically secure RNG for timing jitter (traffic analysis resistance)
+_secure_random = secrets.SystemRandom()
 
 
 class PrivacyLevel(Enum):
@@ -118,12 +121,14 @@ class TimingJitterConfig:
         
         if self.distribution == "exponential":
             # Exponential distribution with mean at (max-min)/2
+            # Use secrets.SystemRandom for security-sensitive timing jitter
             mean = (self.max_delay_ms - self.min_delay_ms) / 2
-            delay = self.min_delay_ms + random.expovariate(1.0 / mean)
+            delay = self.min_delay_ms + _secure_random.expovariate(1.0 / mean)
             delay = min(delay, self.max_delay_ms)
         else:
             # Uniform distribution
-            delay = random.uniform(self.min_delay_ms, self.max_delay_ms)
+            # Use secrets.SystemRandom for security-sensitive timing jitter
+            delay = _secure_random.uniform(self.min_delay_ms, self.max_delay_ms)
         
         return delay / 1000.0  # Convert to seconds
 

--- a/src/valence/network/messages.py
+++ b/src/valence/network/messages.py
@@ -22,8 +22,12 @@ from dataclasses import dataclass, field
 from typing import Optional, List, Tuple
 import json
 import os
+import secrets
 import time
 import uuid
+
+# Use cryptographically secure RNG for security-sensitive operations
+_secure_random = secrets.SystemRandom()
 
 
 # =============================================================================
@@ -555,9 +559,9 @@ def generate_cover_content(target_bucket: Optional[int] = None) -> bytes:
     """
     if target_bucket is None:
         # Random bucket selection weighted toward smaller (more common)
-        import random
+        # Use secrets.SystemRandom for security-sensitive cover traffic
         weights = [0.5, 0.3, 0.15, 0.05]  # Favor smaller buckets
-        target_bucket = random.choices(MESSAGE_SIZE_BUCKETS, weights=weights, k=1)[0]
+        target_bucket = _secure_random.choices(MESSAGE_SIZE_BUCKETS, weights=weights, k=1)[0]
     
     # Account for JSON overhead of CoverMessage (~150 bytes typical)
     # and padding overhead (1 byte marker)

--- a/src/valence/network/router_client.py
+++ b/src/valence/network/router_client.py
@@ -14,8 +14,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import random
+import secrets
 import time
+
+# Use cryptographically secure RNG for router selection (prevents predictable routing)
+_secure_random = secrets.SystemRandom()
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Set, TYPE_CHECKING
 
@@ -174,8 +177,8 @@ class RouterClient:
             
             weights.append(max(0.01, combined_score))
         
-        # Weighted random selection
-        selected = random.choices(candidates, weights=weights, k=1)[0]
+        # Weighted random selection using cryptographically secure RNG
+        selected = _secure_random.choices(candidates, weights=weights, k=1)[0]
         return selected.router
     
     async def handle_router_failure(

--- a/src/valence/network/seed.py
+++ b/src/valence/network/seed.py
@@ -29,9 +29,11 @@ import hashlib
 import json
 import logging
 import os
-import random
 import secrets
 import time
+
+# Use cryptographically secure RNG for router sampling (prevents predictable patterns)
+_secure_random = secrets.SystemRandom()
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
@@ -209,7 +211,7 @@ class HealthMonitor:
                 continue
             
             sample_size = min(self.probe_sample_size, len(routers))
-            sample = random.sample(routers, sample_size)
+            sample = _secure_random.sample(routers, sample_size)
             
             logger.debug(f"Probing {len(sample)} routers")
             
@@ -1862,9 +1864,9 @@ class SeedPeerManager:
             
             candidates.append(router)
         
-        # Randomize and limit
+        # Randomize and limit using cryptographically secure RNG
         if len(candidates) > self.batch_size:
-            candidates = random.sample(candidates, self.batch_size)
+            candidates = _secure_random.sample(candidates, self.batch_size)
         
         return [r.to_dict() for r in candidates]
     

--- a/tests/security/test_secrets_randomness.py
+++ b/tests/security/test_secrets_randomness.py
@@ -1,0 +1,251 @@
+"""
+Tests for cryptographically secure randomness (Issue #170).
+
+Verifies that security-sensitive operations use the secrets module
+instead of the standard random module, which is predictable if seeded.
+
+Security-sensitive operations that require secrets:
+- Timing jitter (traffic analysis resistance)
+- Message bucket selection (cover traffic)
+- Router selection (prevents predictable routing)
+- Router sampling (prevents predictable patterns)
+- Privacy weight decisions
+
+Non-security operations that can use random/np.random:
+- Differential privacy noise (needs specific distributions)
+- Test data generation
+- UX shuffling
+"""
+
+import secrets
+from unittest.mock import patch
+
+import pytest
+
+
+class TestSecretsModuleUsage:
+    """Verify security-sensitive code uses secrets module."""
+
+    def test_config_uses_secure_random(self):
+        """TimingJitterConfig should use secrets.SystemRandom."""
+        from valence.network.config import _secure_random
+        
+        assert isinstance(_secure_random, secrets.SystemRandom), (
+            "config._secure_random must be secrets.SystemRandom"
+        )
+
+    def test_messages_uses_secure_random(self):
+        """Messages module should use secrets.SystemRandom."""
+        from valence.network.messages import _secure_random
+        
+        assert isinstance(_secure_random, secrets.SystemRandom), (
+            "messages._secure_random must be secrets.SystemRandom"
+        )
+
+    def test_router_client_uses_secure_random(self):
+        """RouterClient should use secrets.SystemRandom."""
+        from valence.network.router_client import _secure_random
+        
+        assert isinstance(_secure_random, secrets.SystemRandom), (
+            "router_client._secure_random must be secrets.SystemRandom"
+        )
+
+    def test_seed_uses_secure_random(self):
+        """Seed module should use secrets.SystemRandom."""
+        from valence.network.seed import _secure_random
+        
+        assert isinstance(_secure_random, secrets.SystemRandom), (
+            "seed._secure_random must be secrets.SystemRandom"
+        )
+
+    def test_privacy_uses_secure_random(self):
+        """Privacy module should use secrets.SystemRandom."""
+        from valence.federation.privacy import _secure_random
+        
+        assert isinstance(_secure_random, secrets.SystemRandom), (
+            "privacy._secure_random must be secrets.SystemRandom"
+        )
+
+
+class TestJitterRandomness:
+    """Test timing jitter uses secure randomness."""
+
+    def test_jitter_uniform_distribution(self):
+        """Uniform jitter should produce values in expected range."""
+        from valence.network.config import TimingJitterConfig
+        
+        config = TimingJitterConfig(
+            enabled=True,
+            min_delay_ms=100,
+            max_delay_ms=500,
+            distribution="uniform"
+        )
+        
+        # Generate multiple samples
+        delays = [config.get_jitter_delay() for _ in range(100)]
+        
+        # All should be in range (converted to seconds)
+        for delay in delays:
+            assert 0.1 <= delay <= 0.5, f"Delay {delay} out of range"
+        
+        # Should have some variance (not constant)
+        assert len(set(delays)) > 1, "Jitter should produce varying delays"
+
+    def test_jitter_exponential_distribution(self):
+        """Exponential jitter should produce values in expected range."""
+        from valence.network.config import TimingJitterConfig
+        
+        config = TimingJitterConfig(
+            enabled=True,
+            min_delay_ms=100,
+            max_delay_ms=500,
+            distribution="exponential"
+        )
+        
+        # Generate multiple samples
+        delays = [config.get_jitter_delay() for _ in range(100)]
+        
+        # All should be in range (min to max, converted to seconds)
+        for delay in delays:
+            assert 0.1 <= delay <= 0.5, f"Delay {delay} out of range"
+
+    def test_jitter_disabled_returns_zero(self):
+        """Disabled jitter should return 0."""
+        from valence.network.config import TimingJitterConfig
+        
+        config = TimingJitterConfig(enabled=False)
+        assert config.get_jitter_delay() == 0.0
+
+
+class TestCoverTrafficRandomness:
+    """Test cover traffic uses secure randomness."""
+
+    def test_cover_content_bucket_selection(self):
+        """Cover content should select from valid buckets."""
+        from valence.network.messages import generate_cover_content, MESSAGE_SIZE_BUCKETS
+        
+        # Generate multiple cover messages without specifying bucket
+        # This exercises the weighted random selection
+        sizes = set()
+        for _ in range(50):
+            content = generate_cover_content()
+            # Content size + overhead should be <= bucket size
+            assert len(content) > 0
+            sizes.add(len(content))
+        
+        # Should have some variety in sizes selected
+        assert len(sizes) > 1, "Cover content should vary in size"
+
+    def test_cover_content_specific_bucket(self):
+        """Cover content with specific bucket should match."""
+        from valence.network.messages import generate_cover_content, MESSAGE_SIZE_BUCKETS
+        
+        for bucket in MESSAGE_SIZE_BUCKETS:
+            content = generate_cover_content(target_bucket=bucket)
+            # Content should fit in bucket (with overhead)
+            assert len(content) <= bucket
+
+
+class TestRouterSelectionRandomness:
+    """Test router selection uses secure randomness."""
+
+    def test_router_selection_weighted(self):
+        """Router selection should respect weights but be unpredictable."""
+        from valence.network.router_client import _secure_random
+        
+        # Create mock candidates with varying weights
+        candidates = ['router_a', 'router_b', 'router_c']
+        weights = [0.1, 0.1, 0.8]  # router_c heavily weighted
+        
+        # Select many times
+        selections = [
+            _secure_random.choices(candidates, weights=weights, k=1)[0]
+            for _ in range(100)
+        ]
+        
+        # Should have variety (not deterministic)
+        assert len(set(selections)) > 1, "Selection should vary"
+        
+        # router_c should be selected most often (but not exclusively due to randomness)
+        c_count = selections.count('router_c')
+        assert c_count > 30, f"Heavy-weighted router should appear often, got {c_count}"
+
+
+class TestSeedSamplingRandomness:
+    """Test seed router sampling uses secure randomness."""
+
+    def test_sample_unpredictable(self):
+        """Router sampling should be unpredictable."""
+        from valence.network.seed import _secure_random
+        
+        population = list(range(100))
+        
+        # Sample multiple times
+        samples = [tuple(_secure_random.sample(population, 10)) for _ in range(20)]
+        
+        # Should have variety
+        unique_samples = set(samples)
+        assert len(unique_samples) > 1, "Samples should vary"
+
+
+class TestPrivacyDecisionRandomness:
+    """Test privacy decisions use secure randomness."""
+
+    def test_random_produces_valid_range(self):
+        """Privacy random() should produce values in [0, 1)."""
+        from valence.federation.privacy import _secure_random
+        
+        values = [_secure_random.random() for _ in range(100)]
+        
+        for v in values:
+            assert 0.0 <= v < 1.0, f"Value {v} out of range"
+        
+        # Should have variance
+        assert len(set(values)) > 1, "Should produce varying values"
+
+
+class TestNoStandardRandomInSecurityCode:
+    """Verify standard random module is not used for security operations."""
+
+    def test_config_no_standard_random_import(self):
+        """config.py should not use standard random for security operations."""
+        import inspect
+        from valence.network import config
+        
+        source = inspect.getsource(config)
+        
+        # Should import secrets, not just random
+        assert "import secrets" in source, "Should import secrets module"
+        
+        # _secure_random should be used
+        assert "_secure_random" in source, "Should use _secure_random"
+
+    def test_messages_no_inline_random_import(self):
+        """messages.py should not have inline random import for security ops."""
+        import inspect
+        from valence.network import messages
+        
+        source = inspect.getsource(messages)
+        
+        # Should NOT have inline "import random" in the cover traffic function
+        # Check the generate_cover_content function doesn't do "import random"
+        assert "import secrets" in source, "Should import secrets module"
+        
+        # The old inline import should be removed
+        assert source.count("import random") == 0, (
+            "Should not have 'import random' in security-sensitive code"
+        )
+
+    def test_router_client_no_standard_random(self):
+        """router_client.py should use secrets, not standard random."""
+        import inspect
+        from valence.network import router_client
+        
+        source = inspect.getsource(router_client)
+        
+        assert "import secrets" in source
+        assert "_secure_random" in source
+        # Standard random should not be imported
+        assert "import random" not in source.replace("_secure_random", ""), (
+            "Should not import standard random module"
+        )


### PR DESCRIPTION
## Summary

Closes #170

Replaces standard `random` module with `secrets.SystemRandom()` for security-sensitive operations. The standard `random` module uses a Mersenne Twister PRNG that is predictable if an attacker can observe enough outputs or predict/control the seed.

## Changes

### Security-sensitive operations updated:

| File | Line(s) | Operation | Fix |
|------|---------|-----------|-----|
| `network/config.py` | 122, 126 | Timing jitter | `_secure_random.expovariate()`, `_secure_random.uniform()` |
| `network/messages.py` | 560 | Cover traffic bucket selection | `_secure_random.choices()` |
| `network/router_client.py` | 178 | Router selection | `_secure_random.choices()` |
| `network/seed.py` | 212, 1867 | Router sampling | `_secure_random.sample()` |
| `federation/privacy.py` | 1291 | Privacy weight decisions | `_secure_random.random()` |

### Non-security uses preserved:
- `np.random.laplace()` and `np.random.normal()` in `privacy.py` for differential privacy noise (requires specific statistical distributions, not cryptographic security)

## Implementation

Used `secrets.SystemRandom()` which provides the same API as the standard `random` module but uses `os.urandom()` for cryptographically secure randomness.

```python
import secrets
_secure_random = secrets.SystemRandom()

# Same API, secure implementation
_secure_random.choices(candidates, weights=weights, k=1)
_secure_random.sample(routers, sample_size)
_secure_random.uniform(min_val, max_val)
_secure_random.expovariate(lambd)
_secure_random.random()
```

## Testing

Added comprehensive test suite in `tests/security/test_secrets_randomness.py`:
- Verifies all modules use `secrets.SystemRandom`
- Tests output ranges and variance
- Verifies standard `random` is not imported in security-sensitive code

## Security Impact

Prevents an attacker from predicting:
- Timing jitter patterns (traffic analysis resistance)
- Cover traffic bucket selection
- Router selection (prevents targeted routing attacks)
- Seed router sampling (prevents eclipse attacks)
- Privacy inclusion decisions