### PR TITLE
fix: read server version from package metadata (closes #203)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "valence"
-version = "0.1.0a1"
+version = "0.2.1"
 description = "Personal knowledge substrate for AI agents - beliefs, conversations, patterns"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/valence/server/config.py
+++ b/src/valence/server/config.py
@@ -3,11 +3,24 @@
 from __future__ import annotations
 
 import secrets
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
 
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def get_package_version() -> str:
+    """Get the package version from installed metadata.
+
+    Returns the version from pyproject.toml when installed,
+    or a dev fallback when running from source without install.
+    """
+    try:
+        return version("valence")
+    except PackageNotFoundError:
+        return "0.0.0-dev"
 
 
 class ServerSettings(BaseSettings):
@@ -95,7 +108,7 @@ class ServerSettings(BaseSettings):
 
     # Server name for MCP
     server_name: str = Field(default="valence", description="MCP server name")
-    server_version: str = Field(default="1.0.0", description="Server version")
+    server_version: str = Field(default_factory=get_package_version, description="Server version")
 
     # Production mode flag (explicit override)
     production: bool = Field(


### PR DESCRIPTION
## Summary
Fixes #203 - Server version was hardcoded to "1.0.0" instead of reading from pyproject.toml.

## Changes
- Add `get_package_version()` function using `importlib.metadata` to read the installed package version
- Falls back to `0.0.0-dev` when running from source without installation
- Update `server_version` field to use `default_factory=get_package_version`
- Bump version in pyproject.toml to `0.2.1`
- Add tests for the new version reading function

## Testing
- Added unit tests for `get_package_version()`
- Tests mock both installed and uninstalled scenarios
- Updated existing test to accept dynamic version