### PR TITLE
fix: replace datetime.utcnow() with timezone-aware calls

### DIFF
--- a/src/valence/federation/aggregation.py
+++ b/src/valence/federation/aggregation.py
@@ -15,7 +15,7 @@ import hashlib
 import logging
 import math
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any, Callable
 from uuid import UUID, uuid4
@@ -166,7 +166,7 @@ class DetectedConflict:
     belief_a_content: str = ""
     belief_b_content: str = ""
     
-    detected_at: datetime = field(default_factory=datetime.utcnow)
+    detected_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
@@ -269,7 +269,7 @@ class CrossFederationAggregateResult:
     k_anonymity_satisfied: bool = True
     
     # Metadata
-    computed_at: datetime = field(default_factory=datetime.utcnow)
+    computed_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     valid_until: datetime | None = None
     config_used: dict[str, Any] = field(default_factory=dict)
     
@@ -657,7 +657,7 @@ class TrustWeightedAggregator:
             return 0.5
         
         # Get most recent belief
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         max_age_days = 365
         
         most_recent = max(
@@ -983,7 +983,7 @@ class FederationAggregator:
             privacy_delta=self.config.privacy_config.delta,
             k_anonymity_satisfied=k_satisfied,
             config_used=self.config.to_dict(),
-            valid_until=datetime.utcnow() + timedelta(hours=1),
+            valid_until=datetime.now(UTC) + timedelta(hours=1),
         )
     
     def _resolve_conflicts(

--- a/tests/federation/test_aggregation.py
+++ b/tests/federation/test_aggregation.py
@@ -11,7 +11,7 @@ Tests cover:
 from __future__ import annotations
 
 import math
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
@@ -75,7 +75,7 @@ def sample_belief(sample_confidence: DimensionalConfidence) -> FederatedBelief:
         domain_path=["science", "physics"],
         visibility=Visibility.FEDERATED,
         share_level=ShareLevel.BELIEF_ONLY,
-        signed_at=datetime.utcnow(),
+        signed_at=datetime.now(UTC),
     )
 
 
@@ -114,7 +114,7 @@ def make_belief(
         domain_path=domain_path or ["test"],
         visibility=Visibility.FEDERATED,
         share_level=ShareLevel.BELIEF_ONLY,
-        signed_at=datetime.utcnow(),
+        signed_at=datetime.now(UTC),
     )
 
 
@@ -464,7 +464,7 @@ class TestTrustWeightedAggregator:
             federation_did="did:vkb:fed:new",
             trust_score=0.8,
             beliefs=[make_belief("New")],
-            joined_at=datetime.utcnow() - timedelta(hours=6),  # 6 hours ago
+            joined_at=datetime.now(UTC) - timedelta(hours=6),  # 6 hours ago
         )
         
         # Established federation
@@ -474,7 +474,7 @@ class TestTrustWeightedAggregator:
             federation_did="did:vkb:fed:old",
             trust_score=0.8,  # Same trust
             beliefs=[make_belief("Old")],
-            joined_at=datetime.utcnow() - timedelta(days=30),  # 30 days ago
+            joined_at=datetime.now(UTC) - timedelta(days=30),  # 30 days ago
         )
         
         weights = aggregator.compute_contribution_weights(
@@ -728,10 +728,10 @@ class TestFederationAggregator:
         aggregator = FederationAggregator(config=config)
         
         old_belief = make_belief("Old info", confidence=0.7)
-        old_belief.signed_at = datetime.utcnow() - timedelta(days=30)
+        old_belief.signed_at = datetime.now(UTC) - timedelta(days=30)
         
         new_belief = make_belief("New info", confidence=0.9)
-        new_belief.signed_at = datetime.utcnow()
+        new_belief.signed_at = datetime.now(UTC)
         
         contrib_old = make_contribution([old_belief], trust_score=0.8)
         contrib_new = make_contribution([new_belief], trust_score=0.8)
@@ -1185,12 +1185,12 @@ class TestConflictDetectorInternals:
         detector = ConflictDetector()
         
         belief_a = make_belief("Current fact", confidence=0.8)
-        belief_a.valid_from = datetime.utcnow() - timedelta(days=10)
-        belief_a.valid_until = datetime.utcnow() + timedelta(days=10)
+        belief_a.valid_from = datetime.now(UTC) - timedelta(days=10)
+        belief_a.valid_until = datetime.now(UTC) + timedelta(days=10)
         
         belief_b = make_belief("Current fact", confidence=0.7)
-        belief_b.valid_from = datetime.utcnow() - timedelta(days=5)
-        belief_b.valid_until = datetime.utcnow() + timedelta(days=5)
+        belief_b.valid_from = datetime.now(UTC) - timedelta(days=5)
+        belief_b.valid_until = datetime.now(UTC) + timedelta(days=5)
         
         # Both have temporal constraints - method should return False (simplified impl)
         result = detector._has_temporal_conflict(belief_a, belief_b)
@@ -1201,7 +1201,7 @@ class TestConflictDetectorInternals:
         detector = ConflictDetector()
         
         belief_a = make_belief("Current fact", confidence=0.8)
-        belief_a.valid_from = datetime.utcnow()
+        belief_a.valid_from = datetime.now(UTC)
         
         belief_b = make_belief("Current fact", confidence=0.7)
         # No temporal constraints

--- a/tests/federation/test_gateway.py
+++ b/tests/federation/test_gateway.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4, UUID
 
@@ -786,12 +786,12 @@ class TestGatewayNodeAuditLogging:
         """Test audit log filtering by time."""
         # Create old entry
         old_entry = gateway._audit(AuditEventType.INBOUND_SHARE, success=True)
-        old_entry.timestamp = datetime.utcnow() - timedelta(hours=2)
+        old_entry.timestamp = datetime.now(UTC) - timedelta(hours=2)
         
         # Create recent entry
         gateway._audit(AuditEventType.OUTBOUND_SHARE, success=True)
         
-        since = datetime.utcnow() - timedelta(hours=1)
+        since = datetime.now(UTC) - timedelta(hours=1)
         log = gateway.get_audit_log(since=since)
         
         assert len(log) == 1

--- a/tests/federation/test_privacy.py
+++ b/tests/federation/test_privacy.py
@@ -13,7 +13,7 @@ Tests cover:
 from __future__ import annotations
 
 import math
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import numpy as np
@@ -245,7 +245,7 @@ class TestPrivacyBudget:
         budget.queries_today = 50
         
         # Set period start to yesterday
-        budget.period_start = datetime.utcnow() - timedelta(hours=25)
+        budget.period_start = datetime.now(UTC) - timedelta(hours=25)
         
         # Check should trigger reset
         remaining = budget.remaining_epsilon()
@@ -392,7 +392,7 @@ class TestTemporalSmoother:
     
     def test_active_member_full_weight(self, smoother: TemporalSmoother) -> None:
         """Test long-standing active members have full weight."""
-        old_join = datetime.utcnow() - timedelta(days=30)
+        old_join = datetime.now(UTC) - timedelta(days=30)
         
         weight = smoother.get_contribution_weight(
             member_id="veteran",
@@ -404,7 +404,7 @@ class TestTemporalSmoother:
     def test_new_member_ramping_weight(self, smoother: TemporalSmoother) -> None:
         """Test new members have ramping weight."""
         # Joined 12 hours ago (half of 24h window)
-        recent_join = datetime.utcnow() - timedelta(hours=12)
+        recent_join = datetime.now(UTC) - timedelta(hours=12)
         
         weight = smoother.get_contribution_weight(
             member_id="newbie",
@@ -417,7 +417,7 @@ class TestTemporalSmoother:
     
     def test_very_new_member_low_weight(self, smoother: TemporalSmoother) -> None:
         """Test very new members have low weight."""
-        just_joined = datetime.utcnow() - timedelta(hours=1)
+        just_joined = datetime.now(UTC) - timedelta(hours=1)
         
         weight = smoother.get_contribution_weight(
             member_id="newest",
@@ -433,14 +433,14 @@ class TestTemporalSmoother:
         # Set seed for deterministic test
         np.random.seed(42)
         
-        departed_6h_ago = datetime.utcnow() - timedelta(hours=6)
+        departed_6h_ago = datetime.now(UTC) - timedelta(hours=6)
         
         # Check multiple times - should sometimes include
         included_count = 0
         for _ in range(100):
             if smoother.should_include_member(
                 member_id="departed",
-                joined_at=datetime.utcnow() - timedelta(days=30),
+                joined_at=datetime.now(UTC) - timedelta(days=30),
                 departed_at=departed_6h_ago,
             ):
                 included_count += 1
@@ -450,11 +450,11 @@ class TestTemporalSmoother:
     
     def test_long_departed_excluded(self, smoother: TemporalSmoother) -> None:
         """Test members departed beyond window are excluded."""
-        departed_long_ago = datetime.utcnow() - timedelta(hours=25)
+        departed_long_ago = datetime.now(UTC) - timedelta(hours=25)
         
         included = smoother.should_include_member(
             member_id="long_gone",
-            joined_at=datetime.utcnow() - timedelta(days=30),
+            joined_at=datetime.now(UTC) - timedelta(days=30),
             departed_at=departed_long_ago,
         )
         
@@ -783,11 +783,11 @@ class TestPrivacyIntegration:
         smoother = TemporalSmoother(smoothing_hours=24)
         
         # Member just departed
-        just_departed = datetime.utcnow() - timedelta(minutes=5)
+        just_departed = datetime.now(UTC) - timedelta(minutes=5)
         
         weight = smoother.get_contribution_weight(
             member_id="recent_departure",
-            joined_at=datetime.utcnow() - timedelta(days=30),
+            joined_at=datetime.now(UTC) - timedelta(days=30),
             departed_at=just_departed,
         )
         


### PR DESCRIPTION
Closes #181

## Summary
Replace all uses of the deprecated `datetime.utcnow()` with `datetime.now(UTC)` for timezone-aware datetime handling.

## Changes
- Add `UTC` import from `datetime` module in all affected files
- Replace `datetime.utcnow()` calls with `datetime.now(UTC)`
- Replace `datetime.utcnow` default_factory with `lambda: datetime.now(UTC)`
- Update comment referencing utcnow()

## Files Modified (7)
- `src/valence/federation/privacy.py`
- `src/valence/federation/gateway.py`
- `src/valence/federation/aggregation.py`
- `tests/federation/test_privacy.py`
- `tests/federation/test_privacy_budget_store.py`
- `tests/federation/test_aggregation.py`
- `tests/federation/test_gateway.py`

## Result
Eliminates the 600+ `DeprecationWarning` messages from Python 3.12+ about `datetime.utcnow()` being deprecated.