### PR TITLE
fix(federation): prevent TOCTOU race and add unique constraints

### DIFF
--- a/src/valence/substrate/migrations/003_federation_unique_constraints.sql
+++ b/src/valence/substrate/migrations/003_federation_unique_constraints.sql
@@ -1,0 +1,15 @@
+-- Migration 003: Add unique constraints for federation IDs
+-- Fixes: #235 (TOCTOU race), #237 (missing unique constraint on belief_provenance.federation_id)
+BEGIN;
+
+-- Add unique constraint on beliefs.federation_id (where not null)
+-- This enables ON CONFLICT handling for atomic upserts
+CREATE UNIQUE INDEX IF NOT EXISTS idx_beliefs_federation_unique
+ON beliefs(federation_id) WHERE federation_id IS NOT NULL;
+
+-- Add unique constraint on belief_provenance.federation_id
+-- Ensures each federated belief has exactly one provenance record
+CREATE UNIQUE INDEX IF NOT EXISTS idx_belief_provenance_federation_unique
+ON belief_provenance(federation_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary
Fixes #235 - TOCTOU race in `_process_incoming_belief`
Fixes #237 - missing UNIQUE constraint on `belief_provenance.federation_id`

## Problem
The original code had a Time-Of-Check Time-Of-Use (TOCTOU) race condition:
1. Check if belief exists (line 576)
2. ...do other work...
3. Insert belief (line 661)

Between steps 1 and 3, another concurrent request could insert the same belief, causing either:
- Duplicate beliefs with the same `federation_id`
- A unique constraint violation (if the constraint existed)

Additionally, `belief_provenance.federation_id` lacked a UNIQUE constraint entirely (#237).

## Solution
1. **Migration 003**: Add unique partial index on `beliefs.federation_id` (WHERE NOT NULL) and unique index on `belief_provenance.federation_id`

2. **Atomic INSERT**: Replace early existence check with `ON CONFLICT DO NOTHING`:
   - INSERT returns the new row's id if successful
   - INSERT returns nothing if `federation_id` already exists
   - Check RETURNING result to detect duplicates

3. **Defensive provenance INSERT**: Added `ON CONFLICT DO NOTHING` to provenance insert as well

## Testing
- All existing tests pass (`./scripts/check`)
- Migration is idempotent (`IF NOT EXISTS`)

## Breaking Changes
None - existing functionality preserved, just made race-safe.