### PR TITLE
feat(cli): add embeddings backfill command (#258)

### DIFF
--- a/src/valence/cli/commands/__init__.py
+++ b/src/valence/cli/commands/__init__.py
@@ -3,6 +3,7 @@
 from .beliefs import cmd_add, cmd_init, cmd_list, cmd_query
 from .conflicts import cmd_conflicts
 from .discovery import cmd_discover
+from .embeddings import cmd_embeddings
 from .federation import cmd_query_federated
 from .io import cmd_export, cmd_import
 from .migration import cmd_migrate_visibility
@@ -14,6 +15,7 @@ __all__ = [
     "cmd_add",
     "cmd_conflicts",
     "cmd_discover",
+    "cmd_embeddings",
     "cmd_export",
     "cmd_import",
     "cmd_init",

--- a/src/valence/cli/commands/embeddings.py
+++ b/src/valence/cli/commands/embeddings.py
@@ -1,0 +1,176 @@
+"""Embeddings management commands: backfill."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from ..utils import get_db_connection
+
+logger = logging.getLogger(__name__)
+
+VALID_CONTENT_TYPES = ("belief", "exchange", "pattern")
+
+
+def _count_missing_embeddings(cur, content_type: str) -> int:
+    """Count records missing embeddings for a given content type."""
+    if content_type == "belief":
+        cur.execute("SELECT COUNT(*) as count FROM beliefs WHERE embedding IS NULL AND status = 'active'")
+    elif content_type == "exchange":
+        cur.execute("SELECT COUNT(*) as count FROM exchanges WHERE embedding IS NULL")
+    elif content_type == "pattern":
+        cur.execute("SELECT COUNT(*) as count FROM patterns WHERE embedding IS NULL")
+    else:
+        return 0
+    return cur.fetchone()["count"]
+
+
+def _count_all_embeddings(cur, content_type: str) -> int:
+    """Count all records (for --force mode)."""
+    if content_type == "belief":
+        cur.execute("SELECT COUNT(*) as count FROM beliefs WHERE status = 'active'")
+    elif content_type == "exchange":
+        cur.execute("SELECT COUNT(*) as count FROM exchanges")
+    elif content_type == "pattern":
+        cur.execute("SELECT COUNT(*) as count FROM patterns")
+    else:
+        return 0
+    return cur.fetchone()["count"]
+
+
+def cmd_embeddings(args: argparse.Namespace) -> int:
+    """Route embeddings subcommands."""
+    if args.embeddings_command == "backfill":
+        return cmd_embeddings_backfill(args)
+
+    print("❌ Unknown embeddings command. Use 'valence embeddings backfill'.", file=sys.stderr)
+    return 1
+
+
+def cmd_embeddings_backfill(args: argparse.Namespace) -> int:
+    """Backfill missing or outdated embeddings.
+
+    Wraps the backfill_embeddings() service function with CLI niceties:
+    progress output, dry-run mode, content type filtering, and force re-embed.
+    """
+    from ...embeddings.service import backfill_embeddings, embed_content
+
+    batch_size: int = args.batch_size
+    dry_run: bool = args.dry_run
+    force: bool = args.force
+    content_type_filter: str | None = args.content_type
+
+    # Determine which content types to process
+    if content_type_filter:
+        if content_type_filter not in VALID_CONTENT_TYPES:
+            print(
+                f"❌ Invalid content type '{content_type_filter}'. Must be one of: {', '.join(VALID_CONTENT_TYPES)}",
+                file=sys.stderr,
+            )
+            return 1
+        content_types = [content_type_filter]
+    else:
+        content_types = list(VALID_CONTENT_TYPES)
+
+    conn = None
+    cur = None
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor()
+
+        # Gather counts
+        total_to_process = 0
+        type_counts: dict[str, int] = {}
+        for ct in content_types:
+            if force:
+                count = _count_all_embeddings(cur, ct)
+            else:
+                count = _count_missing_embeddings(cur, ct)
+            type_counts[ct] = count
+            total_to_process += count
+
+        # Show summary
+        print("🧠 Embeddings Backfill")
+        print("─" * 40)
+        for ct in content_types:
+            label = "total" if force else "missing"
+            print(f"  {ct:>10}: {type_counts[ct]} {label}")
+        print(f"  {'total':>10}: {total_to_process}")
+        if force:
+            print("  ⚡ Force mode: re-embedding all records")
+        print(f"  📦 Batch size: {batch_size}")
+        print()
+
+        if total_to_process == 0:
+            print("✅ Nothing to backfill — all embeddings are up to date.")
+            return 0
+
+        if dry_run:
+            print("🔍 Dry run — no changes made.")
+            return 0
+
+        # Process each content type
+        grand_total = 0
+        for ct in content_types:
+            if type_counts[ct] == 0:
+                continue
+
+            if force:
+                # Force mode: fetch all records and re-embed them
+                count = _backfill_force(cur, conn, ct, batch_size, embed_content)
+            else:
+                # Normal mode: use the service function
+                count = backfill_embeddings(ct, batch_size=batch_size)
+
+            grand_total += count
+            print(f"  ✅ {ct}: {count} embedded")
+
+        print()
+        print(f"🎉 Backfill complete: {grand_total} embeddings generated.")
+        return 0
+
+    except Exception as e:
+        print(f"❌ Backfill failed: {e}", file=sys.stderr)
+        logger.exception("Backfill error")
+        return 1
+    finally:
+        if cur:
+            cur.close()
+        if conn:
+            conn.close()
+
+
+def _backfill_force(cur, conn, content_type: str, batch_size: int, embed_fn) -> int:
+    """Force re-embed all records of a given content type."""
+    from ...core.exceptions import DatabaseException, EmbeddingException
+
+    if content_type == "belief":
+        cur.execute(
+            "SELECT id, content FROM beliefs WHERE status = 'active' LIMIT %s",
+            (batch_size,),
+        )
+    elif content_type == "exchange":
+        cur.execute(
+            "SELECT id, content FROM exchanges LIMIT %s",
+            (batch_size,),
+        )
+    elif content_type == "pattern":
+        cur.execute(
+            "SELECT id, description as content FROM patterns LIMIT %s",
+            (batch_size,),
+        )
+    else:
+        return 0
+
+    rows = cur.fetchall()
+    count = 0
+
+    for row in rows:
+        try:
+            embed_fn(content_type, str(row["id"]), row["content"])
+            count += 1
+        except (EmbeddingException, DatabaseException) as e:
+            logger.error(f"Failed to embed {content_type} {row['id']}: {e}")
+
+    return count

--- a/src/valence/cli/main.py
+++ b/src/valence/cli/main.py
@@ -23,6 +23,7 @@ from .commands import (
     cmd_add,
     cmd_conflicts,
     cmd_discover,
+    cmd_embeddings,
     cmd_export,
     cmd_import,
     cmd_init,
@@ -52,6 +53,7 @@ __all__ = [
     "cmd_add",
     "cmd_conflicts",
     "cmd_discover",
+    "cmd_embeddings",
     "cmd_export",
     "cmd_import",
     "cmd_init",
@@ -317,6 +319,41 @@ Federation (Week 2):
     )
 
     # ========================================================================
+    # EMBEDDINGS commands
+    # ========================================================================
+
+    embeddings_parser = subparsers.add_parser("embeddings", help="Embedding management")
+    embeddings_subparsers = embeddings_parser.add_subparsers(dest="embeddings_command", required=True)
+
+    # embeddings backfill
+    backfill_parser = embeddings_subparsers.add_parser("backfill", help="Backfill missing or outdated embeddings")
+    backfill_parser.add_argument(
+        "--batch-size",
+        "-b",
+        type=int,
+        default=100,
+        help="Number of records to process per batch (default: 100)",
+    )
+    backfill_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be backfilled without making changes",
+    )
+    backfill_parser.add_argument(
+        "--content-type",
+        "-t",
+        choices=["belief", "exchange", "pattern"],
+        default=None,
+        help="Content type to backfill (default: all)",
+    )
+    backfill_parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Re-embed all records even if embedding exists (for provider migration)",
+    )
+
+    # ========================================================================
     # MIGRATE-VISIBILITY command
     # ========================================================================
 
@@ -345,6 +382,7 @@ def main() -> int:
         "export": cmd_export,
         "import": cmd_import,
         "trust": cmd_trust,
+        "embeddings": cmd_embeddings,
         "migrate-visibility": cmd_migrate_visibility,
     }
 

--- a/tests/cli/test_embeddings_cli.py
+++ b/tests/cli/test_embeddings_cli.py
@@ -1,0 +1,392 @@
+"""Tests for the embeddings CLI commands.
+
+Tests cover:
+1. Argument parsing for `valence embeddings backfill`
+2. Dry-run mode (no mutations, shows counts)
+3. Content-type filtering
+4. Force mode (re-embed all)
+5. Normal backfill (delegates to service)
+6. Error handling
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from valence.cli.main import app, cmd_embeddings
+
+# ============================================================================
+# Argument Parsing
+# ============================================================================
+
+
+class TestEmbeddingsArgParsing:
+    """Test CLI argument parsing for embeddings commands."""
+
+    def test_embeddings_backfill_defaults(self):
+        """Parse embeddings backfill with defaults."""
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill"])
+        assert args.command == "embeddings"
+        assert args.embeddings_command == "backfill"
+        assert args.batch_size == 100
+        assert args.dry_run is False
+        assert args.content_type is None
+        assert args.force is False
+
+    def test_embeddings_backfill_batch_size(self):
+        """Parse --batch-size flag."""
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "--batch-size", "50"])
+        assert args.batch_size == 50
+
+    def test_embeddings_backfill_batch_size_short(self):
+        """Parse -b short flag."""
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "-b", "200"])
+        assert args.batch_size == 200
+
+    def test_embeddings_backfill_dry_run(self):
+        """Parse --dry-run flag."""
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_embeddings_backfill_content_type(self):
+        """Parse --content-type flag."""
+        parser = app()
+        for ct in ("belief", "exchange", "pattern"):
+            args = parser.parse_args(["embeddings", "backfill", "--content-type", ct])
+            assert args.content_type == ct
+
+    def test_embeddings_backfill_content_type_short(self):
+        """Parse -t short flag."""
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "-t", "belief"])
+        assert args.content_type == "belief"
+
+    def test_embeddings_backfill_content_type_invalid(self):
+        """Invalid content type raises error."""
+        parser = app()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["embeddings", "backfill", "--content-type", "invalid"])
+
+    def test_embeddings_backfill_force(self):
+        """Parse --force flag."""
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "--force"])
+        assert args.force is True
+
+    def test_embeddings_backfill_force_short(self):
+        """Parse -f short flag."""
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "-f"])
+        assert args.force is True
+
+    def test_embeddings_backfill_all_flags(self):
+        """Parse all flags together."""
+        parser = app()
+        args = parser.parse_args(
+            [
+                "embeddings",
+                "backfill",
+                "--batch-size",
+                "25",
+                "--dry-run",
+                "--content-type",
+                "belief",
+                "--force",
+            ]
+        )
+        assert args.batch_size == 25
+        assert args.dry_run is True
+        assert args.content_type == "belief"
+        assert args.force is True
+
+    def test_embeddings_requires_subcommand(self):
+        """embeddings without subcommand raises error."""
+        parser = app()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["embeddings"])
+
+
+# ============================================================================
+# Mock Database Fixture
+# ============================================================================
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock database connection and cursor."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value = mock_cur
+    return mock_conn, mock_cur
+
+
+# ============================================================================
+# Dry Run Tests
+# ============================================================================
+
+
+class TestBackfillDryRun:
+    """Test dry-run mode shows counts without mutating."""
+
+    @patch("valence.cli.commands.embeddings.get_db_connection")
+    def test_dry_run_shows_counts(self, mock_get_conn, mock_db, capsys):
+        """Dry run shows missing counts per type."""
+        mock_conn, mock_cur = mock_db
+        mock_get_conn.return_value = mock_conn
+
+        # Return counts for belief, exchange, pattern
+        mock_cur.fetchone.side_effect = [
+            {"count": 10},  # beliefs missing
+            {"count": 5},  # exchanges missing
+            {"count": 3},  # patterns missing
+        ]
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "--dry-run"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Dry run" in captured.out
+        assert "10" in captured.out
+        assert "5" in captured.out
+        assert "3" in captured.out
+        assert "18" in captured.out  # total
+
+    @patch("valence.cli.commands.embeddings.get_db_connection")
+    def test_dry_run_single_type(self, mock_get_conn, mock_db, capsys):
+        """Dry run with --content-type shows only that type."""
+        mock_conn, mock_cur = mock_db
+        mock_get_conn.return_value = mock_conn
+
+        mock_cur.fetchone.side_effect = [
+            {"count": 15},  # beliefs missing
+        ]
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "--dry-run", "-t", "belief"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Dry run" in captured.out
+        assert "15" in captured.out
+
+    @patch("valence.cli.commands.embeddings.get_db_connection")
+    def test_dry_run_nothing_to_backfill(self, mock_get_conn, mock_db, capsys):
+        """Dry run when nothing needs backfilling."""
+        mock_conn, mock_cur = mock_db
+        mock_get_conn.return_value = mock_conn
+
+        mock_cur.fetchone.side_effect = [
+            {"count": 0},
+            {"count": 0},
+            {"count": 0},
+        ]
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "--dry-run"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Nothing to backfill" in captured.out
+
+    @patch("valence.cli.commands.embeddings.get_db_connection")
+    def test_dry_run_force_counts_all(self, mock_get_conn, mock_db, capsys):
+        """Dry run with --force counts all records, not just missing."""
+        mock_conn, mock_cur = mock_db
+        mock_get_conn.return_value = mock_conn
+
+        # Force mode counts all active records
+        mock_cur.fetchone.side_effect = [
+            {"count": 100},  # all beliefs
+            {"count": 50},  # all exchanges
+            {"count": 25},  # all patterns
+        ]
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "--dry-run", "--force"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Dry run" in captured.out
+        assert "Force mode" in captured.out
+        assert "175" in captured.out  # total
+
+
+# ============================================================================
+# Normal Backfill Tests
+# ============================================================================
+
+
+class TestBackfillNormal:
+    """Test normal backfill delegates to service layer."""
+
+    @patch("valence.embeddings.service.backfill_embeddings", return_value=5)
+    @patch("valence.cli.commands.embeddings.get_db_connection")
+    def test_backfill_calls_service(self, mock_get_conn, mock_backfill, mock_db, capsys):
+        """Backfill delegates to backfill_embeddings service."""
+        mock_conn, mock_cur = mock_db
+        mock_get_conn.return_value = mock_conn
+
+        # Counts
+        mock_cur.fetchone.side_effect = [
+            {"count": 5},  # beliefs missing
+        ]
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "-t", "belief"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        mock_backfill.assert_called_once_with("belief", batch_size=100)
+
+    @patch("valence.embeddings.service.backfill_embeddings", side_effect=[3, 2, 1])
+    @patch("valence.cli.commands.embeddings.get_db_connection")
+    def test_backfill_all_types(self, mock_get_conn, mock_backfill, mock_db, capsys):
+        """Backfill processes all types when no filter."""
+        mock_conn, mock_cur = mock_db
+        mock_get_conn.return_value = mock_conn
+
+        mock_cur.fetchone.side_effect = [
+            {"count": 3},
+            {"count": 2},
+            {"count": 1},
+        ]
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        assert mock_backfill.call_count == 3
+        captured = capsys.readouterr()
+        assert "complete" in captured.out.lower()
+
+    @patch("valence.embeddings.service.backfill_embeddings", return_value=10)
+    @patch("valence.cli.commands.embeddings.get_db_connection")
+    def test_backfill_custom_batch_size(self, mock_get_conn, mock_backfill, mock_db, capsys):
+        """Batch size is passed through to service."""
+        mock_conn, mock_cur = mock_db
+        mock_get_conn.return_value = mock_conn
+
+        mock_cur.fetchone.side_effect = [{"count": 10}]
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "-t", "belief", "-b", "25"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        mock_backfill.assert_called_once_with("belief", batch_size=25)
+
+    @patch("valence.cli.commands.embeddings.get_db_connection")
+    def test_backfill_nothing_to_do(self, mock_get_conn, mock_db, capsys):
+        """Backfill exits cleanly when nothing needs embedding."""
+        mock_conn, mock_cur = mock_db
+        mock_get_conn.return_value = mock_conn
+
+        mock_cur.fetchone.side_effect = [
+            {"count": 0},
+            {"count": 0},
+            {"count": 0},
+        ]
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Nothing to backfill" in captured.out
+
+
+# ============================================================================
+# Force Mode Tests
+# ============================================================================
+
+
+class TestBackfillForce:
+    """Test --force mode re-embeds existing records."""
+
+    @patch("valence.embeddings.service.embed_content", return_value={})
+    @patch("valence.cli.commands.embeddings.get_db_connection")
+    def test_force_reembeds_all(self, mock_get_conn, mock_embed, mock_db, capsys):
+        """Force mode fetches and re-embeds all records."""
+        mock_conn, mock_cur = mock_db
+        mock_get_conn.return_value = mock_conn
+
+        belief_id = uuid4()
+
+        # Count query returns total active beliefs
+        mock_cur.fetchone.side_effect = [{"count": 1}]
+        # Fetch records for force re-embed
+        mock_cur.fetchall.return_value = [
+            {"id": belief_id, "content": "Test belief"},
+        ]
+
+        parser = app()
+        args = parser.parse_args(
+            [
+                "embeddings",
+                "backfill",
+                "--force",
+                "-t",
+                "belief",
+            ]
+        )
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        mock_embed.assert_called_once_with("belief", str(belief_id), "Test belief")
+        captured = capsys.readouterr()
+        assert "Force mode" in captured.out
+
+
+# ============================================================================
+# Error Handling Tests
+# ============================================================================
+
+
+class TestBackfillErrors:
+    """Test error handling in backfill."""
+
+    @patch("valence.cli.commands.embeddings.get_db_connection")
+    def test_db_error_returns_nonzero(self, mock_get_conn, capsys):
+        """Database connection failure returns non-zero exit code."""
+        mock_get_conn.side_effect = Exception("Connection refused")
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill"])
+        result = cmd_embeddings(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "failed" in captured.err.lower()
+
+
+# ============================================================================
+# Command Routing
+# ============================================================================
+
+
+class TestEmbeddingsRouting:
+    """Test embeddings command routing."""
+
+    def test_main_dispatches_to_embeddings(self):
+        """main() dispatches 'embeddings' to cmd_embeddings."""
+        from valence.cli.main import main
+
+        with patch("valence.cli.main.cmd_embeddings", return_value=0) as mock_cmd:
+            with patch("sys.argv", ["valence", "embeddings", "backfill", "--dry-run"]):
+                result = main()
+                assert result == 0
+                mock_cmd.assert_called_once()


### PR DESCRIPTION
Closes #258

Adds `valence embeddings backfill` CLI command wrapping the existing backfill_embeddings() service.

**Flags**: --batch-size/-b (100), --dry-run, --content-type/-t (belief/exchange/pattern), --force/-f
**Tests**: 22 tests in tests/cli/test_embeddings_cli.py