### PR TITLE
fix: Remove skip markers from passing velocity tests

### DIFF
--- a/tests/federation/test_ring_coefficient.py
+++ b/tests/federation/test_ring_coefficient.py
@@ -221,7 +221,6 @@ class TestRingDetector:
 class TestTrustVelocityAnalyzer:
     """Tests for TrustVelocityAnalyzer class."""
 
-    @pytest.mark.skip(reason="TODO: Investigate velocity calculation - falsely flagging normal velocity as anomalous")
     def test_record_and_analyze_normal_velocity(self, node_ids):
         """Test normal trust velocity is not flagged."""
         analyzer = TrustVelocityAnalyzer()
@@ -295,7 +294,6 @@ class TestTrustVelocityAnalyzer:
         # Current velocity should be based only on recent change
         assert result.current_velocity < 0.1
 
-    @pytest.mark.skip(reason="TODO: Investigate velocity calculation - related to test_record_and_analyze_normal_velocity")
     def test_get_all_anomalies(self, node_ids):
         """Test getting all anomalous nodes."""
         analyzer = TrustVelocityAnalyzer(max_normal_velocity=0.05)


### PR DESCRIPTION
Closes #228

## Summary
Removes the skip markers from two tests in `test_ring_coefficient.py` that were previously flagged as falsely detecting anomalous velocity for normal behavior.

## Investigation
Traced through the velocity calculation and verified:
- `test_record_and_analyze_normal_velocity`: Records 10 changes of 0.01 over 10 days
  - Current velocity calculation: `0.07 / 6 = 0.0117` (7 changes in 7-day window)
  - MAX_NORMAL_VELOCITY = 0.1
  - Result: NOT anomalous ✓
  
- `test_get_all_anomalies`: Correctly distinguishes between:
  - Normal node (bob): small changes → not flagged
  - Anomalous node (alice): large changes → flagged ✓

## Testing
```
pytest tests/federation/test_ring_coefficient.py -v
# 39 passed
```

The underlying algorithm was likely fixed in a previous PR, but the skip markers were never removed.