### PR TITLE
docs: add migration policy and versioning rules

### DIFF
--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -1,0 +1,116 @@
+# Database Migrations
+
+## Structure
+
+```
+src/valence/substrate/
+├── schema.sql              # Complete schema for fresh installs
+├── procedures.sql          # Stored procedures
+└── migrations/
+    └── NNN_description.sql # Incremental migrations
+```
+
+## Fresh Install vs Upgrade
+
+**Fresh install:** Apply `schema.sql` + `procedures.sql` only.
+
+**Upgrade:** Apply migrations in order since last version.
+
+## Migration Best Practices
+
+### During Development
+
+1. Create numbered migrations: `migrations/NNN_description.sql`
+2. Make migrations **idempotent** where possible (`IF NOT EXISTS`, `IF EXISTS`)
+3. Never modify existing migrations — create new ones
+4. Test both fresh install and upgrade paths
+
+### At Release Time
+
+**Squash migrations into schema.sql:**
+
+1. Apply all migrations to a fresh DB
+2. Dump the schema: `pg_dump --schema-only`
+3. Replace `schema.sql` with the dump
+4. Archive old migrations to `migrations/archive/vX.Y.Z/`
+5. Start fresh with new migrations for next cycle
+
+This ensures:
+- `schema.sql` is always the complete, current schema
+- Fresh installs don't run 50+ migrations
+- Upgrade path is clear (apply migrations since your version)
+
+### Migration Naming
+
+```
+NNN_short_description.sql
+
+Examples:
+001_add_federation.sql
+002_add_sharing.sql
+003_add_unique_constraints.sql
+```
+
+After release, reset to `001_*` for the next development cycle.
+
+## Schema Changes and Versioning
+
+| Change Type | Version Bump | Example |
+|-------------|--------------|---------|
+| New table/column (additive) | MINOR | Add `audit_logs` table |
+| New index | PATCH | Add index for performance |
+| Drop/rename column | MAJOR | Rename `user_id` to `actor_id` |
+| Drop table | MAJOR | Remove deprecated table |
+| Change column type | MAJOR | `VARCHAR` → `UUID` |
+
+**Rule:** If existing data or queries would break, it's a MAJOR bump.
+
+## Running Migrations
+
+```bash
+# Fresh install
+valence db init
+
+# Check migration status
+valence db status
+
+# Apply pending migrations
+valence db migrate
+
+# Rollback (if supported)
+valence db rollback
+```
+
+## Writing Safe Migrations
+
+### DO:
+```sql
+-- Idempotent creation
+CREATE TABLE IF NOT EXISTS new_table (...);
+CREATE INDEX IF NOT EXISTS idx_name ON table(column);
+ALTER TABLE t ADD COLUMN IF NOT EXISTS new_col TYPE;
+
+-- Wrap in transaction
+BEGIN;
+-- changes
+COMMIT;
+```
+
+### DON'T:
+```sql
+-- Non-idempotent (fails if exists)
+CREATE TABLE new_table (...);
+
+-- Data loss risk without backup
+DROP TABLE important_data;
+ALTER TABLE t DROP COLUMN used_column;
+```
+
+## Pre-Release Checklist
+
+- [ ] All migrations tested on fresh DB
+- [ ] All migrations tested on previous version DB
+- [ ] `schema.sql` updated with squashed migrations
+- [ ] Old migrations archived
+- [ ] Version bumped appropriately (MAJOR/MINOR/PATCH)
+- [ ] CHANGELOG updated with schema changes

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -2,6 +2,33 @@
 
 This document defines the required steps before any Valence release.
 
+## Versioning Policy
+
+Valence follows [Semantic Versioning](https://semver.org/):
+
+| Change Type | Version Bump | Examples |
+|-------------|--------------|----------|
+| Breaking API/schema changes | **MAJOR** | Drop column, rename endpoint, remove feature |
+| New features, additive schema | **MINOR** | New table, new endpoint, new optional field |
+| Bug fixes, docs, no API changes | **PATCH** | Fix bug, update docs, performance improvement |
+
+**Schema changes:**
+- Additive (new table/column) → MINOR
+- Breaking (drop/rename/retype) → MAJOR
+- Index-only changes → PATCH
+
+## Schema & Migration Handling
+
+See [MIGRATIONS.md](./MIGRATIONS.md) for detailed guidance.
+
+**At each release:**
+1. [ ] Squash all migrations into `schema.sql`
+2. [ ] Archive old migrations to `migrations/archive/vX.Y.Z/`
+3. [ ] Reset migration numbering for next cycle
+4. [ ] Test fresh install with new `schema.sql`
+5. [ ] Test upgrade path with archived migrations
+6. [ ] Document schema changes in CHANGELOG
+
 ## Pre-Release Audit Requirements
 
 All releases MUST complete the following audits:


### PR DESCRIPTION
## Summary
Documents migration best practices and versioning policy.

## Changes
- **New `docs/MIGRATIONS.md`**:
  - Fresh install vs upgrade paths
  - Squash migrations at each release
  - Schema change → version bump mapping
  - Safe migration patterns (idempotent, transactional)
  
- **Updated `docs/RELEASE-CHECKLIST.md`**:
  - Versioning policy (semver rules)
  - Schema/migration pre-release checklist

## Policy Summary
| Change Type | Version Bump |
|-------------|--------------|
| Breaking schema/API | MAJOR |
| Additive schema/features | MINOR |
| Bug fixes, docs | PATCH |

Migrations squashed into `schema.sql` at each release.