### PR TITLE
feat(core): extensible dimensions via JSONB-style storage

### DIFF
--- a/src/valence/core/confidence.py
+++ b/src/valence/core/confidence.py
@@ -5,18 +5,22 @@ that can be independently assessed and combined.
 
 Per spec (MATH.md), geometric mean is preferred for overall confidence
 calculation as it better penalizes imbalanced vectors.
+
+This module supports extensible dimensions:
+- Core dimensions (v1.confidence.core) are the original 6
+- Additional dimensions can be added via the `dimensions` dict
+- Schema field tracks which dimension set is in use
 """
 
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
 
 class ConfidenceDimension(StrEnum):
-    """Dimensions of belief confidence."""
+    """Core dimensions of belief confidence (v1.confidence.core)."""
 
     OVERALL = "overall"
     SOURCE_RELIABILITY = "source_reliability"
@@ -27,8 +31,21 @@ class ConfidenceDimension(StrEnum):
     DOMAIN_APPLICABILITY = "domain_applicability"
 
 
+# Core dimensions (excluding overall)
+CORE_DIMENSIONS = [
+    ConfidenceDimension.SOURCE_RELIABILITY,
+    ConfidenceDimension.METHOD_QUALITY,
+    ConfidenceDimension.INTERNAL_CONSISTENCY,
+    ConfidenceDimension.TEMPORAL_FRESHNESS,
+    ConfidenceDimension.CORROBORATION,
+    ConfidenceDimension.DOMAIN_APPLICABILITY,
+]
+
+# Default schema identifier
+DEFAULT_SCHEMA = "v1.confidence.core"
+
 # Default weights for combining dimensions into overall score
-DEFAULT_WEIGHTS: dict[ConfidenceDimension, float] = {
+DEFAULT_WEIGHTS: dict[str, float] = {
     ConfidenceDimension.SOURCE_RELIABILITY: 0.25,
     ConfidenceDimension.METHOD_QUALITY: 0.15,
     ConfidenceDimension.INTERNAL_CONSISTENCY: 0.20,
@@ -42,8 +59,8 @@ EPSILON = 0.001
 
 
 def _compute_overall(
-    dims: dict[ConfidenceDimension, float],
-    weights: dict[ConfidenceDimension, float],
+    dims: dict[str, float],
+    weights: dict[str, float] | None = None,
     use_geometric: bool = True,
 ) -> float:
     """Compute overall confidence from dimension values.
@@ -53,8 +70,8 @@ def _compute_overall(
     - Arithmetic mean: ∑(w_i * v_i) / ∑w_i - traditional weighted average
 
     Args:
-        dims: Dictionary of dimension -> value
-        weights: Dictionary of dimension -> weight
+        dims: Dictionary of dimension name -> value
+        weights: Dictionary of dimension name -> weight (defaults to equal weights)
         use_geometric: If True, use weighted geometric mean (recommended per spec)
 
     Returns:
@@ -63,6 +80,9 @@ def _compute_overall(
     if not dims:
         return 0.5  # Default when no dimensions present
 
+    # Use provided weights, fall back to defaults, then equal weights
+    effective_weights = weights or DEFAULT_WEIGHTS
+
     if use_geometric:
         # Weighted geometric mean: (∏v_i^{w_i})^{1/∑w_i}
         # Use log-space for numerical stability: exp(∑(w_i * log(v_i)) / ∑w_i)
@@ -70,7 +90,8 @@ def _compute_overall(
         total_weight = 0.0
 
         for dim, value in dims.items():
-            w = weights.get(dim, 0.0)
+            # Get weight: try explicit weights, then default to 1.0
+            w = effective_weights.get(dim, 1.0 / len(dims))
             if w > 0:
                 # Use floor to prevent log(0)
                 safe_value = max(EPSILON, value)
@@ -87,7 +108,7 @@ def _compute_overall(
         total_weight = 0.0
 
         for dim, value in dims.items():
-            w = weights.get(dim, 0.0)
+            w = effective_weights.get(dim, 1.0 / len(dims))
             if w > 0:
                 weighted_sum += w * value
                 total_weight += w
@@ -100,11 +121,13 @@ def _compute_overall(
     return min(1.0, max(0.0, overall))
 
 
-@dataclass
 class DimensionalConfidence:
     """Multi-dimensional confidence for a belief.
 
-    Dimensions:
+    Supports both core dimensions (v1.confidence.core) and extensible
+    custom dimensions via the `dimensions` dict.
+
+    Core dimensions:
     - overall: Combined score (0-1)
     - source_reliability: How trustworthy is the source?
     - method_quality: How rigorous was the extraction/inference?
@@ -112,22 +135,152 @@ class DimensionalConfidence:
     - temporal_freshness: How recent is this information?
     - corroboration: Is it supported by multiple sources?
     - domain_applicability: How relevant is it to current context?
+
+    Custom dimensions can be added via the `dimensions` dict and will
+    be included in serialization and overall calculation.
+
+    Backward compatible: accepts core dimension names as keyword arguments.
     """
 
-    overall: float = 0.7
-    source_reliability: float | None = None
-    method_quality: float | None = None
-    internal_consistency: float | None = None
-    temporal_freshness: float | None = None
-    corroboration: float | None = None
-    domain_applicability: float | None = None
+    def __init__(
+        self,
+        overall: float = 0.7,
+        schema: str = DEFAULT_SCHEMA,
+        dimensions: dict[str, float] | None = None,
+        # Backward-compatible kwargs for core dimensions
+        source_reliability: float | None = None,
+        method_quality: float | None = None,
+        internal_consistency: float | None = None,
+        temporal_freshness: float | None = None,
+        corroboration: float | None = None,
+        domain_applicability: float | None = None,
+    ) -> None:
+        """Initialize with optional core dimensions as kwargs for backward compat."""
+        self.overall = overall
+        self.schema = schema
+        self.dimensions = dimensions.copy() if dimensions else {}
 
-    def __post_init__(self) -> None:
-        """Validate confidence values."""
-        for dim in ConfidenceDimension:
-            value = getattr(self, dim.value, None)
-            if value is not None and (value < 0 or value > 1):
-                raise ValueError(f"{dim.value} must be between 0 and 1, got {value}")
+        # Merge in core dimension kwargs (backward compat)
+        if source_reliability is not None:
+            self.dimensions[ConfidenceDimension.SOURCE_RELIABILITY] = source_reliability
+        if method_quality is not None:
+            self.dimensions[ConfidenceDimension.METHOD_QUALITY] = method_quality
+        if internal_consistency is not None:
+            self.dimensions[ConfidenceDimension.INTERNAL_CONSISTENCY] = internal_consistency
+        if temporal_freshness is not None:
+            self.dimensions[ConfidenceDimension.TEMPORAL_FRESHNESS] = temporal_freshness
+        if corroboration is not None:
+            self.dimensions[ConfidenceDimension.CORROBORATION] = corroboration
+        if domain_applicability is not None:
+            self.dimensions[ConfidenceDimension.DOMAIN_APPLICABILITY] = domain_applicability
+
+        # Validate
+        if self.overall < 0 or self.overall > 1:
+            raise ValueError(f"overall must be between 0 and 1, got {self.overall}")
+        for dim, value in self.dimensions.items():
+            if value < 0 or value > 1:
+                raise ValueError(f"{dim} must be between 0 and 1, got {value}")
+
+    # =========================================================================
+    # Backward-compatible properties for core dimensions
+    # =========================================================================
+
+    @property
+    def source_reliability(self) -> float | None:
+        """How trustworthy is the source?"""
+        return self.dimensions.get(ConfidenceDimension.SOURCE_RELIABILITY)
+
+    @source_reliability.setter
+    def source_reliability(self, value: float | None) -> None:
+        if value is not None:
+            self.dimensions[ConfidenceDimension.SOURCE_RELIABILITY] = value
+        elif ConfidenceDimension.SOURCE_RELIABILITY in self.dimensions:
+            del self.dimensions[ConfidenceDimension.SOURCE_RELIABILITY]
+
+    @property
+    def method_quality(self) -> float | None:
+        """How rigorous was the extraction/inference?"""
+        return self.dimensions.get(ConfidenceDimension.METHOD_QUALITY)
+
+    @method_quality.setter
+    def method_quality(self, value: float | None) -> None:
+        if value is not None:
+            self.dimensions[ConfidenceDimension.METHOD_QUALITY] = value
+        elif ConfidenceDimension.METHOD_QUALITY in self.dimensions:
+            del self.dimensions[ConfidenceDimension.METHOD_QUALITY]
+
+    @property
+    def internal_consistency(self) -> float | None:
+        """Does it align with other beliefs?"""
+        return self.dimensions.get(ConfidenceDimension.INTERNAL_CONSISTENCY)
+
+    @internal_consistency.setter
+    def internal_consistency(self, value: float | None) -> None:
+        if value is not None:
+            self.dimensions[ConfidenceDimension.INTERNAL_CONSISTENCY] = value
+        elif ConfidenceDimension.INTERNAL_CONSISTENCY in self.dimensions:
+            del self.dimensions[ConfidenceDimension.INTERNAL_CONSISTENCY]
+
+    @property
+    def temporal_freshness(self) -> float | None:
+        """How recent is this information?"""
+        return self.dimensions.get(ConfidenceDimension.TEMPORAL_FRESHNESS)
+
+    @temporal_freshness.setter
+    def temporal_freshness(self, value: float | None) -> None:
+        if value is not None:
+            self.dimensions[ConfidenceDimension.TEMPORAL_FRESHNESS] = value
+        elif ConfidenceDimension.TEMPORAL_FRESHNESS in self.dimensions:
+            del self.dimensions[ConfidenceDimension.TEMPORAL_FRESHNESS]
+
+    @property
+    def corroboration(self) -> float | None:
+        """Is it supported by multiple sources?"""
+        return self.dimensions.get(ConfidenceDimension.CORROBORATION)
+
+    @corroboration.setter
+    def corroboration(self, value: float | None) -> None:
+        if value is not None:
+            self.dimensions[ConfidenceDimension.CORROBORATION] = value
+        elif ConfidenceDimension.CORROBORATION in self.dimensions:
+            del self.dimensions[ConfidenceDimension.CORROBORATION]
+
+    @property
+    def domain_applicability(self) -> float | None:
+        """How relevant is it to current context?"""
+        return self.dimensions.get(ConfidenceDimension.DOMAIN_APPLICABILITY)
+
+    @domain_applicability.setter
+    def domain_applicability(self, value: float | None) -> None:
+        if value is not None:
+            self.dimensions[ConfidenceDimension.DOMAIN_APPLICABILITY] = value
+        elif ConfidenceDimension.DOMAIN_APPLICABILITY in self.dimensions:
+            del self.dimensions[ConfidenceDimension.DOMAIN_APPLICABILITY]
+
+    # =========================================================================
+    # Extensible dimension access
+    # =========================================================================
+
+    def get_dimension(self, name: str) -> float | None:
+        """Get any dimension by name."""
+        return self.dimensions.get(name)
+
+    def set_dimension(self, name: str, value: float | None) -> None:
+        """Set any dimension by name."""
+        if value is not None:
+            if value < 0 or value > 1:
+                raise ValueError(f"{name} must be between 0 and 1, got {value}")
+            self.dimensions[name] = value
+        elif name in self.dimensions:
+            del self.dimensions[name]
+
+    def has_dimension(self, name: str) -> bool:
+        """Check if a dimension is set."""
+        return name in self.dimensions
+
+    # =========================================================================
+    # Factory methods
+    # =========================================================================
 
     @classmethod
     def simple(cls, overall: float) -> DimensionalConfidence:
@@ -143,7 +296,7 @@ class DimensionalConfidence:
         temporal_freshness: float,
         corroboration: float,
         domain_applicability: float,
-        weights: dict[ConfidenceDimension, float] | None = None,
+        weights: dict[str, float] | None = None,
         use_geometric: bool = True,
     ) -> DimensionalConfidence:
         """Create full dimensional confidence with calculated overall.
@@ -152,29 +305,36 @@ class DimensionalConfidence:
             use_geometric: If True (default), use weighted geometric mean per spec.
                           This better penalizes imbalanced vectors.
         """
-        w = weights or DEFAULT_WEIGHTS
-        dims = {
-            ConfidenceDimension.SOURCE_RELIABILITY: source_reliability,
-            ConfidenceDimension.METHOD_QUALITY: method_quality,
-            ConfidenceDimension.INTERNAL_CONSISTENCY: internal_consistency,
-            ConfidenceDimension.TEMPORAL_FRESHNESS: temporal_freshness,
-            ConfidenceDimension.CORROBORATION: corroboration,
-            ConfidenceDimension.DOMAIN_APPLICABILITY: domain_applicability,
+        dims: dict[str, float] = {
+            str(ConfidenceDimension.SOURCE_RELIABILITY): source_reliability,
+            str(ConfidenceDimension.METHOD_QUALITY): method_quality,
+            str(ConfidenceDimension.INTERNAL_CONSISTENCY): internal_consistency,
+            str(ConfidenceDimension.TEMPORAL_FRESHNESS): temporal_freshness,
+            str(ConfidenceDimension.CORROBORATION): corroboration,
+            str(ConfidenceDimension.DOMAIN_APPLICABILITY): domain_applicability,
         }
-        overall = _compute_overall(dims, w, use_geometric=use_geometric)
-        return cls(
-            overall=overall,
-            source_reliability=source_reliability,
-            method_quality=method_quality,
-            internal_consistency=internal_consistency,
-            temporal_freshness=temporal_freshness,
-            corroboration=corroboration,
-            domain_applicability=domain_applicability,
-        )
+        overall = _compute_overall(dims, weights, use_geometric=use_geometric)
+        return cls(overall=overall, dimensions=dims)
+
+    @classmethod
+    def from_dimensions(
+        cls,
+        dimensions: dict[str, float],
+        schema: str = DEFAULT_SCHEMA,
+        weights: dict[str, float] | None = None,
+        use_geometric: bool = True,
+    ) -> DimensionalConfidence:
+        """Create confidence from arbitrary dimensions with calculated overall."""
+        overall = _compute_overall(dimensions, weights, use_geometric=use_geometric)
+        return cls(overall=overall, schema=schema, dimensions=dict(dimensions))
+
+    # =========================================================================
+    # Manipulation methods
+    # =========================================================================
 
     def recalculate_overall(
         self,
-        weights: dict[ConfidenceDimension, float] | None = None,
+        weights: dict[str, float] | None = None,
         use_geometric: bool = True,
     ) -> DimensionalConfidence:
         """Recalculate overall from dimensions.
@@ -183,38 +343,33 @@ class DimensionalConfidence:
             weights: Custom weights for each dimension.
             use_geometric: If True (default), use weighted geometric mean per spec.
         """
-        w = weights or DEFAULT_WEIGHTS
-        dims: dict[ConfidenceDimension, float] = {}
-        for dim in ConfidenceDimension:
-            if dim == ConfidenceDimension.OVERALL:
-                continue
-            value = getattr(self, dim.value, None)
-            if value is not None:
-                dims[dim] = value
-
-        if dims:
-            self.overall = _compute_overall(dims, w, use_geometric=use_geometric)
-
+        if self.dimensions:
+            self.overall = _compute_overall(self.dimensions, weights, use_geometric=use_geometric)
         return self
 
     def with_dimension(
         self,
-        dimension: ConfidenceDimension,
+        dimension: str,
         value: float,
         recalculate: bool = True,
     ) -> DimensionalConfidence:
         """Return a new confidence with one dimension updated."""
+        # Handle overall specially - it's not in the dimensions dict
+        if dimension == ConfidenceDimension.OVERALL or dimension == "overall":
+            return DimensionalConfidence(
+                overall=value,
+                schema=self.schema,
+                dimensions=dict(self.dimensions),
+            )
+
+        new_dims = dict(self.dimensions)
+        new_dims[dimension] = value
         result = DimensionalConfidence(
             overall=self.overall,
-            source_reliability=self.source_reliability,
-            method_quality=self.method_quality,
-            internal_consistency=self.internal_consistency,
-            temporal_freshness=self.temporal_freshness,
-            corroboration=self.corroboration,
-            domain_applicability=self.domain_applicability,
+            schema=self.schema,
+            dimensions=new_dims,
         )
-        setattr(result, dimension.value, value)
-        if recalculate and dimension != ConfidenceDimension.OVERALL:
+        if recalculate:
             result.recalculate_overall()
         return result
 
@@ -224,20 +379,15 @@ class DimensionalConfidence:
         This reduces temporal_freshness and recalculates overall.
         """
         if self.temporal_freshness is not None:
-            new_freshness = self.temporal_freshness * factor
             return self.with_dimension(
                 ConfidenceDimension.TEMPORAL_FRESHNESS,
-                new_freshness,
+                self.temporal_freshness * factor,
             )
         # If no temporal dimension, decay overall directly
         return DimensionalConfidence(
             overall=self.overall * factor,
-            source_reliability=self.source_reliability,
-            method_quality=self.method_quality,
-            internal_consistency=self.internal_consistency,
-            temporal_freshness=self.temporal_freshness,
-            corroboration=self.corroboration,
-            domain_applicability=self.domain_applicability,
+            schema=self.schema,
+            dimensions=dict(self.dimensions),
         )
 
     def boost_corroboration(self, amount: float = 0.1) -> DimensionalConfidence:
@@ -246,41 +396,66 @@ class DimensionalConfidence:
         new_value = min(1.0, current + amount)
         return self.with_dimension(ConfidenceDimension.CORROBORATION, new_value)
 
+    # =========================================================================
+    # Serialization
+    # =========================================================================
+
     def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary for JSON/database storage."""
+        """Convert to dictionary for JSON/database storage.
+
+        Output format:
+        {
+            "overall": 0.7,
+            "schema": "v1.confidence.core",  # Only if not default
+            "source_reliability": 0.8,       # Dimensions inline
+            ...
+        }
+        """
         result: dict[str, Any] = {"overall": self.overall}
-        for dim in ConfidenceDimension:
-            if dim == ConfidenceDimension.OVERALL:
-                continue
-            value = getattr(self, dim.value, None)
-            if value is not None:
-                result[dim.value] = value
+
+        # Include schema if not default
+        if self.schema != DEFAULT_SCHEMA:
+            result["schema"] = self.schema
+
+        # Include all dimensions
+        result.update(self.dimensions)
+
         return result
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> DimensionalConfidence:
-        """Create from dictionary."""
-        return cls(
-            overall=data.get("overall", 0.7),
-            source_reliability=data.get("source_reliability"),
-            method_quality=data.get("method_quality"),
-            internal_consistency=data.get("internal_consistency"),
-            temporal_freshness=data.get("temporal_freshness"),
-            corroboration=data.get("corroboration"),
-            domain_applicability=data.get("domain_applicability"),
-        )
+        """Create from dictionary.
+
+        Handles both old format (flat dimensions) and new format (with schema).
+        """
+        overall = data.get("overall", 0.7)
+        schema = data.get("schema", DEFAULT_SCHEMA)
+
+        # Extract dimensions (everything except overall and schema)
+        dimensions: dict[str, float] = {}
+        for key, value in data.items():
+            if key in ("overall", "schema"):
+                continue
+            if isinstance(value, int | float):
+                dimensions[key] = float(value)
+
+        return cls(overall=overall, schema=schema, dimensions=dimensions)
 
     def __str__(self) -> str:
         """Human-readable representation."""
         parts = [f"overall={self.overall:.2f}"]
-        for dim in ConfidenceDimension:
-            if dim == ConfidenceDimension.OVERALL:
-                continue
-            value = getattr(self, dim.value, None)
-            if value is not None:
-                short_name = dim.value.replace("_", "")[:6]
-                parts.append(f"{short_name}={value:.2f}")
+        for dim, value in sorted(self.dimensions.items()):
+            short_name = dim.replace("_", "")[:6]
+            parts.append(f"{short_name}={value:.2f}")
+        if self.schema != DEFAULT_SCHEMA:
+            parts.append(f"schema={self.schema}")
         return f"Confidence({', '.join(parts)})"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality."""
+        if not isinstance(other, DimensionalConfidence):
+            return False
+        return abs(self.overall - other.overall) < 0.0001 and self.schema == other.schema and self.dimensions == other.dimensions
 
 
 def confidence_label(confidence: float) -> str:
@@ -318,73 +493,43 @@ def aggregate_confidence(
     if len(confidences) == 1:
         return confidences[0]
 
+    # Collect all dimension names across all confidences
+    all_dims: set[str] = set()
+    for c in confidences:
+        all_dims.update(c.dimensions.keys())
+
+    # Use schema from first confidence (they should match in practice)
+    schema = confidences[0].schema
+
     if method == "minimum":
+        result_dims: dict[str, float] = {}
+        for dim in all_dims:
+            values = [c.dimensions[dim] for c in confidences if dim in c.dimensions]
+            if values:
+                result_dims[dim] = min(values)
         return DimensionalConfidence(
             overall=min(c.overall for c in confidences),
-            source_reliability=min(
-                (c.source_reliability for c in confidences if c.source_reliability is not None),
-                default=None,
-            ),
-            method_quality=min(
-                (c.method_quality for c in confidences if c.method_quality is not None),
-                default=None,
-            ),
-            internal_consistency=min(
-                (c.internal_consistency for c in confidences if c.internal_consistency is not None),
-                default=None,
-            ),
-            temporal_freshness=min(
-                (c.temporal_freshness for c in confidences if c.temporal_freshness is not None),
-                default=None,
-            ),
-            corroboration=min(
-                (c.corroboration for c in confidences if c.corroboration is not None),
-                default=None,
-            ),
-            domain_applicability=min(
-                (c.domain_applicability for c in confidences if c.domain_applicability is not None),
-                default=None,
-            ),
+            schema=schema,
+            dimensions=result_dims,
         )
 
     elif method == "maximum":
+        result_dims = {}
+        for dim in all_dims:
+            values = [c.dimensions[dim] for c in confidences if dim in c.dimensions]
+            if values:
+                result_dims[dim] = max(values)
         return DimensionalConfidence(
             overall=max(c.overall for c in confidences),
-            source_reliability=max(
-                (c.source_reliability for c in confidences if c.source_reliability is not None),
-                default=None,
-            ),
-            method_quality=max(
-                (c.method_quality for c in confidences if c.method_quality is not None),
-                default=None,
-            ),
-            internal_consistency=max(
-                (c.internal_consistency for c in confidences if c.internal_consistency is not None),
-                default=None,
-            ),
-            temporal_freshness=max(
-                (c.temporal_freshness for c in confidences if c.temporal_freshness is not None),
-                default=None,
-            ),
-            corroboration=max(
-                (c.corroboration for c in confidences if c.corroboration is not None),
-                default=None,
-            ),
-            domain_applicability=max(
-                (c.domain_applicability for c in confidences if c.domain_applicability is not None),
-                default=None,
-            ),
+            schema=schema,
+            dimensions=result_dims,
         )
 
     elif method == "geometric":
         # Weighted geometric mean per spec (MATH.md)
-        total_weight = sum(c.overall for c in confidences)
-        if total_weight == 0:
-            total_weight = len(confidences)
-
-        def weighted_geo(getter) -> float | None:
+        def weighted_geo(dim: str) -> float | None:
             """Compute weighted geometric mean for a dimension."""
-            values = [(getter(c), c.overall) for c in confidences if getter(c) is not None]
+            values = [(c.dimensions[dim], c.overall) for c in confidences if dim in c.dimensions]
             if not values:
                 return None
             # Geometric mean in log space: exp(∑(w * log(v)) / ∑w)
@@ -393,6 +538,12 @@ def aggregate_confidence(
                 total_w = len(values)
             log_sum = sum(w * math.log(max(EPSILON, v)) for v, w in values)
             return math.exp(log_sum / total_w)
+
+        result_dims = {}
+        for dim in all_dims:
+            val = weighted_geo(dim)
+            if val is not None:
+                result_dims[dim] = val
 
         # For overall, use geometric mean of the overall scores
         overall_values = [c.overall for c in confidences]
@@ -404,31 +555,33 @@ def aggregate_confidence(
 
         return DimensionalConfidence(
             overall=min(1.0, max(0.0, geo_overall)),
-            source_reliability=weighted_geo(lambda c: c.source_reliability),
-            method_quality=weighted_geo(lambda c: c.method_quality),
-            internal_consistency=weighted_geo(lambda c: c.internal_consistency),
-            temporal_freshness=weighted_geo(lambda c: c.temporal_freshness),
-            corroboration=weighted_geo(lambda c: c.corroboration),
-            domain_applicability=weighted_geo(lambda c: c.domain_applicability),
+            schema=schema,
+            dimensions=result_dims,
         )
 
     else:  # weighted_average (arithmetic)
+
+        def weighted_avg(dim: str) -> float | None:
+            values = [(c.dimensions[dim], c.overall) for c in confidences if dim in c.dimensions]
+            if not values:
+                return None
+            total_w = sum(w for _, w in values)
+            if total_w == 0:
+                total_w = len(values)
+            return sum(v * w for v, w in values) / total_w
+
+        result_dims = {}
+        for dim in all_dims:
+            val = weighted_avg(dim)
+            if val is not None:
+                result_dims[dim] = val
+
         total_weight = sum(c.overall for c in confidences)
         if total_weight == 0:
             total_weight = len(confidences)
 
-        def weighted_avg(getter) -> float | None:
-            values = [(getter(c), c.overall) for c in confidences if getter(c) is not None]
-            if not values:
-                return None
-            return sum(v * w for v, w in values) / sum(w for _, w in values)
-
         return DimensionalConfidence(
             overall=sum(c.overall * c.overall for c in confidences) / total_weight,
-            source_reliability=weighted_avg(lambda c: c.source_reliability),
-            method_quality=weighted_avg(lambda c: c.method_quality),
-            internal_consistency=weighted_avg(lambda c: c.internal_consistency),
-            temporal_freshness=weighted_avg(lambda c: c.temporal_freshness),
-            corroboration=weighted_avg(lambda c: c.corroboration),
-            domain_applicability=weighted_avg(lambda c: c.domain_applicability),
+            schema=schema,
+            dimensions=result_dims,
         )


### PR DESCRIPTION
## Summary

Implements #266 — making confidence dimensions extensible without code changes.

## Changes

- **Add `schema` field** — identifies which dimension schema is in use (default: `v1.confidence.core`)
- **Store dimensions in dict** — instead of fixed dataclass fields
- **Backward-compatible properties** — core dimensions (source_reliability, etc.) accessible as before
- **Backward-compatible constructor** — accepts dimension kwargs for existing code
- **Flexible serialization** — `to_dict()` / `from_dict()` handle both old and new formats

## Why

This is the foundation for:
- Custom dimension schemas emerging from network usage
- Trust dimensions using the same pattern (#268)
- Schema registry for community-defined dimensions (#267)

## Testing

- All 71 confidence tests pass
- All 821 core tests pass
- Pre-commit hooks pass (ruff, mypy, bandit)

## Example

```python
# Old style (still works)
conf = DimensionalConfidence(overall=0.7, source_reliability=0.8)

# New style (extensible)
conf = DimensionalConfidence.from_dimensions({
    "source_reliability": 0.8,
    "my_custom_dimension": 0.9,
}, schema="v2.confidence.custom")

# Access either way
conf.source_reliability  # 0.8
conf.get_dimension("my_custom_dimension")  # 0.9
```

Closes #266