### PR TITLE
fix: include token_endpoint_auth_method in OAuth registration response (closes #204)

### DIFF
--- a/src/valence/server/oauth.py
+++ b/src/valence/server/oauth.py
@@ -165,6 +165,7 @@ async def register_client(request: Request) -> JSONResponse:
             "grant_types": client.grant_types,
             "response_types": client.response_types,
             "scope": client.scope,
+            "token_endpoint_auth_method": "none",  # Public clients (RFC 7591)
             "client_id_issued_at": int(client.created_at),
         },
         status_code=201,

--- a/tests/server/test_oauth.py
+++ b/tests/server/test_oauth.py
@@ -231,6 +231,28 @@ class TestClientRegistration:
         assert response.status_code == 201
         assert response.json()["scope"] == "mcp:tools"
 
+    def test_register_client_includes_token_endpoint_auth_method(self, client):
+        """Test registration response includes token_endpoint_auth_method.
+        
+        Per RFC 7591 Section 3.2.1, the registration response SHOULD include
+        token_endpoint_auth_method. For public clients, this should be "none".
+        
+        See GitHub issue #204.
+        """
+        response = client.post(
+            f"{API_V1}/oauth/register",
+            json={
+                "redirect_uris": ["http://localhost:3000/callback"],
+                "client_name": "Test App",
+            },
+        )
+        
+        assert response.status_code == 201
+        data = response.json()
+        
+        assert "token_endpoint_auth_method" in data
+        assert data["token_endpoint_auth_method"] == "none"
+
 
 # ============================================================================
 # Authorization Endpoint Tests


### PR DESCRIPTION
## Summary
Per RFC 7591 Section 3.2.1, the dynamic client registration response SHOULD include `token_endpoint_auth_method`. For public clients (which is what Valence supports), this should be `"none"`.

## Changes
- Added `token_endpoint_auth_method: "none"` to the registration response in `register_client()`
- Added test `test_register_client_includes_token_endpoint_auth_method` to verify the field is present

## References
- RFC 7591: https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1
- Closes #204