### PR TITLE
fix: warn when auto-generating JWT secret (closes #200)

### DIFF
--- a/src/valence/server/config.py
+++ b/src/valence/server/config.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import secrets
 from pathlib import Path
 from typing import Any
 
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 class ServerSettings(BaseSettings):
@@ -213,6 +216,7 @@ class ServerSettings(BaseSettings):
 
         # For development, generate a random secret if not provided
         if not self.oauth_jwt_secret:
+            logger.warning("Auto-generating JWT secret - tokens will not persist across restarts")
             object.__setattr__(self, "oauth_jwt_secret", secrets.token_hex(32))
 
         return self

--- a/tests/server/test_config_security.py
+++ b/tests/server/test_config_security.py
@@ -150,3 +150,24 @@ class TestJWTSecretRequirement:
                 )
                 # Secret should be generated
                 assert settings.oauth_jwt_secret is not None
+
+    def test_auto_generate_jwt_secret_logs_warning(self, caplog):
+        """Auto-generating JWT secret should log a warning about non-persistence."""
+        import logging
+
+        with patch.dict(os.environ, {}, clear=True):
+            with caplog.at_level(logging.WARNING, logger="valence.server.config"):
+                settings = ServerSettings(
+                    host="127.0.0.1",
+                    oauth_enabled=True,
+                    oauth_jwt_secret=None,
+                )
+
+                # Secret should be generated
+                assert settings.oauth_jwt_secret is not None
+                # Warning should be logged
+                assert any(
+                    "Auto-generating JWT secret" in record.message
+                    and "tokens will not persist" in record.message
+                    for record in caplog.records
+                )


### PR DESCRIPTION
## Summary

Adds a warning log when the JWT secret is auto-generated in development mode, alerting users that tokens will not persist across restarts.

## Changes

- Added `logger.warning()` call before auto-generating JWT secret
- Added test to verify the warning is logged

## Related Issue

Closes #200

## Testing

- `pytest tests/server/test_config_security.py` - all 10 tests pass