### PR TITLE
test: add tests for low-coverage modules

### DIFF
--- a/tests/cli/test_router.py
+++ b/tests/cli/test_router.py
@@ -1,0 +1,411 @@
+"""Tests for Valence Router CLI (cli/router.py).
+
+Tests cover:
+1. Argument parsing for start and status commands
+2. _print_status helper function
+3. cmd_status with mocked HTTP responses
+4. Signal handling in cmd_start (partial - hard to test fully)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from valence.cli.router import (
+    create_parser,
+    _print_status,
+    cmd_status,
+    main,
+    async_main,
+)
+
+
+# ============================================================================
+# Argument Parser Tests
+# ============================================================================
+
+class TestCreateParser:
+    """Test CLI argument parsing."""
+    
+    def test_no_command_shows_help(self):
+        """No command prints help."""
+        parser = create_parser()
+        args = parser.parse_args([])
+        assert args.command is None
+    
+    def test_start_command_defaults(self):
+        """Start command with default values."""
+        parser = create_parser()
+        args = parser.parse_args(['start'])
+        
+        assert args.command == 'start'
+        assert args.host == '0.0.0.0'
+        assert args.port == 8471
+        assert args.seed is None
+        assert args.max_connections == 100
+        assert args.heartbeat_interval == 300
+    
+    def test_start_command_custom_values(self):
+        """Start command with custom values."""
+        parser = create_parser()
+        args = parser.parse_args([
+            'start',
+            '--host', '127.0.0.1',
+            '--port', '9000',
+            '--seed', 'https://seed.example.com:8470',
+            '--max-connections', '200',
+            '--heartbeat-interval', '600',
+        ])
+        
+        assert args.host == '127.0.0.1'
+        assert args.port == 9000
+        assert args.seed == 'https://seed.example.com:8470'
+        assert args.max_connections == 200
+        assert args.heartbeat_interval == 600
+    
+    def test_start_command_short_flags(self):
+        """Start command with short flags."""
+        parser = create_parser()
+        args = parser.parse_args([
+            'start',
+            '-p', '8500',
+            '-s', 'https://seed.valence.network',
+            '-m', '50',
+        ])
+        
+        assert args.port == 8500
+        assert args.seed == 'https://seed.valence.network'
+        assert args.max_connections == 50
+    
+    def test_start_command_json_flag(self):
+        """Start command with JSON output flag."""
+        parser = create_parser()
+        args = parser.parse_args(['start', '--json'])
+        assert args.json is True
+    
+    def test_status_command_defaults(self):
+        """Status command with default values."""
+        parser = create_parser()
+        args = parser.parse_args(['status'])
+        
+        assert args.command == 'status'
+        assert args.host == 'localhost'
+        assert args.port == 8471
+    
+    def test_status_command_custom_values(self):
+        """Status command with custom values."""
+        parser = create_parser()
+        args = parser.parse_args([
+            'status',
+            '--host', '192.168.1.100',
+            '--port', '8500',
+            '--json',
+        ])
+        
+        assert args.host == '192.168.1.100'
+        assert args.port == 8500
+        assert args.json is True
+    
+    def test_global_verbose_flag(self):
+        """Global verbose flag."""
+        parser = create_parser()
+        args = parser.parse_args(['-v', 'status'])
+        assert args.verbose is True
+    
+    def test_global_json_flag(self):
+        """Global JSON flag."""
+        parser = create_parser()
+        args = parser.parse_args(['--json', 'status'])
+        assert args.json is True
+
+
+# ============================================================================
+# _print_status Helper Tests
+# ============================================================================
+
+class TestPrintStatus:
+    """Test _print_status helper function."""
+    
+    def test_print_running_status(self, capsys):
+        """Print status when router is running."""
+        data = {
+            'running': True,
+            'host': 'localhost',
+            'port': 8471,
+            'seed_url': 'https://seed.example.com',
+            'connections': {
+                'current': 5,
+                'max': 100,
+                'total': 150,
+            },
+            'queues': {
+                'nodes': 3,
+                'total_messages': 42,
+            },
+            'metrics': {
+                'messages_relayed': 1000,
+                'messages_queued': 50,
+                'messages_delivered': 950,
+            },
+        }
+        
+        _print_status(data)
+        captured = capsys.readouterr()
+        
+        assert '🟢' in captured.out
+        assert 'Running' in captured.out
+        assert 'localhost:8471' in captured.out
+        assert 'seed.example.com' in captured.out
+        assert '5/100' in captured.out
+        assert '1000' in captured.out
+    
+    def test_print_stopped_status(self, capsys):
+        """Print status when router is stopped."""
+        data = {
+            'running': False,
+            'host': '0.0.0.0',
+            'port': 8471,
+        }
+        
+        _print_status(data)
+        captured = capsys.readouterr()
+        
+        assert '🔴' in captured.out
+        assert 'Stopped' in captured.out
+    
+    def test_print_status_no_seed(self, capsys):
+        """Print status without seed URL."""
+        data = {
+            'running': True,
+            'host': 'localhost',
+            'port': 8471,
+            'connections': {},
+            'queues': {},
+            'metrics': {},
+        }
+        
+        _print_status(data)
+        captured = capsys.readouterr()
+        
+        # Should not crash, seed line should not appear
+        assert 'VALENCE ROUTER STATUS' in captured.out
+        assert '🌱' not in captured.out
+
+
+# ============================================================================
+# cmd_status Tests
+# ============================================================================
+
+class TestCmdStatus:
+    """Test cmd_status function."""
+    
+    @pytest.mark.asyncio
+    async def test_status_success_json(self):
+        """Status command with JSON output."""
+        args = argparse.Namespace(
+            host='localhost',
+            port=8471,
+            json=True,
+        )
+        
+        mock_response_data = {
+            'running': True,
+            'host': 'localhost',
+            'port': 8471,
+        }
+        
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=mock_response_data)
+        
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_response),
+            __aexit__=AsyncMock(return_value=None),
+        ))
+        
+        with patch('aiohttp.ClientSession') as mock_client:
+            mock_client.return_value = AsyncMock(
+                __aenter__=AsyncMock(return_value=mock_session),
+                __aexit__=AsyncMock(return_value=None),
+            )
+            
+            result = await cmd_status(args)
+        
+        assert result == 0
+    
+    @pytest.mark.asyncio
+    async def test_status_success_human_readable(self, capsys):
+        """Status command with human-readable output."""
+        args = argparse.Namespace(
+            host='localhost',
+            port=8471,
+            json=False,
+        )
+        
+        mock_response_data = {
+            'running': True,
+            'host': 'localhost',
+            'port': 8471,
+            'connections': {'current': 5, 'max': 100, 'total': 50},
+            'queues': {'nodes': 2, 'total_messages': 10},
+            'metrics': {'messages_relayed': 100, 'messages_queued': 5, 'messages_delivered': 95},
+        }
+        
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=mock_response_data)
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            result = await cmd_status(args)
+        
+        assert result == 0
+    
+    @pytest.mark.asyncio
+    async def test_status_http_error(self, capsys):
+        """Status command with HTTP error."""
+        args = argparse.Namespace(
+            host='localhost',
+            port=8471,
+            json=False,
+        )
+        
+        mock_response = AsyncMock()
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value='Internal Server Error')
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            result = await cmd_status(args)
+        
+        assert result == 1
+        captured = capsys.readouterr()
+        assert '❌' in captured.err
+        assert '500' in captured.err
+    
+    @pytest.mark.asyncio
+    async def test_status_connection_error(self, capsys):
+        """Status command when router is unreachable."""
+        import aiohttp
+        
+        args = argparse.Namespace(
+            host='localhost',
+            port=8471,
+            json=False,
+        )
+        
+        mock_session_ctx = AsyncMock()
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(side_effect=aiohttp.ClientConnectorError(
+            connection_key=MagicMock(), os_error=OSError("Connection refused")
+        ))
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            result = await cmd_status(args)
+        
+        assert result == 1
+        captured = capsys.readouterr()
+        assert '❌' in captured.err
+        assert 'Cannot connect' in captured.err
+
+
+# ============================================================================
+# async_main Tests
+# ============================================================================
+
+class TestAsyncMain:
+    """Test async_main dispatcher."""
+    
+    @pytest.mark.asyncio
+    async def test_dispatch_to_status(self):
+        """Dispatch to status command."""
+        args = argparse.Namespace(
+            command='status',
+            host='localhost',
+            port=8471,
+            json=True,
+            verbose=False,
+        )
+        
+        with patch('valence.cli.router.cmd_status', new_callable=AsyncMock) as mock_status:
+            mock_status.return_value = 0
+            result = await async_main(args)
+        
+        assert result == 0
+        mock_status.assert_called_once_with(args)
+    
+    @pytest.mark.asyncio
+    async def test_dispatch_no_command(self, capsys):
+        """No command shows help."""
+        args = argparse.Namespace(
+            command=None,
+            verbose=False,
+        )
+        
+        result = await async_main(args)
+        
+        assert result == 0
+    
+    @pytest.mark.asyncio
+    async def test_verbose_logging(self):
+        """Verbose flag enables debug logging."""
+        args = argparse.Namespace(
+            command=None,
+            verbose=True,
+        )
+        
+        with patch('logging.basicConfig') as mock_logging:
+            await async_main(args)
+            
+            # Should configure DEBUG level
+            mock_logging.assert_called()
+            call_kwargs = mock_logging.call_args[1]
+            assert call_kwargs.get('level') == 10  # DEBUG
+
+
+# ============================================================================
+# main() Entry Point Tests
+# ============================================================================
+
+class TestMain:
+    """Test main entry point."""
+    
+    def test_main_no_command_returns_0(self):
+        """Main with no command returns 0."""
+        with patch('sys.argv', ['valence-router']):
+            result = main()
+        assert result == 0
+    
+    def test_main_help_exits_0(self):
+        """Main with --help exits with 0."""
+        with patch('sys.argv', ['valence-router', '--help']):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 0

--- a/tests/cli/test_seed.py
+++ b/tests/cli/test_seed.py
@@ -1,0 +1,689 @@
+"""Tests for Valence Seed Node CLI (cli/seed.py).
+
+Tests cover:
+1. Argument parsing for start, status, and discover commands
+2. get_config_from_env function
+3. cmd_status and cmd_discover with mocked HTTP responses
+4. Error handling scenarios
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from valence.cli.seed import (
+    create_parser,
+    get_config_from_env,
+    cmd_status,
+    cmd_discover,
+    main,
+    async_main,
+)
+
+
+# ============================================================================
+# Argument Parser Tests
+# ============================================================================
+
+class TestCreateParser:
+    """Test CLI argument parsing."""
+    
+    def test_no_command_shows_help(self):
+        """No command prints help."""
+        parser = create_parser()
+        args = parser.parse_args([])
+        assert args.command is None
+    
+    def test_start_command_defaults(self):
+        """Start command with default values."""
+        parser = create_parser()
+        args = parser.parse_args(['start'])
+        
+        assert args.command == 'start'
+        assert args.host is None  # Gets from env or default
+        assert args.port is None
+        assert args.seed_id is None
+        assert args.peer == []
+    
+    def test_start_command_custom_values(self):
+        """Start command with custom values."""
+        parser = create_parser()
+        args = parser.parse_args([
+            'start',
+            '--host', '127.0.0.1',
+            '--port', '8470',
+            '--seed-id', 'test-seed-001',
+            '--peer', 'https://peer1.example.com',
+            '--peer', 'https://peer2.example.com',
+        ])
+        
+        assert args.host == '127.0.0.1'
+        assert args.port == 8470
+        assert args.seed_id == 'test-seed-001'
+        assert args.peer == ['https://peer1.example.com', 'https://peer2.example.com']
+    
+    def test_start_command_short_flags(self):
+        """Start command with short flags."""
+        parser = create_parser()
+        args = parser.parse_args([
+            'start',
+            '-H', '0.0.0.0',
+            '-p', '9000',
+        ])
+        
+        assert args.host == '0.0.0.0'
+        assert args.port == 9000
+    
+    def test_status_command_defaults(self):
+        """Status command with default values."""
+        parser = create_parser()
+        args = parser.parse_args(['status'])
+        
+        assert args.command == 'status'
+        assert args.url is None
+        assert args.port is None
+        assert args.json is False
+    
+    def test_status_command_custom_values(self):
+        """Status command with custom values."""
+        parser = create_parser()
+        args = parser.parse_args([
+            'status',
+            '--url', 'https://seed.example.com',
+            '--json',
+        ])
+        
+        assert args.url == 'https://seed.example.com'
+        assert args.json is True
+    
+    def test_status_command_short_flags(self):
+        """Status command with short flags."""
+        parser = create_parser()
+        args = parser.parse_args([
+            'status',
+            '-u', 'http://localhost:8470',
+            '-p', '8470',
+        ])
+        
+        assert args.url == 'http://localhost:8470'
+        assert args.port == 8470
+    
+    def test_discover_command_defaults(self):
+        """Discover command with default values."""
+        parser = create_parser()
+        args = parser.parse_args(['discover'])
+        
+        assert args.command == 'discover'
+        assert args.url is None
+        assert args.count == 5
+        assert args.region is None
+        assert args.feature == []
+        assert args.json is False
+    
+    def test_discover_command_custom_values(self):
+        """Discover command with custom values."""
+        parser = create_parser()
+        args = parser.parse_args([
+            'discover',
+            '--url', 'https://seed.example.com',
+            '--count', '10',
+            '--region', 'us-west',
+            '--feature', 'fast',
+            '--feature', 'reliable',
+            '--json',
+        ])
+        
+        assert args.url == 'https://seed.example.com'
+        assert args.count == 10
+        assert args.region == 'us-west'
+        assert args.feature == ['fast', 'reliable']
+        assert args.json is True
+    
+    def test_discover_command_short_flags(self):
+        """Discover command with short flags."""
+        parser = create_parser()
+        args = parser.parse_args([
+            'discover',
+            '-n', '20',
+            '-r', 'eu-central',
+            '-f', 'encrypted',
+        ])
+        
+        assert args.count == 20
+        assert args.region == 'eu-central'
+        assert args.feature == ['encrypted']
+    
+    def test_global_verbose_flag(self):
+        """Global verbose flag."""
+        parser = create_parser()
+        args = parser.parse_args(['-v', 'status'])
+        assert args.verbose is True
+
+
+# ============================================================================
+# get_config_from_env Tests
+# ============================================================================
+
+class TestGetConfigFromEnv:
+    """Test environment config loading."""
+    
+    def test_get_config_empty(self, monkeypatch):
+        """Get config when no env vars set."""
+        # Clear env vars
+        for var in ['VALENCE_SEED_HOST', 'VALENCE_SEED_PORT', 'VALENCE_SEED_ID', 'VALENCE_SEED_PEERS']:
+            monkeypatch.delenv(var, raising=False)
+        
+        # Mock get_config to return empty
+        mock_core_config = MagicMock()
+        mock_core_config.seed_host = None
+        mock_core_config.seed_port = None
+        mock_core_config.seed_id = None
+        mock_core_config.seed_peers = None
+        
+        with patch('valence.cli.seed.get_config', return_value=mock_core_config):
+            config = get_config_from_env()
+        
+        assert config == {}
+    
+    def test_get_config_with_values(self):
+        """Get config with env vars set."""
+        mock_core_config = MagicMock()
+        mock_core_config.seed_host = '0.0.0.0'
+        mock_core_config.seed_port = 8470
+        mock_core_config.seed_id = 'test-seed'
+        mock_core_config.seed_peers = 'https://peer1.com, https://peer2.com'
+        
+        with patch('valence.cli.seed.get_config', return_value=mock_core_config):
+            config = get_config_from_env()
+        
+        assert config['host'] == '0.0.0.0'
+        assert config['port'] == 8470
+        assert config['seed_id'] == 'test-seed'
+        assert config['known_seeds'] == ['https://peer1.com', 'https://peer2.com']
+    
+    def test_get_config_empty_peers(self):
+        """Get config with empty peers string."""
+        mock_core_config = MagicMock()
+        mock_core_config.seed_host = None
+        mock_core_config.seed_port = None
+        mock_core_config.seed_id = None
+        mock_core_config.seed_peers = '   ,  '  # Empty after stripping
+        
+        with patch('valence.cli.seed.get_config', return_value=mock_core_config):
+            config = get_config_from_env()
+        
+        assert 'known_seeds' not in config or config.get('known_seeds') == []
+
+
+# ============================================================================
+# cmd_status Tests
+# ============================================================================
+
+class TestCmdStatus:
+    """Test cmd_status function."""
+    
+    @pytest.mark.asyncio
+    async def test_status_success_json(self):
+        """Status command with JSON output."""
+        args = argparse.Namespace(
+            url='http://localhost:8470',
+            port=None,
+            json=True,
+        )
+        
+        mock_response_data = {
+            'seed_id': 'test-seed-001',
+            'status': 'running',
+            'routers': {'total': 10, 'healthy': 8},
+            'known_seeds': 2,
+        }
+        
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=mock_response_data)
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            result = await cmd_status(args)
+        
+        assert result == 0
+    
+    @pytest.mark.asyncio
+    async def test_status_success_human_readable(self, capsys):
+        """Status command with human-readable output."""
+        args = argparse.Namespace(
+            url=None,  # Use local
+            port=8470,
+            json=False,
+        )
+        
+        mock_response_data = {
+            'seed_id': 'test-seed-001',
+            'status': 'running',
+            'routers': {'total': 10, 'healthy': 8},
+            'known_seeds': 2,
+        }
+        
+        mock_config = MagicMock()
+        mock_config.seed_port = 8470
+        
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=mock_response_data)
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            with patch('valence.cli.seed.get_config', return_value=mock_config):
+                result = await cmd_status(args)
+        
+        assert result == 0
+        captured = capsys.readouterr()
+        assert '✅' in captured.out
+        assert 'test-seed-001' in captured.out
+    
+    @pytest.mark.asyncio
+    async def test_status_http_error(self, capsys):
+        """Status command with HTTP error."""
+        args = argparse.Namespace(
+            url='http://localhost:8470',
+            port=None,
+            json=False,
+        )
+        
+        mock_response = AsyncMock()
+        mock_response.status = 500
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            result = await cmd_status(args)
+        
+        assert result == 1
+        captured = capsys.readouterr()
+        assert '❌' in captured.err
+    
+    @pytest.mark.asyncio
+    async def test_status_connection_error(self, capsys):
+        """Status command when seed is unreachable."""
+        import aiohttp
+        
+        args = argparse.Namespace(
+            url='http://localhost:8470',
+            port=None,
+            json=False,
+        )
+        
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(side_effect=aiohttp.ClientError("Connection refused"))
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            result = await cmd_status(args)
+        
+        assert result == 1
+        captured = capsys.readouterr()
+        assert '❌' in captured.err
+    
+    @pytest.mark.asyncio
+    async def test_status_url_normalization(self):
+        """Status normalizes URL correctly."""
+        args = argparse.Namespace(
+            url='seed.example.com',  # No http://
+            port=None,
+            json=True,
+        )
+        
+        mock_response_data = {'seed_id': 'test'}
+        
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=mock_response_data)
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            result = await cmd_status(args)
+        
+        # Should have added http://
+        call_args = mock_session.get.call_args[0][0]
+        assert call_args.startswith('http://')
+        assert result == 0
+
+
+# ============================================================================
+# cmd_discover Tests
+# ============================================================================
+
+class TestCmdDiscover:
+    """Test cmd_discover function."""
+    
+    @pytest.mark.asyncio
+    async def test_discover_success_json(self):
+        """Discover command with JSON output."""
+        args = argparse.Namespace(
+            url='http://localhost:8470',
+            port=None,
+            count=5,
+            region=None,
+            feature=[],
+            json=True,
+        )
+        
+        mock_response_data = {
+            'seed_id': 'test-seed',
+            'routers': [
+                {
+                    'router_id': 'router-001',
+                    'endpoints': ['ws://router1.example.com'],
+                    'regions': ['us-west'],
+                    'capacity': {'current_load_pct': 45},
+                    'health': {'uptime_pct': 99.5},
+                },
+            ],
+            'other_seeds': [],
+        }
+        
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=mock_response_data)
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            result = await cmd_discover(args)
+        
+        assert result == 0
+    
+    @pytest.mark.asyncio
+    async def test_discover_success_human_readable(self, capsys):
+        """Discover command with human-readable output."""
+        args = argparse.Namespace(
+            url='http://localhost:8470',
+            port=None,
+            count=5,
+            region='us-west',
+            feature=['fast'],
+            json=False,
+        )
+        
+        mock_response_data = {
+            'seed_id': 'test-seed',
+            'routers': [
+                {
+                    'router_id': 'router-001',
+                    'endpoints': ['ws://router1.example.com'],
+                    'regions': ['us-west'],
+                    'capacity': {'current_load_pct': 45},
+                    'health': {'uptime_pct': 99.5},
+                },
+                {
+                    'router_id': 'router-002-very-long-id-that-should-be-truncated',
+                    'endpoints': ['ws://router2.example.com', 'wss://router2.secure.com'],
+                    'regions': [],
+                    'capacity': {'current_load_pct': 20},
+                    'health': {'uptime_pct': 98.0},
+                },
+            ],
+            'other_seeds': ['https://seed2.example.com'],
+        }
+        
+        mock_config = MagicMock()
+        mock_config.seed_port = 8470
+        
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=mock_response_data)
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            with patch('valence.cli.seed.get_config', return_value=mock_config):
+                result = await cmd_discover(args)
+        
+        assert result == 0
+        captured = capsys.readouterr()
+        assert '📡' in captured.out
+        assert 'router-001' in captured.out
+        assert 'us-west' in captured.out
+        assert 'seed2.example.com' in captured.out
+    
+    @pytest.mark.asyncio
+    async def test_discover_no_routers(self, capsys):
+        """Discover command with no routers found."""
+        args = argparse.Namespace(
+            url='http://localhost:8470',
+            port=None,
+            count=5,
+            region=None,
+            feature=[],
+            json=False,
+        )
+        
+        mock_response_data = {
+            'seed_id': 'test-seed',
+            'routers': [],
+        }
+        
+        mock_config = MagicMock()
+        mock_config.seed_port = 8470
+        
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=mock_response_data)
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            with patch('valence.cli.seed.get_config', return_value=mock_config):
+                result = await cmd_discover(args)
+        
+        assert result == 0
+        captured = capsys.readouterr()
+        assert 'No routers available' in captured.out
+    
+    @pytest.mark.asyncio
+    async def test_discover_sends_preferences(self):
+        """Discover sends region and feature preferences."""
+        args = argparse.Namespace(
+            url='http://localhost:8470',
+            port=None,
+            count=10,
+            region='eu-west',
+            feature=['encrypted', 'low-latency'],
+            json=True,
+        )
+        
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={'routers': []})
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            await cmd_discover(args)
+        
+        # Check the JSON payload sent
+        call_kwargs = mock_session.post.call_args[1]
+        assert call_kwargs['json']['requested_count'] == 10
+        assert call_kwargs['json']['preferences']['region'] == 'eu-west'
+        assert call_kwargs['json']['preferences']['features'] == ['encrypted', 'low-latency']
+
+
+# ============================================================================
+# async_main Tests
+# ============================================================================
+
+class TestAsyncMain:
+    """Test async_main dispatcher."""
+    
+    @pytest.mark.asyncio
+    async def test_dispatch_to_start(self):
+        """Dispatch to start command."""
+        args = argparse.Namespace(
+            command='start',
+            host=None,
+            port=None,
+            seed_id=None,
+            peer=[],
+            verbose=False,
+        )
+        
+        with patch('valence.cli.seed.cmd_start', new_callable=AsyncMock) as mock_start:
+            mock_start.return_value = 0
+            result = await async_main(args)
+        
+        assert result == 0
+        mock_start.assert_called_once_with(args)
+    
+    @pytest.mark.asyncio
+    async def test_dispatch_to_status(self):
+        """Dispatch to status command."""
+        args = argparse.Namespace(
+            command='status',
+            url=None,
+            port=None,
+            json=False,
+            verbose=False,
+        )
+        
+        with patch('valence.cli.seed.cmd_status', new_callable=AsyncMock) as mock_status:
+            mock_status.return_value = 0
+            result = await async_main(args)
+        
+        assert result == 0
+        mock_status.assert_called_once_with(args)
+    
+    @pytest.mark.asyncio
+    async def test_dispatch_to_discover(self):
+        """Dispatch to discover command."""
+        args = argparse.Namespace(
+            command='discover',
+            url=None,
+            port=None,
+            count=5,
+            region=None,
+            feature=[],
+            json=False,
+            verbose=False,
+        )
+        
+        with patch('valence.cli.seed.cmd_discover', new_callable=AsyncMock) as mock_discover:
+            mock_discover.return_value = 0
+            result = await async_main(args)
+        
+        assert result == 0
+        mock_discover.assert_called_once_with(args)
+    
+    @pytest.mark.asyncio
+    async def test_dispatch_no_command(self):
+        """No command shows help."""
+        args = argparse.Namespace(
+            command=None,
+            verbose=False,
+        )
+        
+        result = await async_main(args)
+        
+        assert result == 0
+
+
+# ============================================================================
+# main() Entry Point Tests
+# ============================================================================
+
+class TestMain:
+    """Test main entry point."""
+    
+    def test_main_no_command_returns_0(self):
+        """Main with no command returns 0."""
+        with patch('sys.argv', ['valence-seed']):
+            result = main()
+        assert result == 0
+    
+    def test_main_help_exits_0(self):
+        """Main with --help exits with 0."""
+        with patch('sys.argv', ['valence-seed', '--help']):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 0

--- a/tests/federation/test_server.py
+++ b/tests/federation/test_server.py
@@ -1,0 +1,716 @@
+"""Tests for Federation Server (federation/server.py).
+
+Tests cover:
+1. NodeIdentity dataclass
+2. LocalBelief dataclass
+3. FederationNode initialization and identity
+4. Endpoint handlers (_info, _introduce, _share, _query, _list_peers)
+5. Client methods (introduce_to, share_belief, query_peer)
+6. PII scanning integration
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from starlette.testclient import TestClient
+
+from valence.federation.server import (
+    NodeIdentity,
+    LocalBelief,
+    FederationNode,
+    create_node,
+)
+
+
+# ============================================================================
+# NodeIdentity Tests
+# ============================================================================
+
+class TestNodeIdentity:
+    """Test NodeIdentity dataclass."""
+    
+    def test_node_identity_creation(self):
+        """Create NodeIdentity with all fields."""
+        mock_keypair = MagicMock()
+        mock_keypair.public_key_multibase = 'z6MkTest123'
+        
+        identity = NodeIdentity(
+            did='did:vkb:key:z6MkTest123',
+            keypair=mock_keypair,
+            name='Test Node',
+            endpoint='http://localhost:8000',
+        )
+        
+        assert identity.did == 'did:vkb:key:z6MkTest123'
+        assert identity.name == 'Test Node'
+        assert identity.endpoint == 'http://localhost:8000'
+    
+    def test_node_identity_public_key_property(self):
+        """Access public key through property."""
+        mock_keypair = MagicMock()
+        mock_keypair.public_key_multibase = 'z6MkTest456'
+        
+        identity = NodeIdentity(
+            did='did:vkb:key:z6MkTest456',
+            keypair=mock_keypair,
+        )
+        
+        assert identity.public_key_multibase == 'z6MkTest456'
+    
+    def test_node_identity_to_dict(self):
+        """Convert identity to dictionary."""
+        mock_keypair = MagicMock()
+        mock_keypair.public_key_multibase = 'z6MkTestKey'
+        
+        identity = NodeIdentity(
+            did='did:vkb:key:z6MkTestKey',
+            keypair=mock_keypair,
+            name='Test Node',
+            endpoint='http://localhost:8000',
+        )
+        
+        d = identity.to_dict()
+        
+        assert d['did'] == 'did:vkb:key:z6MkTestKey'
+        assert d['name'] == 'Test Node'
+        assert d['endpoint'] == 'http://localhost:8000'
+        assert d['public_key_multibase'] == 'z6MkTestKey'
+
+
+# ============================================================================
+# LocalBelief Tests
+# ============================================================================
+
+class TestLocalBelief:
+    """Test LocalBelief dataclass."""
+    
+    def test_local_belief_creation(self):
+        """Create LocalBelief with required fields."""
+        belief = LocalBelief(
+            id='belief-001',
+            content='Test belief content',
+            confidence=0.85,
+            domains=['tech', 'python'],
+        )
+        
+        assert belief.id == 'belief-001'
+        assert belief.content == 'Test belief content'
+        assert belief.confidence == 0.85
+        assert belief.domains == ['tech', 'python']
+        assert belief.signature is None
+        assert belief.origin_did is None
+        assert isinstance(belief.created_at, datetime)
+    
+    def test_local_belief_with_optional_fields(self):
+        """Create LocalBelief with optional fields."""
+        created = datetime(2024, 1, 15, 10, 30, 0)
+        
+        belief = LocalBelief(
+            id='belief-002',
+            content='Signed belief',
+            confidence=0.9,
+            domains=['security'],
+            created_at=created,
+            signature='base64signature',
+            origin_did='did:vkb:key:z6MkOrigin',
+        )
+        
+        assert belief.created_at == created
+        assert belief.signature == 'base64signature'
+        assert belief.origin_did == 'did:vkb:key:z6MkOrigin'
+    
+    def test_local_belief_to_dict(self):
+        """Convert belief to dictionary."""
+        created = datetime(2024, 1, 15, 10, 30, 0)
+        
+        belief = LocalBelief(
+            id='belief-003',
+            content='Dict test',
+            confidence=0.75,
+            domains=['test'],
+            created_at=created,
+            signature='sig123',
+            origin_did='did:vkb:key:z6MkTest',
+        )
+        
+        d = belief.to_dict()
+        
+        assert d['id'] == 'belief-003'
+        assert d['content'] == 'Dict test'
+        assert d['confidence'] == 0.75
+        assert d['domains'] == ['test']
+        assert d['created_at'] == created.isoformat()
+        assert d['signature'] == 'sig123'
+        assert d['origin_did'] == 'did:vkb:key:z6MkTest'
+
+
+# ============================================================================
+# FederationNode Tests
+# ============================================================================
+
+class TestFederationNodeInit:
+    """Test FederationNode initialization."""
+    
+    def test_node_creation_generates_keypair(self):
+        """Node generates keypair if not provided."""
+        with patch('valence.federation.server.generate_keypair') as mock_gen:
+            mock_keypair = MagicMock()
+            mock_keypair.public_key_multibase = 'z6MkGenerated'
+            mock_gen.return_value = mock_keypair
+            
+            with patch('valence.federation.server.create_key_did') as mock_did:
+                mock_did_obj = MagicMock()
+                mock_did_obj.full = 'did:vkb:key:z6MkGenerated'
+                mock_did.return_value = mock_did_obj
+                
+                node = FederationNode(name='Test Node', port=8000)
+        
+        assert node.name == 'Test Node'
+        assert node.port == 8000
+        assert node.endpoint == 'http://127.0.0.1:8000'
+        assert node.identity.did == 'did:vkb:key:z6MkGenerated'
+    
+    def test_node_creation_with_keypair(self):
+        """Node uses provided keypair."""
+        mock_keypair = MagicMock()
+        mock_keypair.public_key_multibase = 'z6MkProvided'
+        
+        with patch('valence.federation.server.create_key_did') as mock_did:
+            mock_did_obj = MagicMock()
+            mock_did_obj.full = 'did:vkb:key:z6MkProvided'
+            mock_did.return_value = mock_did_obj
+            
+            node = FederationNode(
+                name='Test Node',
+                port=8001,
+                keypair=mock_keypair,
+            )
+        
+        assert node.keypair == mock_keypair
+    
+    def test_node_has_empty_stores(self):
+        """New node has empty peer and belief stores."""
+        with patch('valence.federation.server.generate_keypair'):
+            with patch('valence.federation.server.create_key_did') as mock_did:
+                mock_did_obj = MagicMock()
+                mock_did_obj.full = 'did:test'
+                mock_did.return_value = mock_did_obj
+                
+                node = FederationNode(name='Empty Node', port=8002)
+        
+        assert node.beliefs == {}
+        assert len(node.peer_store.list_peers()) == 0
+
+
+# ============================================================================
+# Endpoint Handler Tests
+# ============================================================================
+
+class TestFederationEndpoints:
+    """Test federation HTTP endpoint handlers."""
+    
+    @pytest.fixture
+    def node(self):
+        """Create a test federation node."""
+        with patch('valence.federation.server.generate_keypair') as mock_gen:
+            mock_keypair = MagicMock()
+            mock_keypair.public_key_multibase = 'z6MkTestNode'
+            mock_keypair.private_key_bytes = b'test_private_key'
+            mock_gen.return_value = mock_keypair
+            
+            with patch('valence.federation.server.create_key_did') as mock_did:
+                mock_did_obj = MagicMock()
+                mock_did_obj.full = 'did:vkb:key:z6MkTestNode'
+                mock_did.return_value = mock_did_obj
+                
+                return FederationNode(name='Test Node', port=9000)
+    
+    @pytest.fixture
+    def client(self, node):
+        """Create a test client for the node."""
+        return TestClient(node.app)
+    
+    def test_info_endpoint(self, client, node):
+        """GET / returns node info."""
+        response = client.get('/')
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert 'node' in data
+        assert data['node']['name'] == 'Test Node'
+        assert data['beliefs_count'] == 0
+        assert data['peers_count'] == 0
+    
+    def test_introduce_endpoint_success(self, client, node):
+        """POST /federation/introduce registers peer."""
+        payload = {
+            'did': 'did:vkb:key:z6MkPeer1',
+            'endpoint': 'http://peer1.example.com:8000',
+            'public_key_multibase': 'z6MkPeer1Key',
+            'name': 'Peer Node',
+        }
+        
+        response = client.post('/federation/introduce', json=payload)
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['success'] is True
+        assert 'Test Node' in data['message']
+        assert data['node']['did'] == node.identity.did
+    
+    def test_introduce_endpoint_missing_field(self, client):
+        """POST /federation/introduce rejects missing required field."""
+        payload = {
+            'did': 'did:vkb:key:z6MkPeer1',
+            # Missing endpoint and public_key_multibase
+        }
+        
+        response = client.post('/federation/introduce', json=payload)
+        
+        assert response.status_code == 400
+        assert 'endpoint' in response.json()['error']
+    
+    def test_introduce_endpoint_invalid_json(self, client):
+        """POST /federation/introduce rejects invalid JSON."""
+        response = client.post(
+            '/federation/introduce',
+            content='not json',
+            headers={'Content-Type': 'application/json'},
+        )
+        
+        assert response.status_code == 400
+        assert 'Invalid JSON' in response.json()['error']
+    
+    def test_share_endpoint_success(self, client, node):
+        """POST /federation/share accepts valid belief."""
+        # First register the peer
+        peer_did = 'did:vkb:key:z6MkSender'
+        node.peer_store.add_peer(
+            did=peer_did,
+            endpoint='http://sender.example.com',
+            public_key_multibase='z6MkSenderKey',
+        )
+        
+        payload = {
+            'belief': {
+                'id': 'belief-shared-001',
+                'content': 'Shared belief content',
+                'confidence': 0.8,
+                'domains': ['test'],
+                'origin_did': peer_did,
+            },
+            'sender_did': peer_did,
+        }
+        
+        with patch('valence.federation.server.verify_belief_signature', return_value=True):
+            response = client.post('/federation/share', json=payload)
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['success'] is True
+        assert data['belief_id'] == 'belief-shared-001'
+        assert 'belief-shared-001' in node.beliefs
+    
+    def test_share_endpoint_unknown_sender(self, client):
+        """POST /federation/share rejects unknown sender."""
+        payload = {
+            'belief': {
+                'id': 'belief-001',
+                'content': 'Test',
+                'confidence': 0.8,
+            },
+            'sender_did': 'did:vkb:key:z6MkUnknown',
+        }
+        
+        response = client.post('/federation/share', json=payload)
+        
+        assert response.status_code == 403
+        assert 'Unknown sender' in response.json()['error']
+    
+    def test_share_endpoint_invalid_signature(self, client, node):
+        """POST /federation/share rejects invalid signature."""
+        peer_did = 'did:vkb:key:z6MkBadSig'
+        node.peer_store.add_peer(
+            did=peer_did,
+            endpoint='http://bad.example.com',
+            public_key_multibase='z6MkBadKey',
+        )
+        
+        payload = {
+            'belief': {
+                'id': 'belief-badsig',
+                'content': 'Bad signature',
+                'confidence': 0.8,
+                'origin_did': peer_did,
+                'signature': 'invalid_signature',
+            },
+            'sender_did': peer_did,
+        }
+        
+        with patch('valence.federation.server.verify_belief_signature', return_value=False):
+            response = client.post('/federation/share', json=payload)
+        
+        assert response.status_code == 403
+        assert 'Invalid signature' in response.json()['error']
+    
+    def test_query_endpoint_success(self, client, node):
+        """POST /federation/query returns matching beliefs."""
+        # Add some beliefs
+        node.beliefs['b1'] = LocalBelief(
+            id='b1',
+            content='Python is a great programming language',
+            confidence=0.9,
+            domains=['tech', 'programming'],
+        )
+        node.beliefs['b2'] = LocalBelief(
+            id='b2',
+            content='JavaScript runs in browsers',
+            confidence=0.85,
+            domains=['tech', 'web'],
+        )
+        
+        payload = {
+            'query': 'python',
+            'min_confidence': 0.5,
+        }
+        
+        response = client.post('/federation/query', json=payload)
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['success'] is True
+        assert data['total'] == 1
+        assert data['results'][0]['id'] == 'b1'
+    
+    def test_query_endpoint_with_domain_filter(self, client, node):
+        """POST /federation/query filters by domain."""
+        node.beliefs['b1'] = LocalBelief(
+            id='b1',
+            content='Web development',
+            confidence=0.9,
+            domains=['tech', 'web'],
+        )
+        node.beliefs['b2'] = LocalBelief(
+            id='b2',
+            content='Data science',
+            confidence=0.9,
+            domains=['tech', 'data'],
+        )
+        
+        payload = {
+            'query': '',  # Match all
+            'domains': ['web'],
+        }
+        
+        response = client.post('/federation/query', json=payload)
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['total'] == 1
+        assert data['results'][0]['id'] == 'b1'
+    
+    def test_query_endpoint_with_confidence_filter(self, client, node):
+        """POST /federation/query filters by min confidence."""
+        node.beliefs['low'] = LocalBelief(
+            id='low',
+            content='Low confidence belief',
+            confidence=0.3,
+            domains=[],
+        )
+        node.beliefs['high'] = LocalBelief(
+            id='high',
+            content='High confidence belief',
+            confidence=0.95,
+            domains=[],
+        )
+        
+        payload = {
+            'query': 'belief',
+            'min_confidence': 0.8,
+        }
+        
+        response = client.post('/federation/query', json=payload)
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['total'] == 1
+        assert data['results'][0]['id'] == 'high'
+    
+    def test_list_peers_endpoint(self, client, node):
+        """GET /federation/peers returns peer list."""
+        node.peer_store.add_peer(
+            did='did:vkb:key:z6MkPeer1',
+            endpoint='http://peer1.example.com',
+            public_key_multibase='z6MkPeer1Key',
+        )
+        node.peer_store.add_peer(
+            did='did:vkb:key:z6MkPeer2',
+            endpoint='http://peer2.example.com',
+            public_key_multibase='z6MkPeer2Key',
+        )
+        
+        response = client.get('/federation/peers')
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['count'] == 2
+        assert len(data['peers']) == 2
+
+
+# ============================================================================
+# Client Method Tests
+# ============================================================================
+
+class TestFederationNodeClientMethods:
+    """Test FederationNode client methods."""
+    
+    @pytest.fixture
+    def node(self):
+        """Create a test federation node."""
+        with patch('valence.federation.server.generate_keypair') as mock_gen:
+            mock_keypair = MagicMock()
+            mock_keypair.public_key_multibase = 'z6MkClient'
+            mock_keypair.private_key_bytes = b'private_key_bytes'
+            mock_gen.return_value = mock_keypair
+            
+            with patch('valence.federation.server.create_key_did') as mock_did:
+                mock_did_obj = MagicMock()
+                mock_did_obj.full = 'did:vkb:key:z6MkClient'
+                mock_did.return_value = mock_did_obj
+                
+                return FederationNode(name='Client Node', port=9001)
+    
+    @pytest.mark.asyncio
+    async def test_introduce_to_success(self, node):
+        """Successfully introduce to another node."""
+        mock_response = AsyncMock()
+        mock_response.json = AsyncMock(return_value={
+            'success': True,
+            'node': {
+                'did': 'did:vkb:key:z6MkRemote',
+                'endpoint': 'http://remote.example.com',
+                'public_key_multibase': 'z6MkRemoteKey',
+                'name': 'Remote Node',
+            },
+        })
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            result = await node.introduce_to('http://remote.example.com')
+        
+        assert result['success'] is True
+        # Peer should be registered
+        peer = node.peer_store.get_peer('did:vkb:key:z6MkRemote')
+        assert peer is not None
+        assert peer.name == 'Remote Node'
+    
+    @pytest.mark.asyncio
+    async def test_share_belief_success(self, node):
+        """Successfully share a belief with a peer."""
+        # Register peer first
+        peer_did = 'did:vkb:key:z6MkTarget'
+        node.peer_store.add_peer(
+            did=peer_did,
+            endpoint='http://target.example.com',
+            public_key_multibase='z6MkTargetKey',
+        )
+        
+        mock_response = AsyncMock()
+        mock_response.json = AsyncMock(return_value={
+            'success': True,
+            'belief_id': 'shared-001',
+        })
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            with patch('valence.federation.server.sign_belief_content', return_value='signature'):
+                with patch('valence.federation.server.check_federation_allowed', return_value=(True, MagicMock())):
+                    result = await node.share_belief(
+                        peer_did=peer_did,
+                        content='Shared belief content',
+                        confidence=0.8,
+                        domains=['test'],
+                    )
+        
+        assert result['success'] is True
+    
+    @pytest.mark.asyncio
+    async def test_share_belief_pii_blocked(self, node):
+        """Share is blocked when PII is detected."""
+        peer_did = 'did:vkb:key:z6MkTarget'
+        node.peer_store.add_peer(
+            did=peer_did,
+            endpoint='http://target.example.com',
+            public_key_multibase='z6MkTargetKey',
+        )
+        
+        mock_scan_result = MagicMock()
+        mock_scan_result.to_dict.return_value = {'level': 'L3', 'findings': ['email']}
+        
+        with patch('valence.federation.server.check_federation_allowed', return_value=(False, mock_scan_result)):
+            result = await node.share_belief(
+                peer_did=peer_did,
+                content='Contact me at john@example.com',
+                confidence=0.8,
+            )
+        
+        assert result['success'] is False
+        assert 'PII' in result['error']
+    
+    @pytest.mark.asyncio
+    async def test_share_belief_pii_force_override(self, node):
+        """Share with force=True overrides PII block."""
+        peer_did = 'did:vkb:key:z6MkTarget'
+        node.peer_store.add_peer(
+            did=peer_did,
+            endpoint='http://target.example.com',
+            public_key_multibase='z6MkTargetKey',
+        )
+        
+        mock_response = AsyncMock()
+        mock_response.json = AsyncMock(return_value={'success': True, 'belief_id': 'x'})
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            with patch('valence.federation.server.sign_belief_content', return_value='sig'):
+                with patch('valence.federation.server.check_federation_allowed', return_value=(True, MagicMock())):
+                    result = await node.share_belief(
+                        peer_did=peer_did,
+                        content='Contact me at john@example.com',
+                        confidence=0.8,
+                        force=True,
+                    )
+        
+        assert result['success'] is True
+    
+    @pytest.mark.asyncio
+    async def test_share_belief_unknown_peer(self, node):
+        """Share fails for unknown peer."""
+        result = await node.share_belief(
+            peer_did='did:vkb:key:z6MkUnknown',
+            content='Test',
+            confidence=0.8,
+        )
+        
+        assert result['success'] is False
+        assert 'Unknown peer' in result['error']
+    
+    @pytest.mark.asyncio
+    async def test_query_peer_success(self, node):
+        """Successfully query a peer."""
+        peer_did = 'did:vkb:key:z6MkQueryTarget'
+        node.peer_store.add_peer(
+            did=peer_did,
+            endpoint='http://query-target.example.com',
+            public_key_multibase='z6MkKey',
+        )
+        
+        mock_response = AsyncMock()
+        mock_response.json = AsyncMock(return_value={
+            'success': True,
+            'results': [
+                {'id': 'result-1', 'content': 'Match 1', 'confidence': 0.9},
+            ],
+        })
+        
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_ctx)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        
+        with patch('aiohttp.ClientSession', return_value=mock_session_ctx):
+            result = await node.query_peer(
+                peer_did=peer_did,
+                query='test query',
+                min_confidence=0.5,
+            )
+        
+        assert result['success'] is True
+        assert len(result['results']) == 1
+    
+    @pytest.mark.asyncio
+    async def test_query_peer_unknown(self, node):
+        """Query fails for unknown peer."""
+        result = await node.query_peer(
+            peer_did='did:vkb:key:z6MkUnknown',
+            query='test',
+        )
+        
+        assert result['success'] is False
+        assert 'Unknown peer' in result['error']
+
+
+# ============================================================================
+# create_node Factory Tests
+# ============================================================================
+
+class TestCreateNode:
+    """Test create_node factory function."""
+    
+    @pytest.mark.asyncio
+    async def test_create_node(self):
+        """Create a node using factory function."""
+        with patch('valence.federation.server.generate_keypair') as mock_gen:
+            mock_keypair = MagicMock()
+            mock_keypair.public_key_multibase = 'z6MkFactory'
+            mock_gen.return_value = mock_keypair
+            
+            with patch('valence.federation.server.create_key_did') as mock_did:
+                mock_did_obj = MagicMock()
+                mock_did_obj.full = 'did:vkb:key:z6MkFactory'
+                mock_did.return_value = mock_did_obj
+                
+                node = await create_node(name='Factory Node', port=9999)
+        
+        assert isinstance(node, FederationNode)
+        assert node.name == 'Factory Node'
+        assert node.port == 9999
+        assert node.host == '127.0.0.1'

--- a/tests/federation/test_threat_detector.py
+++ b/tests/federation/test_threat_detector.py
@@ -1,0 +1,541 @@
+"""Tests for Threat Detector (federation/threat_detector.py).
+
+Tests cover:
+1. ThreatDetector initialization
+2. assess_threat_level with various signals
+3. apply_threat_response for each threat level
+4. Edge cases and signal combinations
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from valence.federation.threat_detector import (
+    ThreatDetector,
+    THREAT_THRESHOLDS,
+)
+from valence.federation.models import ThreatLevel, NodeTrust
+
+
+# ============================================================================
+# ThreatDetector Initialization Tests
+# ============================================================================
+
+class TestThreatDetectorInit:
+    """Test ThreatDetector initialization."""
+    
+    def test_detector_creation(self):
+        """Create detector with registry."""
+        mock_registry = MagicMock()
+        detector = ThreatDetector(registry=mock_registry)
+        
+        assert detector.registry == mock_registry
+
+
+# ============================================================================
+# assess_threat_level Tests
+# ============================================================================
+
+class TestAssessThreatLevel:
+    """Test assess_threat_level method."""
+    
+    @pytest.fixture
+    def detector(self):
+        """Create a detector with mock registry."""
+        mock_registry = MagicMock()
+        return ThreatDetector(registry=mock_registry)
+    
+    def test_no_trust_record(self, detector):
+        """No trust record returns NONE level."""
+        detector.registry.get_node_trust.return_value = None
+        node_id = uuid4()
+        
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        assert level == ThreatLevel.NONE
+        assert assessment['reason'] == 'No trust record'
+    
+    def test_clean_node_no_threat(self, detector):
+        """Clean node with good behavior has no threat."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 5  # Low activity, under threshold
+        node_trust.beliefs_disputed = 0
+        node_trust.sync_requests_served = 2
+        node_trust.aggregation_participations = 3
+        node_trust.overall = 0.8  # Good trust
+        node_trust.beliefs_corroborated = 4
+        node_trust.relationship_started_at = datetime.now() - timedelta(days=30)
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        assert level == ThreatLevel.NONE
+        assert assessment['threat_score'] == 0.0
+        assert len(assessment['signals']) == 0
+    
+    def test_high_dispute_ratio_signal(self, detector):
+        """High dispute ratio triggers threat signal."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 100
+        node_trust.beliefs_disputed = 50  # 50% dispute ratio
+        node_trust.sync_requests_served = 5
+        node_trust.aggregation_participations = 5
+        node_trust.overall = 0.5
+        node_trust.beliefs_corroborated = 50
+        node_trust.relationship_started_at = datetime.now() - timedelta(days=30)
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        # Should have high_dispute_ratio signal
+        signal_types = [s['type'] for s in assessment['signals']]
+        assert 'high_dispute_ratio' in signal_types
+        
+        # 50% dispute ratio should contribute 0.3 (capped)
+        dispute_signal = next(s for s in assessment['signals'] if s['type'] == 'high_dispute_ratio')
+        assert dispute_signal['value'] == 0.5
+        assert dispute_signal['contribution'] == 0.3
+    
+    def test_persistently_low_trust_signal(self, detector):
+        """Persistently low trust triggers threat signal."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 15
+        node_trust.beliefs_disputed = 2
+        node_trust.sync_requests_served = 10
+        node_trust.aggregation_participations = 5
+        node_trust.overall = 0.15  # Very low trust
+        node_trust.beliefs_corroborated = 10
+        node_trust.relationship_started_at = datetime.now() - timedelta(days=30)
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        signal_types = [s['type'] for s in assessment['signals']]
+        assert 'persistently_low_trust' in signal_types
+        
+        low_trust_signal = next(s for s in assessment['signals'] if s['type'] == 'persistently_low_trust')
+        assert low_trust_signal['contribution'] == 0.2
+    
+    def test_low_corroboration_signal(self, detector):
+        """Low corroboration ratio triggers threat signal."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 100
+        node_trust.beliefs_disputed = 5
+        node_trust.sync_requests_served = 10
+        node_trust.aggregation_participations = 5
+        node_trust.overall = 0.5
+        node_trust.beliefs_corroborated = 5  # Only 5% corroborated
+        node_trust.relationship_started_at = datetime.now() - timedelta(days=30)
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        signal_types = [s['type'] for s in assessment['signals']]
+        assert 'low_corroboration' in signal_types
+        
+        corr_signal = next(s for s in assessment['signals'] if s['type'] == 'low_corroboration')
+        assert corr_signal['contribution'] == 0.15
+    
+    def test_high_volume_signal(self, detector):
+        """High volume (potential spam) triggers threat signal."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 500  # Very high
+        node_trust.beliefs_disputed = 10
+        node_trust.sync_requests_served = 50
+        node_trust.aggregation_participations = 20
+        node_trust.overall = 0.7
+        node_trust.beliefs_corroborated = 400
+        # Active for only 3 days = 166 beliefs/day
+        node_trust.relationship_started_at = datetime.now() - timedelta(days=3)
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        signal_types = [s['type'] for s in assessment['signals']]
+        assert 'high_volume' in signal_types
+        
+        volume_signal = next(s for s in assessment['signals'] if s['type'] == 'high_volume')
+        assert volume_signal['value'] > 50  # Daily rate above threshold
+    
+    def test_combined_signals_medium_threat(self, detector):
+        """Combined signals can reach MEDIUM threat level."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 100
+        node_trust.beliefs_disputed = 35  # 35% dispute ratio
+        node_trust.sync_requests_served = 20
+        node_trust.aggregation_participations = 10
+        node_trust.overall = 0.4  # Mediocre trust
+        node_trust.beliefs_corroborated = 8  # 8% corroboration
+        node_trust.relationship_started_at = datetime.now() - timedelta(days=30)
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        # Should have multiple signals
+        assert len(assessment['signals']) >= 2
+        # Should reach at least MEDIUM
+        assert level.value in ('medium', 'high')
+        assert assessment['threat_score'] >= THREAT_THRESHOLDS[ThreatLevel.MEDIUM]
+    
+    def test_critical_threat_level(self, detector):
+        """Many severe signals can reach CRITICAL threat level."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 500
+        node_trust.beliefs_disputed = 250  # 50% dispute
+        node_trust.sync_requests_served = 50
+        node_trust.aggregation_participations = 50
+        node_trust.overall = 0.1  # Very low trust
+        node_trust.beliefs_corroborated = 5  # 1% corroboration
+        # High volume
+        node_trust.relationship_started_at = datetime.now() - timedelta(days=2)
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        # Should reach CRITICAL
+        assert level == ThreatLevel.CRITICAL
+        assert assessment['threat_score'] >= 0.8
+    
+    def test_threat_level_thresholds(self, detector):
+        """Verify threat level thresholds are correctly applied."""
+        # Verify threshold values
+        assert THREAT_THRESHOLDS[ThreatLevel.NONE] == 0.0
+        assert THREAT_THRESHOLDS[ThreatLevel.LOW] == 0.2
+        assert THREAT_THRESHOLDS[ThreatLevel.MEDIUM] == 0.4
+        assert THREAT_THRESHOLDS[ThreatLevel.HIGH] == 0.6
+        assert THREAT_THRESHOLDS[ThreatLevel.CRITICAL] == 0.8
+
+
+# ============================================================================
+# apply_threat_response Tests
+# ============================================================================
+
+class TestApplyThreatResponse:
+    """Test apply_threat_response method."""
+    
+    @pytest.fixture
+    def detector(self):
+        """Create a detector with mock registry."""
+        mock_registry = MagicMock()
+        return ThreatDetector(registry=mock_registry)
+    
+    def test_no_node_trust_returns_false(self, detector):
+        """No node trust record returns False."""
+        detector.registry.get_node_trust.return_value = None
+        node_id = uuid4()
+        
+        result = detector.apply_threat_response(
+            node_id=node_id,
+            threat_level=ThreatLevel.MEDIUM,
+            assessment={'signals': []},
+        )
+        
+        assert result is False
+    
+    def test_none_level_no_action(self, detector):
+        """NONE threat level requires no action."""
+        node_id = uuid4()
+        node_trust = MagicMock(spec=NodeTrust)
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        result = detector.apply_threat_response(
+            node_id=node_id,
+            threat_level=ThreatLevel.NONE,
+            assessment={'signals': []},
+        )
+        
+        assert result is True
+        # No modifications should have been made
+        detector.registry.save_node_trust.assert_not_called()
+    
+    def test_low_level_logs_warning(self, detector, caplog):
+        """LOW threat level logs warning but no penalty."""
+        import logging
+        
+        node_id = uuid4()
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.manual_trust_adjustment = 0.0
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        with caplog.at_level(logging.WARNING):
+            result = detector.apply_threat_response(
+                node_id=node_id,
+                threat_level=ThreatLevel.LOW,
+                assessment={'signals': [{'type': 'test'}]},
+            )
+        
+        assert result is True
+        # Should not save (no changes)
+        detector.registry.save_node_trust.assert_not_called()
+        # Should log warning
+        assert 'LOW threat level' in caplog.text
+    
+    def test_medium_level_applies_penalty(self, detector):
+        """MEDIUM threat level applies trust penalty."""
+        node_id = uuid4()
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.manual_trust_adjustment = 0.0
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        result = detector.apply_threat_response(
+            node_id=node_id,
+            threat_level=ThreatLevel.MEDIUM,
+            assessment={'signals': []},
+        )
+        
+        assert result is True
+        # Should have applied -0.1 penalty
+        assert node_trust.manual_trust_adjustment == -0.1
+        assert 'medium' in node_trust.adjustment_reason.lower()
+        node_trust.recalculate_overall.assert_called_once()
+        detector.registry.save_node_trust.assert_called_once()
+    
+    def test_high_level_quarantines(self, detector):
+        """HIGH threat level quarantines node."""
+        node_id = uuid4()
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.manual_trust_adjustment = 0.0
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        with patch('valence.federation.threat_detector.get_cursor') as mock_cursor:
+            mock_cur = MagicMock()
+            mock_cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+            mock_cursor.return_value.__exit__ = MagicMock(return_value=False)
+            
+            result = detector.apply_threat_response(
+                node_id=node_id,
+                threat_level=ThreatLevel.HIGH,
+                assessment={'signals': []},
+            )
+        
+        assert result is True
+        # Should have applied -0.3 penalty
+        assert node_trust.manual_trust_adjustment == -0.3
+        assert 'quarantine' in node_trust.adjustment_reason.lower()
+        node_trust.recalculate_overall.assert_called_once()
+        # Should have updated database for quarantine
+        mock_cur.execute.assert_called_once()
+        assert 'quarantine_until' in mock_cur.execute.call_args[0][0]
+    
+    def test_critical_level_isolates(self, detector):
+        """CRITICAL threat level isolates node (read-only)."""
+        node_id = uuid4()
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.manual_trust_adjustment = 0.0
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        with patch('valence.federation.threat_detector.get_cursor') as mock_cursor:
+            mock_cur = MagicMock()
+            mock_cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+            mock_cursor.return_value.__exit__ = MagicMock(return_value=False)
+            
+            result = detector.apply_threat_response(
+                node_id=node_id,
+                threat_level=ThreatLevel.CRITICAL,
+                assessment={'signals': [{'type': 'multiple_flags'}]},
+            )
+        
+        assert result is True
+        # Should have applied -0.5 penalty (capped at -0.9)
+        assert node_trust.manual_trust_adjustment == -0.5
+        assert 'isolation' in node_trust.adjustment_reason.lower()
+        # Should have set read_only and suspended
+        assert 'read_only' in mock_cur.execute.call_args[0][0]
+        assert 'suspended' in mock_cur.execute.call_args[0][0]
+    
+    def test_critical_penalty_caps_at_minus_0_9(self, detector):
+        """CRITICAL penalty is capped at -0.9 total."""
+        node_id = uuid4()
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.manual_trust_adjustment = -0.6  # Already has penalty
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        with patch('valence.federation.threat_detector.get_cursor') as mock_cursor:
+            mock_cur = MagicMock()
+            mock_cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+            mock_cursor.return_value.__exit__ = MagicMock(return_value=False)
+            
+            detector.apply_threat_response(
+                node_id=node_id,
+                threat_level=ThreatLevel.CRITICAL,
+                assessment={'signals': []},
+            )
+        
+        # -0.6 + -0.5 = -1.1, but should cap at -0.9
+        assert node_trust.manual_trust_adjustment == -0.9
+    
+    def test_db_error_handled_gracefully(self, detector, caplog):
+        """Database errors are handled gracefully."""
+        import logging
+        
+        node_id = uuid4()
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.manual_trust_adjustment = 0.0
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        with patch('valence.federation.threat_detector.get_cursor') as mock_cursor:
+            mock_cursor.return_value.__enter__ = MagicMock(
+                side_effect=Exception("DB connection failed")
+            )
+            mock_cursor.return_value.__exit__ = MagicMock(return_value=False)
+            
+            with caplog.at_level(logging.ERROR):
+                result = detector.apply_threat_response(
+                    node_id=node_id,
+                    threat_level=ThreatLevel.HIGH,
+                    assessment={'signals': []},
+                )
+        
+        # Should still return True (response was applied, just DB failed)
+        assert result is True
+        # Should log error
+        assert 'quarantine' in caplog.text.lower() or 'error' in caplog.text.lower()
+
+
+# ============================================================================
+# Edge Case Tests
+# ============================================================================
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+    
+    @pytest.fixture
+    def detector(self):
+        """Create a detector with mock registry."""
+        mock_registry = MagicMock()
+        return ThreatDetector(registry=mock_registry)
+    
+    def test_dispute_ratio_threshold_exactly_30_percent(self, detector):
+        """Dispute ratio exactly at 30% threshold."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 100
+        node_trust.beliefs_disputed = 30  # Exactly 30%
+        node_trust.sync_requests_served = 5
+        node_trust.aggregation_participations = 5
+        node_trust.overall = 0.5
+        node_trust.beliefs_corroborated = 50
+        node_trust.relationship_started_at = datetime.now() - timedelta(days=30)
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        # At exactly 30%, should NOT trigger (>0.3 is the condition)
+        signal_types = [s['type'] for s in assessment['signals']]
+        assert 'high_dispute_ratio' not in signal_types
+    
+    def test_dispute_ratio_just_above_threshold(self, detector):
+        """Dispute ratio just above 30% threshold."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 100
+        node_trust.beliefs_disputed = 31  # Just above 30%
+        node_trust.sync_requests_served = 5
+        node_trust.aggregation_participations = 5
+        node_trust.overall = 0.5
+        node_trust.beliefs_corroborated = 50
+        node_trust.relationship_started_at = datetime.now() - timedelta(days=30)
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        # Just above 30% should trigger
+        signal_types = [s['type'] for s in assessment['signals']]
+        assert 'high_dispute_ratio' in signal_types
+    
+    def test_new_node_no_volume_signal(self, detector):
+        """New node with few beliefs doesn't trigger volume signal."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 50  # Under 100 threshold
+        node_trust.beliefs_disputed = 0
+        node_trust.sync_requests_served = 5
+        node_trust.aggregation_participations = 5
+        node_trust.overall = 0.7
+        node_trust.beliefs_corroborated = 40
+        # Even if very recent, under 100 beliefs shouldn't trigger
+        node_trust.relationship_started_at = datetime.now() - timedelta(hours=1)
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        signal_types = [s['type'] for s in assessment['signals']]
+        assert 'high_volume' not in signal_types
+    
+    def test_zero_beliefs_corroborated_division(self, detector):
+        """Zero beliefs corroborated doesn't cause division error."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 10
+        node_trust.beliefs_disputed = 0
+        node_trust.sync_requests_served = 5
+        node_trust.aggregation_participations = 5
+        node_trust.overall = 0.5
+        node_trust.beliefs_corroborated = 0  # Zero corroborated
+        node_trust.relationship_started_at = datetime.now() - timedelta(days=30)
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        # Should not raise
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        # With 0 corroborated and >0 received, ratio is 0% - triggers if <10%
+        # But beliefs_received = 10 means low_corroboration check doesn't trigger
+        # (needs beliefs_corroborated > 0 per the condition)
+        assert level is not None
+    
+    def test_zero_days_active(self, detector):
+        """Node active for 0 days (same day) doesn't cause division error."""
+        node_id = uuid4()
+        
+        node_trust = MagicMock(spec=NodeTrust)
+        node_trust.beliefs_received = 200
+        node_trust.beliefs_disputed = 10
+        node_trust.sync_requests_served = 5
+        node_trust.aggregation_participations = 5
+        node_trust.overall = 0.7
+        node_trust.beliefs_corroborated = 150
+        # Just started today
+        node_trust.relationship_started_at = datetime.now()
+        
+        detector.registry.get_node_trust.return_value = node_trust
+        
+        # Should not raise (max(1, days) protects against division by zero)
+        level, assessment = detector.assess_threat_level(node_id)
+        
+        # With 200 beliefs in 1 day = 200/day, well above 50 threshold
+        signal_types = [s['type'] for s in assessment['signals']]
+        assert 'high_volume' in signal_types

--- a/tests/server/test_notification_endpoints.py
+++ b/tests/server/test_notification_endpoints.py
@@ -1,0 +1,416 @@
+"""Tests for Notification API endpoints (server/notification_endpoints.py).
+
+Tests cover:
+1. list_notifications_endpoint - GET /api/v1/notifications
+2. acknowledge_notification_endpoint - POST /api/v1/notifications/{id}/acknowledge
+3. Error handling (missing fields, invalid JSON, service unavailable)
+4. _notification_to_dict helper
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.requests import Request
+from starlette.testclient import TestClient
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+from valence.server.notification_endpoints import (
+    list_notifications_endpoint,
+    acknowledge_notification_endpoint,
+    _notification_to_dict,
+)
+from valence.server.sharing_endpoints import set_sharing_service
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+@pytest.fixture
+def mock_sharing_service():
+    """Create a mock sharing service."""
+    service = MagicMock()
+    return service
+
+
+@pytest.fixture
+def app(mock_sharing_service):
+    """Create a test Starlette app with notification endpoints."""
+    routes = [
+        Route('/api/v1/notifications', list_notifications_endpoint, methods=['GET']),
+        Route('/api/v1/notifications/{id}/acknowledge', acknowledge_notification_endpoint, methods=['POST']),
+    ]
+    
+    set_sharing_service(mock_sharing_service)
+    return Starlette(routes=routes)
+
+
+@pytest.fixture
+def client(app):
+    """Create a test client."""
+    return TestClient(app)
+
+
+# ============================================================================
+# list_notifications_endpoint Tests
+# ============================================================================
+
+class TestListNotificationsEndpoint:
+    """Test GET /api/v1/notifications endpoint."""
+    
+    def test_list_notifications_success(self, client, mock_sharing_service):
+        """Successfully list notifications."""
+        mock_notification = MagicMock()
+        mock_notification.id = 'notif-001'
+        mock_notification.recipient_did = 'did:vkb:key:z6MkRecipient'
+        mock_notification.notification_type = 'share_received'
+        mock_notification.payload = {'share_id': 'share-001'}
+        mock_notification.created_at = '2024-01-15T10:30:00Z'
+        mock_notification.acknowledged_at = None
+        
+        mock_sharing_service.get_pending_notifications = AsyncMock(
+            return_value=[mock_notification]
+        )
+        
+        response = client.get('/api/v1/notifications', params={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['success'] is True
+        assert data['count'] == 1
+        assert len(data['notifications']) == 1
+        assert data['notifications'][0]['id'] == 'notif-001'
+        assert data['notifications'][0]['notification_type'] == 'share_received'
+    
+    def test_list_notifications_empty(self, client, mock_sharing_service):
+        """List notifications returns empty list."""
+        mock_sharing_service.get_pending_notifications = AsyncMock(return_value=[])
+        
+        response = client.get('/api/v1/notifications', params={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['success'] is True
+        assert data['count'] == 0
+        assert data['notifications'] == []
+    
+    def test_list_notifications_multiple(self, client, mock_sharing_service):
+        """List multiple notifications."""
+        mock_notifications = []
+        for i in range(3):
+            n = MagicMock()
+            n.id = f'notif-00{i+1}'
+            n.recipient_did = 'did:vkb:key:z6MkRecipient'
+            n.notification_type = 'share_received'
+            n.payload = {'share_id': f'share-00{i+1}'}
+            n.created_at = f'2024-01-1{5+i}T10:30:00Z'
+            n.acknowledged_at = None
+            mock_notifications.append(n)
+        
+        mock_sharing_service.get_pending_notifications = AsyncMock(
+            return_value=mock_notifications
+        )
+        
+        response = client.get('/api/v1/notifications', params={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['count'] == 3
+        assert len(data['notifications']) == 3
+    
+    def test_list_notifications_missing_recipient_did(self, client, mock_sharing_service):
+        """Missing recipient_did returns 400."""
+        response = client.get('/api/v1/notifications')
+        
+        assert response.status_code == 400
+        data = response.json()
+        assert 'recipient_did' in data['error']
+    
+    def test_list_notifications_service_unavailable(self, client):
+        """Service unavailable returns 503."""
+        set_sharing_service(None)
+        
+        response = client.get('/api/v1/notifications', params={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 503
+    
+    def test_list_notifications_internal_error(self, client, mock_sharing_service):
+        """Internal error returns 500."""
+        mock_sharing_service.get_pending_notifications = AsyncMock(
+            side_effect=Exception("Database error")
+        )
+        
+        response = client.get('/api/v1/notifications', params={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 500
+
+
+# ============================================================================
+# acknowledge_notification_endpoint Tests
+# ============================================================================
+
+class TestAcknowledgeNotificationEndpoint:
+    """Test POST /api/v1/notifications/{id}/acknowledge endpoint."""
+    
+    def test_acknowledge_success(self, client, mock_sharing_service):
+        """Successfully acknowledge a notification."""
+        mock_sharing_service.acknowledge_notification = AsyncMock(return_value=True)
+        
+        response = client.post('/api/v1/notifications/notif-001/acknowledge', json={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['success'] is True
+        assert data['notification_id'] == 'notif-001'
+        assert data['acknowledged'] is True
+    
+    def test_acknowledge_not_found(self, client, mock_sharing_service):
+        """Notification not found returns 404."""
+        mock_sharing_service.acknowledge_notification = AsyncMock(return_value=False)
+        
+        response = client.post('/api/v1/notifications/nonexistent/acknowledge', json={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 404
+    
+    def test_acknowledge_missing_recipient_did(self, client, mock_sharing_service):
+        """Missing recipient_did returns 400."""
+        response = client.post('/api/v1/notifications/notif-001/acknowledge', json={})
+        
+        assert response.status_code == 400
+        data = response.json()
+        assert 'recipient_did' in data['error']
+    
+    def test_acknowledge_invalid_json(self, client, mock_sharing_service):
+        """Invalid JSON returns 400."""
+        response = client.post(
+            '/api/v1/notifications/notif-001/acknowledge',
+            content='not valid json',
+            headers={'Content-Type': 'application/json'},
+        )
+        
+        assert response.status_code == 400
+        data = response.json()
+        assert 'JSON' in data['error']
+    
+    def test_acknowledge_permission_denied(self, client, mock_sharing_service):
+        """Permission denied returns 403."""
+        mock_sharing_service.acknowledge_notification = AsyncMock(
+            side_effect=PermissionError("Not the notification recipient")
+        )
+        
+        response = client.post('/api/v1/notifications/notif-001/acknowledge', json={
+            'recipient_did': 'did:vkb:key:z6MkWrongRecipient',
+        })
+        
+        assert response.status_code == 403
+    
+    def test_acknowledge_service_unavailable(self, client):
+        """Service unavailable returns 503."""
+        set_sharing_service(None)
+        
+        response = client.post('/api/v1/notifications/notif-001/acknowledge', json={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 503
+    
+    def test_acknowledge_internal_error(self, client, mock_sharing_service):
+        """Internal error returns 500."""
+        mock_sharing_service.acknowledge_notification = AsyncMock(
+            side_effect=Exception("Database error")
+        )
+        
+        response = client.post('/api/v1/notifications/notif-001/acknowledge', json={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 500
+
+
+# ============================================================================
+# _notification_to_dict Helper Tests
+# ============================================================================
+
+class TestNotificationToDict:
+    """Test _notification_to_dict helper function."""
+    
+    def test_notification_to_dict_full(self):
+        """Convert notification with all fields."""
+        notification = MagicMock()
+        notification.id = 'notif-001'
+        notification.recipient_did = 'did:vkb:key:z6MkRecipient'
+        notification.notification_type = 'share_received'
+        notification.payload = {'share_id': 'share-001', 'sharer_name': 'Alice'}
+        notification.created_at = '2024-01-15T10:30:00Z'
+        notification.acknowledged_at = '2024-01-16T08:00:00Z'
+        
+        result = _notification_to_dict(notification)
+        
+        assert result['id'] == 'notif-001'
+        assert result['recipient_did'] == 'did:vkb:key:z6MkRecipient'
+        assert result['notification_type'] == 'share_received'
+        assert result['payload'] == {'share_id': 'share-001', 'sharer_name': 'Alice'}
+        assert result['created_at'] == '2024-01-15T10:30:00Z'
+        assert result['acknowledged_at'] == '2024-01-16T08:00:00Z'
+    
+    def test_notification_to_dict_unacknowledged(self):
+        """Convert unacknowledged notification."""
+        notification = MagicMock()
+        notification.id = 'notif-002'
+        notification.recipient_did = 'did:vkb:key:z6MkRecipient'
+        notification.notification_type = 'share_revoked'
+        notification.payload = {'share_id': 'share-001'}
+        notification.created_at = '2024-01-15T10:30:00Z'
+        notification.acknowledged_at = None
+        
+        result = _notification_to_dict(notification)
+        
+        assert result['id'] == 'notif-002'
+        assert result['notification_type'] == 'share_revoked'
+        assert result['acknowledged_at'] is None
+    
+    def test_notification_to_dict_empty_payload(self):
+        """Convert notification with empty payload."""
+        notification = MagicMock()
+        notification.id = 'notif-003'
+        notification.recipient_did = 'did:vkb:key:z6MkRecipient'
+        notification.notification_type = 'consent_expired'
+        notification.payload = {}
+        notification.created_at = '2024-01-15T10:30:00Z'
+        notification.acknowledged_at = None
+        
+        result = _notification_to_dict(notification)
+        
+        assert result['payload'] == {}
+    
+    def test_notification_to_dict_complex_payload(self):
+        """Convert notification with complex payload."""
+        notification = MagicMock()
+        notification.id = 'notif-004'
+        notification.recipient_did = 'did:vkb:key:z6MkRecipient'
+        notification.notification_type = 'batch_share'
+        notification.payload = {
+            'shares': [
+                {'id': 'share-001', 'belief_id': 'belief-001'},
+                {'id': 'share-002', 'belief_id': 'belief-002'},
+            ],
+            'total': 2,
+            'from_did': 'did:vkb:key:z6MkSharer',
+        }
+        notification.created_at = '2024-01-15T10:30:00Z'
+        notification.acknowledged_at = None
+        
+        result = _notification_to_dict(notification)
+        
+        assert len(result['payload']['shares']) == 2
+        assert result['payload']['total'] == 2
+
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+class TestNotificationIntegration:
+    """Integration tests for notification flow."""
+    
+    def test_list_then_acknowledge_flow(self, client, mock_sharing_service):
+        """Test complete flow: list notifications, then acknowledge one."""
+        # Setup: Create pending notifications
+        mock_notification = MagicMock()
+        mock_notification.id = 'notif-flow-001'
+        mock_notification.recipient_did = 'did:vkb:key:z6MkRecipient'
+        mock_notification.notification_type = 'share_received'
+        mock_notification.payload = {'share_id': 'share-001'}
+        mock_notification.created_at = '2024-01-15T10:30:00Z'
+        mock_notification.acknowledged_at = None
+        
+        mock_sharing_service.get_pending_notifications = AsyncMock(
+            return_value=[mock_notification]
+        )
+        mock_sharing_service.acknowledge_notification = AsyncMock(return_value=True)
+        
+        # Step 1: List notifications
+        list_response = client.get('/api/v1/notifications', params={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert list_response.status_code == 200
+        notifications = list_response.json()['notifications']
+        assert len(notifications) == 1
+        notification_id = notifications[0]['id']
+        
+        # Step 2: Acknowledge the notification
+        ack_response = client.post(
+            f'/api/v1/notifications/{notification_id}/acknowledge',
+            json={'recipient_did': 'did:vkb:key:z6MkRecipient'},
+        )
+        
+        assert ack_response.status_code == 200
+        assert ack_response.json()['acknowledged'] is True
+        
+        # Verify acknowledge was called with correct args
+        mock_sharing_service.acknowledge_notification.assert_called_once_with(
+            'notif-flow-001',
+            'did:vkb:key:z6MkRecipient',
+        )
+    
+    def test_different_notification_types(self, client, mock_sharing_service):
+        """Test different notification types are returned correctly."""
+        notification_types = [
+            ('share_received', {'share_id': 's1'}),
+            ('share_revoked', {'share_id': 's2', 'reason': 'Privacy'}),
+            ('consent_expired', {'chain_id': 'c1'}),
+            ('access_requested', {'requester_did': 'did:x'}),
+        ]
+        
+        mock_notifications = []
+        for i, (ntype, payload) in enumerate(notification_types):
+            n = MagicMock()
+            n.id = f'notif-type-{i}'
+            n.recipient_did = 'did:vkb:key:z6MkRecipient'
+            n.notification_type = ntype
+            n.payload = payload
+            n.created_at = '2024-01-15T10:30:00Z'
+            n.acknowledged_at = None
+            mock_notifications.append(n)
+        
+        mock_sharing_service.get_pending_notifications = AsyncMock(
+            return_value=mock_notifications
+        )
+        
+        response = client.get('/api/v1/notifications', params={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['count'] == 4
+        
+        # Verify each type is present
+        types_returned = {n['notification_type'] for n in data['notifications']}
+        expected_types = {'share_received', 'share_revoked', 'consent_expired', 'access_requested'}
+        assert types_returned == expected_types

--- a/tests/server/test_sharing_endpoints.py
+++ b/tests/server/test_sharing_endpoints.py
@@ -1,0 +1,518 @@
+"""Tests for Sharing API endpoints (server/sharing_endpoints.py).
+
+Tests cover:
+1. share_belief_endpoint - POST /api/v1/share
+2. list_shares_endpoint - GET /api/v1/shares
+3. get_share_endpoint - GET /api/v1/shares/{id}
+4. revoke_share_endpoint - POST /api/v1/shares/{id}/revoke
+5. Error handling (missing fields, invalid JSON, service unavailable)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.requests import Request
+from starlette.testclient import TestClient
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+from valence.server.sharing_endpoints import (
+    share_belief_endpoint,
+    list_shares_endpoint,
+    get_share_endpoint,
+    revoke_share_endpoint,
+    get_sharing_service,
+    set_sharing_service,
+    _share_to_dict,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+@pytest.fixture
+def mock_sharing_service():
+    """Create a mock sharing service."""
+    service = MagicMock()
+    service.identity = MagicMock()
+    service.identity.get_did.return_value = 'did:vkb:key:z6MkSharer'
+    return service
+
+
+@pytest.fixture
+def app(mock_sharing_service):
+    """Create a test Starlette app with sharing endpoints."""
+    routes = [
+        Route('/api/v1/share', share_belief_endpoint, methods=['POST']),
+        Route('/api/v1/shares', list_shares_endpoint, methods=['GET']),
+        Route('/api/v1/shares/{id}', get_share_endpoint, methods=['GET']),
+        Route('/api/v1/shares/{id}/revoke', revoke_share_endpoint, methods=['POST']),
+    ]
+    
+    set_sharing_service(mock_sharing_service)
+    return Starlette(routes=routes)
+
+
+@pytest.fixture
+def client(app):
+    """Create a test client."""
+    return TestClient(app)
+
+
+# ============================================================================
+# Service Management Tests
+# ============================================================================
+
+class TestServiceManagement:
+    """Test sharing service get/set functions."""
+    
+    def test_set_and_get_service(self):
+        """Set and get sharing service."""
+        # Clear any existing service
+        set_sharing_service(None)
+        assert get_sharing_service() is None
+        
+        mock_service = MagicMock()
+        set_sharing_service(mock_service)
+        
+        assert get_sharing_service() == mock_service
+        
+        # Clean up
+        set_sharing_service(None)
+
+
+# ============================================================================
+# share_belief_endpoint Tests
+# ============================================================================
+
+class TestShareBeliefEndpoint:
+    """Test POST /api/v1/share endpoint."""
+    
+    def test_share_success(self, client, mock_sharing_service):
+        """Successfully share a belief."""
+        mock_result = MagicMock()
+        mock_result.share_id = 'share-001'
+        mock_result.consent_chain_id = 'chain-001'
+        mock_result.encrypted_for = 'did:vkb:key:z6MkRecipient'
+        mock_result.created_at = '2024-01-15T10:30:00Z'
+        
+        mock_sharing_service.share = AsyncMock(return_value=mock_result)
+        
+        response = client.post('/api/v1/share', json={
+            'belief_id': 'belief-001',
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['success'] is True
+        assert data['share_id'] == 'share-001'
+        assert data['consent_chain_id'] == 'chain-001'
+    
+    def test_share_with_policy(self, client, mock_sharing_service):
+        """Share with explicit policy."""
+        mock_result = MagicMock()
+        mock_result.share_id = 'share-002'
+        mock_result.consent_chain_id = 'chain-002'
+        mock_result.encrypted_for = 'did:vkb:key:z6MkRecipient'
+        mock_result.created_at = '2024-01-15T10:30:00Z'
+        
+        mock_sharing_service.share = AsyncMock(return_value=mock_result)
+        
+        response = client.post('/api/v1/share', json={
+            'belief_id': 'belief-002',
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+            'policy': {
+                'level': 'direct',
+                'enforcement': 'cryptographic',
+            },
+        })
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data['success'] is True
+    
+    def test_share_missing_belief_id(self, client, mock_sharing_service):
+        """Missing belief_id returns 400."""
+        response = client.post('/api/v1/share', json={
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 400
+        data = response.json()
+        assert 'belief_id' in data['error']
+    
+    def test_share_missing_recipient_did(self, client, mock_sharing_service):
+        """Missing recipient_did returns 400."""
+        response = client.post('/api/v1/share', json={
+            'belief_id': 'belief-001',
+        })
+        
+        assert response.status_code == 400
+        data = response.json()
+        assert 'recipient_did' in data['error']
+    
+    def test_share_invalid_json(self, client, mock_sharing_service):
+        """Invalid JSON returns 400."""
+        response = client.post(
+            '/api/v1/share',
+            content='not valid json',
+            headers={'Content-Type': 'application/json'},
+        )
+        
+        assert response.status_code == 400
+        data = response.json()
+        assert 'JSON' in data['error']
+    
+    def test_share_invalid_policy(self, client, mock_sharing_service):
+        """Invalid policy returns 400."""
+        # Mock SharePolicy.from_dict to raise
+        with patch('valence.server.sharing_endpoints.SharePolicy') as mock_policy:
+            mock_policy.from_dict.side_effect = ValueError("Invalid level")
+            
+            response = client.post('/api/v1/share', json={
+                'belief_id': 'belief-001',
+                'recipient_did': 'did:vkb:key:z6MkRecipient',
+                'policy': {'level': 'invalid'},
+            })
+        
+        assert response.status_code == 400
+        data = response.json()
+        assert 'policy' in data['error'].lower()
+    
+    def test_share_service_unavailable(self, client):
+        """Service unavailable returns 503."""
+        set_sharing_service(None)
+        
+        response = client.post('/api/v1/share', json={
+            'belief_id': 'belief-001',
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 503
+    
+    def test_share_validation_error(self, client, mock_sharing_service):
+        """Service validation error returns 400."""
+        mock_sharing_service.share = AsyncMock(
+            side_effect=ValueError("Belief not found")
+        )
+        
+        response = client.post('/api/v1/share', json={
+            'belief_id': 'nonexistent',
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 400
+        data = response.json()
+        assert 'Belief not found' in data['error']
+    
+    def test_share_internal_error(self, client, mock_sharing_service):
+        """Internal error returns 500."""
+        mock_sharing_service.share = AsyncMock(
+            side_effect=Exception("Database error")
+        )
+        
+        response = client.post('/api/v1/share', json={
+            'belief_id': 'belief-001',
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+        })
+        
+        assert response.status_code == 500
+
+
+# ============================================================================
+# list_shares_endpoint Tests
+# ============================================================================
+
+class TestListSharesEndpoint:
+    """Test GET /api/v1/shares endpoint."""
+    
+    def test_list_shares_success(self, client, mock_sharing_service):
+        """Successfully list shares."""
+        mock_share = MagicMock()
+        mock_share.id = 'share-001'
+        mock_share.consent_chain_id = 'chain-001'
+        mock_share.recipient_did = 'did:vkb:key:z6MkRecipient'
+        mock_share.created_at = '2024-01-15T10:30:00Z'
+        mock_share.accessed_at = None
+        
+        mock_sharing_service.list_shares = AsyncMock(return_value=[mock_share])
+        
+        response = client.get('/api/v1/shares')
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['success'] is True
+        assert data['count'] == 1
+        assert len(data['shares']) == 1
+        assert data['shares'][0]['id'] == 'share-001'
+    
+    def test_list_shares_with_filters(self, client, mock_sharing_service):
+        """List shares with query filters."""
+        mock_sharing_service.list_shares = AsyncMock(return_value=[])
+        
+        response = client.get('/api/v1/shares', params={
+            'sharer_did': 'did:vkb:key:z6MkSharer',
+            'recipient_did': 'did:vkb:key:z6MkRecipient',
+            'limit': '50',
+            'revoked': 'true',
+        })
+        
+        assert response.status_code == 200
+        
+        # Verify filters were passed
+        call_kwargs = mock_sharing_service.list_shares.call_args[1]
+        assert call_kwargs['sharer_did'] == 'did:vkb:key:z6MkSharer'
+        assert call_kwargs['recipient_did'] == 'did:vkb:key:z6MkRecipient'
+        assert call_kwargs['limit'] == 50
+        assert call_kwargs['include_revoked'] is True
+    
+    def test_list_shares_limit_capped(self, client, mock_sharing_service):
+        """Limit is capped at 1000."""
+        mock_sharing_service.list_shares = AsyncMock(return_value=[])
+        
+        response = client.get('/api/v1/shares', params={'limit': '5000'})
+        
+        assert response.status_code == 200
+        
+        call_kwargs = mock_sharing_service.list_shares.call_args[1]
+        assert call_kwargs['limit'] == 1000
+    
+    def test_list_shares_invalid_limit(self, client, mock_sharing_service):
+        """Invalid limit defaults to 100."""
+        mock_sharing_service.list_shares = AsyncMock(return_value=[])
+        
+        response = client.get('/api/v1/shares', params={'limit': 'abc'})
+        
+        assert response.status_code == 200
+        
+        call_kwargs = mock_sharing_service.list_shares.call_args[1]
+        assert call_kwargs['limit'] == 100
+    
+    def test_list_shares_service_unavailable(self, client):
+        """Service unavailable returns 503."""
+        set_sharing_service(None)
+        
+        response = client.get('/api/v1/shares')
+        
+        assert response.status_code == 503
+    
+    def test_list_shares_internal_error(self, client, mock_sharing_service):
+        """Internal error returns 500."""
+        mock_sharing_service.list_shares = AsyncMock(
+            side_effect=Exception("Database error")
+        )
+        
+        response = client.get('/api/v1/shares')
+        
+        assert response.status_code == 500
+
+
+# ============================================================================
+# get_share_endpoint Tests
+# ============================================================================
+
+class TestGetShareEndpoint:
+    """Test GET /api/v1/shares/{id} endpoint."""
+    
+    def test_get_share_success(self, client, mock_sharing_service):
+        """Successfully get a share."""
+        mock_share = MagicMock()
+        mock_share.id = 'share-001'
+        mock_share.consent_chain_id = 'chain-001'
+        mock_share.recipient_did = 'did:vkb:key:z6MkRecipient'
+        mock_share.created_at = '2024-01-15T10:30:00Z'
+        mock_share.accessed_at = '2024-01-16T08:00:00Z'
+        
+        mock_sharing_service.get_share = AsyncMock(return_value=mock_share)
+        
+        response = client.get('/api/v1/shares/share-001')
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['success'] is True
+        assert data['share']['id'] == 'share-001'
+    
+    def test_get_share_not_found(self, client, mock_sharing_service):
+        """Share not found returns 404."""
+        mock_sharing_service.get_share = AsyncMock(return_value=None)
+        
+        response = client.get('/api/v1/shares/nonexistent')
+        
+        assert response.status_code == 404
+    
+    def test_get_share_service_unavailable(self, client):
+        """Service unavailable returns 503."""
+        set_sharing_service(None)
+        
+        response = client.get('/api/v1/shares/share-001')
+        
+        assert response.status_code == 503
+    
+    def test_get_share_internal_error(self, client, mock_sharing_service):
+        """Internal error returns 500."""
+        mock_sharing_service.get_share = AsyncMock(
+            side_effect=Exception("Database error")
+        )
+        
+        response = client.get('/api/v1/shares/share-001')
+        
+        assert response.status_code == 500
+
+
+# ============================================================================
+# revoke_share_endpoint Tests
+# ============================================================================
+
+class TestRevokeShareEndpoint:
+    """Test POST /api/v1/shares/{id}/revoke endpoint."""
+    
+    def test_revoke_success(self, client, mock_sharing_service):
+        """Successfully revoke a share."""
+        mock_result = MagicMock()
+        mock_result.share_id = 'share-001'
+        mock_result.consent_chain_id = 'chain-001'
+        mock_result.revoked_at = '2024-01-17T12:00:00Z'
+        mock_result.affected_recipients = ['did:vkb:key:z6MkRecipient']
+        
+        mock_sharing_service.revoke_share = AsyncMock(return_value=mock_result)
+        
+        response = client.post('/api/v1/shares/share-001/revoke', json={})
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data['success'] is True
+        assert data['share_id'] == 'share-001'
+        assert data['revoked_at'] == '2024-01-17T12:00:00Z'
+    
+    def test_revoke_with_reason(self, client, mock_sharing_service):
+        """Revoke with reason."""
+        mock_result = MagicMock()
+        mock_result.share_id = 'share-001'
+        mock_result.consent_chain_id = 'chain-001'
+        mock_result.revoked_at = '2024-01-17T12:00:00Z'
+        mock_result.affected_recipients = []
+        
+        mock_sharing_service.revoke_share = AsyncMock(return_value=mock_result)
+        
+        response = client.post('/api/v1/shares/share-001/revoke', json={
+            'reason': 'Privacy concern',
+        })
+        
+        assert response.status_code == 200
+        
+        # Verify reason was passed
+        call_args = mock_sharing_service.revoke_share.call_args[0]
+        assert call_args[0].reason == 'Privacy concern'
+    
+    def test_revoke_empty_body(self, client, mock_sharing_service):
+        """Revoke with empty body is OK (reason is optional)."""
+        mock_result = MagicMock()
+        mock_result.share_id = 'share-001'
+        mock_result.consent_chain_id = 'chain-001'
+        mock_result.revoked_at = '2024-01-17T12:00:00Z'
+        mock_result.affected_recipients = []
+        
+        mock_sharing_service.revoke_share = AsyncMock(return_value=mock_result)
+        
+        # Send without body
+        response = client.post('/api/v1/shares/share-001/revoke')
+        
+        assert response.status_code == 200
+    
+    def test_revoke_not_found(self, client, mock_sharing_service):
+        """Share not found returns 404."""
+        mock_sharing_service.revoke_share = AsyncMock(
+            side_effect=ValueError("Share not found")
+        )
+        
+        response = client.post('/api/v1/shares/nonexistent/revoke', json={})
+        
+        assert response.status_code == 404
+    
+    def test_revoke_already_revoked(self, client, mock_sharing_service):
+        """Already revoked returns 409."""
+        mock_sharing_service.revoke_share = AsyncMock(
+            side_effect=ValueError("Share already revoked")
+        )
+        
+        response = client.post('/api/v1/shares/share-001/revoke', json={})
+        
+        assert response.status_code == 409
+        data = response.json()
+        assert 'already revoked' in data['error'].lower()
+    
+    def test_revoke_permission_denied(self, client, mock_sharing_service):
+        """Not owner returns 403."""
+        mock_sharing_service.revoke_share = AsyncMock(
+            side_effect=PermissionError("Not the original sharer")
+        )
+        
+        response = client.post('/api/v1/shares/share-001/revoke', json={})
+        
+        assert response.status_code == 403
+    
+    def test_revoke_service_unavailable(self, client):
+        """Service unavailable returns 503."""
+        set_sharing_service(None)
+        
+        response = client.post('/api/v1/shares/share-001/revoke', json={})
+        
+        assert response.status_code == 503
+    
+    def test_revoke_internal_error(self, client, mock_sharing_service):
+        """Internal error returns 500."""
+        mock_sharing_service.revoke_share = AsyncMock(
+            side_effect=Exception("Database error")
+        )
+        
+        response = client.post('/api/v1/shares/share-001/revoke', json={})
+        
+        assert response.status_code == 500
+
+
+# ============================================================================
+# _share_to_dict Helper Tests
+# ============================================================================
+
+class TestShareToDict:
+    """Test _share_to_dict helper function."""
+    
+    def test_share_to_dict_full(self):
+        """Convert share with all fields."""
+        share = MagicMock()
+        share.id = 'share-001'
+        share.consent_chain_id = 'chain-001'
+        share.recipient_did = 'did:vkb:key:z6MkRecipient'
+        share.created_at = '2024-01-15T10:30:00Z'
+        share.accessed_at = '2024-01-16T08:00:00Z'
+        
+        result = _share_to_dict(share)
+        
+        assert result['id'] == 'share-001'
+        assert result['consent_chain_id'] == 'chain-001'
+        assert result['recipient_did'] == 'did:vkb:key:z6MkRecipient'
+        assert result['created_at'] == '2024-01-15T10:30:00Z'
+        assert result['accessed_at'] == '2024-01-16T08:00:00Z'
+    
+    def test_share_to_dict_null_accessed(self):
+        """Convert share with null accessed_at."""
+        share = MagicMock()
+        share.id = 'share-002'
+        share.consent_chain_id = 'chain-002'
+        share.recipient_did = 'did:vkb:key:z6MkRecipient'
+        share.created_at = '2024-01-15T10:30:00Z'
+        share.accessed_at = None
+        
+        result = _share_to_dict(share)
+        
+        assert result['accessed_at'] is None


### PR DESCRIPTION
## Summary
Closes #179

Added comprehensive test suites for previously uncovered/low-coverage modules:

| File | Previous Coverage | Tests Added |
|------|------------------|-------------|
| `cli/router.py` | 0% | Argument parsing, _print_status helper, cmd_status with mocked HTTP |
| `cli/seed.py` | 0% | Argument parsing, get_config_from_env, cmd_status, cmd_discover |
| `federation/server.py` | 0% | NodeIdentity, LocalBelief dataclasses, FederationNode endpoints, client methods, PII integration |
| `federation/threat_detector.py` | 12% | assess_threat_level signals, apply_threat_response graduated responses |
| `server/sharing_endpoints.py` | 13% | share/list/get/revoke endpoints, error handling |
| `server/notification_endpoints.py` | 19% | list/acknowledge endpoints, _notification_to_dict |

## Test Categories
- **Unit tests**: Pure functions, dataclass serialization
- **Endpoint tests**: Starlette TestClient with mocked services
- **Error handling**: Missing fields, invalid JSON, service unavailable
- **Edge cases**: Boundary conditions, division safety

## Notes
- All tests compile and are syntactically correct
- Tests focus on critical paths and meaningful coverage
- No production code changes