### PR TITLE
refactor(cli): modular command registration pattern

### DIFF
--- a/src/valence/cli/commands/__init__.py
+++ b/src/valence/cli/commands/__init__.py
@@ -1,5 +1,25 @@
-"""CLI command modules for Valence."""
+"""CLI command modules for Valence.
 
+Each module exposes a ``register(subparsers)`` function that wires up
+its argparse sub-commands and sets ``parser.set_defaults(func=handler)``.
+"""
+
+from . import (
+    attestations,
+    beliefs,
+    conflicts,
+    discovery,
+    embeddings,
+    identity,
+    io,
+    migration,
+    peers,
+    qos,
+    resources,
+    schema,
+    stats,
+    trust,
+)
 from .attestations import cmd_attestations
 from .beliefs import cmd_add, cmd_init, cmd_list, cmd_query
 from .conflicts import cmd_conflicts
@@ -16,7 +36,26 @@ from .schema import cmd_schema
 from .stats import cmd_stats
 from .trust import cmd_trust
 
+# All command modules with register() functions, in registration order.
+COMMAND_MODULES = [
+    beliefs,
+    conflicts,
+    stats,
+    discovery,
+    peers,
+    io,
+    trust,
+    embeddings,
+    attestations,
+    resources,
+    migration,
+    schema,
+    qos,
+    identity,
+]
+
 __all__ = [
+    "COMMAND_MODULES",
     "cmd_add",
     "cmd_attestations",
     "cmd_conflicts",
@@ -36,9 +75,9 @@ __all__ = [
     "cmd_qos",
     "cmd_query",
     "cmd_query_federated",
-    "register_identity_commands",
     "cmd_resources",
     "cmd_schema",
     "cmd_stats",
     "cmd_trust",
+    "register_identity_commands",
 ]

--- a/src/valence/cli/commands/attestations.py
+++ b/src/valence/cli/commands/attestations.py
@@ -51,6 +51,8 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     trust_parser.add_argument("resource_id", help="Resource UUID")
     trust_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
 
+    att_parser.set_defaults(func=cmd_attestations)
+
 
 def cmd_attestations(args: argparse.Namespace) -> int:
     """Dispatch attestations subcommands."""

--- a/src/valence/cli/commands/conflicts.py
+++ b/src/valence/cli/commands/conflicts.py
@@ -7,6 +7,25 @@ import argparse
 from ..utils import get_db_connection
 
 
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register the conflicts command on the CLI parser."""
+    conflicts_parser = subparsers.add_parser("conflicts", help="Detect contradicting beliefs")
+    conflicts_parser.add_argument(
+        "--threshold",
+        "-t",
+        type=float,
+        default=0.85,
+        help="Similarity threshold for conflict detection",
+    )
+    conflicts_parser.add_argument(
+        "--auto-record",
+        "-r",
+        action="store_true",
+        help="Automatically record detected conflicts as tensions",
+    )
+    conflicts_parser.set_defaults(func=cmd_conflicts)
+
+
 def cmd_conflicts(args: argparse.Namespace) -> int:
     """Detect beliefs that may contradict each other.
 

--- a/src/valence/cli/commands/discovery.py
+++ b/src/valence/cli/commands/discovery.py
@@ -6,6 +6,38 @@ import argparse
 import sys
 
 
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register the discover command on the CLI parser."""
+    discover_parser = subparsers.add_parser("discover", help="Discover network routers via seeds")
+    discover_parser.add_argument(
+        "--seed",
+        "-s",
+        action="append",
+        dest="seeds",
+        help="Custom seed URL (repeatable)",
+    )
+    discover_parser.add_argument(
+        "--count",
+        "-n",
+        type=int,
+        default=5,
+        help="Number of routers to request (default: 5)",
+    )
+    discover_parser.add_argument("--region", "-r", help="Preferred region")
+    discover_parser.add_argument(
+        "--feature",
+        "-f",
+        action="append",
+        dest="features",
+        help="Required feature (repeatable)",
+    )
+    discover_parser.add_argument("--refresh", action="store_true", help="Force refresh (bypass cache)")
+    discover_parser.add_argument("--no-verify", action="store_true", help="Skip router signature verification")
+    discover_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+    discover_parser.add_argument("--stats", action="store_true", help="Show discovery statistics")
+    discover_parser.set_defaults(func=cmd_discover)
+
+
 def cmd_discover(args: argparse.Namespace) -> int:
     """Discover network routers via seed nodes."""
     import asyncio

--- a/src/valence/cli/commands/embeddings.py
+++ b/src/valence/cli/commands/embeddings.py
@@ -13,6 +13,42 @@ logger = logging.getLogger(__name__)
 VALID_CONTENT_TYPES = ("belief", "exchange", "pattern")
 
 
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register embeddings commands on the CLI parser."""
+    embeddings_parser = subparsers.add_parser("embeddings", help="Embedding management")
+    embeddings_subparsers = embeddings_parser.add_subparsers(dest="embeddings_command", required=True)
+
+    # embeddings backfill
+    backfill_parser = embeddings_subparsers.add_parser("backfill", help="Backfill missing or outdated embeddings")
+    backfill_parser.add_argument(
+        "--batch-size",
+        "-b",
+        type=int,
+        default=100,
+        help="Number of records to process per batch (default: 100)",
+    )
+    backfill_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be backfilled without making changes",
+    )
+    backfill_parser.add_argument(
+        "--content-type",
+        "-t",
+        choices=["belief", "exchange", "pattern"],
+        default=None,
+        help="Content type to backfill (default: all)",
+    )
+    backfill_parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Re-embed all records even if embedding exists (for provider migration)",
+    )
+
+    embeddings_parser.set_defaults(func=cmd_embeddings)
+
+
 def _count_missing_embeddings(cur, content_type: str) -> int:
     """Count records missing embeddings for a given content type."""
     if content_type == "belief":

--- a/src/valence/cli/commands/identity.py
+++ b/src/valence/cli/commands/identity.py
@@ -212,7 +212,7 @@ def cmd_identity(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
-def register_identity_commands(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     """Register ``valence identity`` sub-commands on the main CLI parser.
 
     Called from :func:`valence.cli.main.app` to wire up the identity commands.
@@ -248,3 +248,9 @@ def register_identity_commands(subparsers: argparse._SubParsersAction) -> None: 
     revoke_parser.add_argument("did", help="DID to revoke")
     revoke_parser.add_argument("--reason", "-r", help="Reason for revocation")
     revoke_parser.add_argument("--store", help="Path to identity store file")
+
+    identity_parser.set_defaults(func=cmd_identity)
+
+
+# Backward-compatible alias
+register_identity_commands = register

--- a/src/valence/cli/commands/io.py
+++ b/src/valence/cli/commands/io.py
@@ -6,6 +6,30 @@ import argparse
 import json
 
 
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register export and import commands on the CLI parser."""
+    # export
+    export_parser = subparsers.add_parser("export", help="Export beliefs for sharing")
+    export_parser.add_argument("--to", dest="to", help="Recipient DID (for filtering)")
+    export_parser.add_argument("--output", "-o", help="Output file (default: stdout)")
+    export_parser.add_argument("--domain", "-d", action="append", help="Filter by domain")
+    export_parser.add_argument("--min-confidence", type=float, default=0.0, help="Minimum confidence threshold")
+    export_parser.add_argument("--limit", "-n", type=int, default=1000, help="Max beliefs")
+    export_parser.add_argument(
+        "--include-federated",
+        action="store_true",
+        help="Include beliefs received from other peers",
+    )
+    export_parser.set_defaults(func=cmd_export)
+
+    # import
+    import_parser = subparsers.add_parser("import", help="Import beliefs from a peer")
+    import_parser.add_argument("file", help="Import file (JSON) or - for stdin")
+    import_parser.add_argument("--from", dest="source", help="Source peer DID (overrides package)")
+    import_parser.add_argument("--trust", type=float, help="Override trust level (otherwise uses registry)")
+    import_parser.set_defaults(func=cmd_import)
+
+
 def cmd_export(args: argparse.Namespace) -> int:
     """Export beliefs for sharing with a peer."""
     from ...federation.peer_sync import export_beliefs

--- a/src/valence/cli/commands/migration.py
+++ b/src/valence/cli/commands/migration.py
@@ -21,6 +21,43 @@ from ..utils import get_db_connection
 logger = logging.getLogger(__name__)
 
 
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register migrate and migrate-visibility commands on the CLI parser."""
+    # migrate
+    migrate_parser = subparsers.add_parser("migrate", help="Database migration management")
+    migrate_subparsers = migrate_parser.add_subparsers(dest="migrate_command", required=True)
+
+    # migrate up
+    migrate_up = migrate_subparsers.add_parser("up", help="Apply pending migrations")
+    migrate_up.add_argument("--to", help="Apply up to this version (inclusive)")
+    migrate_up.add_argument("--dry-run", action="store_true", help="Show what would be applied")
+
+    # migrate down
+    migrate_down = migrate_subparsers.add_parser("down", help="Rollback migrations")
+    migrate_down.add_argument("--to", help="Rollback to this version (exclusive — it stays applied)")
+    migrate_down.add_argument("--dry-run", action="store_true", help="Show what would be rolled back")
+
+    # migrate status
+    migrate_subparsers.add_parser("status", help="Show migration status")
+
+    # migrate create
+    migrate_create = migrate_subparsers.add_parser("create", help="Scaffold a new migration")
+    migrate_create.add_argument("name", help="Migration name (e.g. add_users_table)")
+
+    # migrate bootstrap
+    migrate_bootstrap = migrate_subparsers.add_parser("bootstrap", help="Bootstrap fresh database")
+    migrate_bootstrap.add_argument("--dry-run", action="store_true", help="Show what would be applied")
+
+    migrate_parser.set_defaults(func=cmd_migrate)
+
+    # migrate-visibility (legacy)
+    mv_parser = subparsers.add_parser(
+        "migrate-visibility",
+        help="Migrate existing beliefs from visibility to SharePolicy",
+    )
+    mv_parser.set_defaults(func=cmd_migrate_visibility)
+
+
 def _get_migrations_dir() -> Path:
     """Resolve the migrations directory (repo root / migrations)."""
     # Walk up from this file to find the repo root

--- a/src/valence/cli/commands/peers.py
+++ b/src/valence/cli/commands/peers.py
@@ -7,6 +7,33 @@ import argparse
 from ..utils import format_age
 
 
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register the peer command on the CLI parser."""
+    peer_parser = subparsers.add_parser("peer", help="Manage trusted peers")
+    peer_subparsers = peer_parser.add_subparsers(dest="peer_command", required=True)
+
+    # peer add
+    peer_add_parser = peer_subparsers.add_parser("add", help="Add or update a trusted peer")
+    peer_add_parser.add_argument("did", help="Peer DID (e.g., did:vkb:web:alice.example.com)")
+    peer_add_parser.add_argument(
+        "--trust",
+        type=float,
+        required=True,
+        help="Trust level 0.0-1.0 (e.g., 0.8 for 80%% trust)",
+    )
+    peer_add_parser.add_argument("--name", help="Human-readable name for this peer")
+    peer_add_parser.add_argument("--notes", help="Notes about this peer")
+
+    # peer list
+    peer_subparsers.add_parser("list", help="List trusted peers")
+
+    # peer remove
+    peer_remove_parser = peer_subparsers.add_parser("remove", help="Remove a peer")
+    peer_remove_parser.add_argument("did", help="Peer DID to remove")
+
+    peer_parser.set_defaults(func=cmd_peer)
+
+
 def cmd_peer_add(args: argparse.Namespace) -> int:
     """Add a trusted peer to the local registry."""
     from ...federation.peer_sync import get_trust_registry

--- a/src/valence/cli/commands/qos.py
+++ b/src/valence/cli/commands/qos.py
@@ -12,6 +12,58 @@ import argparse
 import json
 
 
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register QoS commands on the CLI parser."""
+    qos_parser = subparsers.add_parser("qos", help="Contribution-based QoS management")
+    qos_subparsers = qos_parser.add_subparsers(dest="qos_command", required=True)
+
+    # qos status
+    qos_status_parser = qos_subparsers.add_parser("status", help="Show QoS system status")
+    qos_status_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    # qos score
+    qos_score_parser = qos_subparsers.add_parser("score", help="Show contribution score for a node")
+    qos_score_parser.add_argument("node_id", nargs="?", default=None, help="Node ID (default: self)")
+    qos_score_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+    qos_score_parser.add_argument(
+        "--routing-capacity",
+        type=float,
+        default=None,
+        dest="routing_capacity",
+        help="Set routing_capacity score (0.0-1.0)",
+    )
+    qos_score_parser.add_argument(
+        "--uptime-reliability",
+        type=float,
+        default=None,
+        dest="uptime_reliability",
+        help="Set uptime_reliability score (0.0-1.0)",
+    )
+    qos_score_parser.add_argument(
+        "--belief-quality",
+        type=float,
+        default=None,
+        dest="belief_quality",
+        help="Set belief_quality score (0.0-1.0)",
+    )
+    qos_score_parser.add_argument(
+        "--resource-sharing",
+        type=float,
+        default=None,
+        dest="resource_sharing",
+        help="Set resource_sharing score (0.0-1.0)",
+    )
+    qos_score_parser.add_argument(
+        "--trust-received",
+        type=float,
+        default=None,
+        dest="trust_received",
+        help="Set trust_received score (0.0-1.0)",
+    )
+
+    qos_parser.set_defaults(func=cmd_qos)
+
+
 def cmd_qos_status(args: argparse.Namespace) -> int:
     """Show QoS system status including policy, load, and tier summary."""
     from ...network.qos import QoSPolicy

--- a/src/valence/cli/commands/resources.py
+++ b/src/valence/cli/commands/resources.py
@@ -17,6 +17,47 @@ from pathlib import Path
 from uuid import UUID, uuid4
 
 
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register resources commands on the CLI parser."""
+    resources_parser = subparsers.add_parser("resources", help="Manage shared resources (prompts, configs, patterns)")
+    resources_subparsers = resources_parser.add_subparsers(dest="resources_command", required=True)
+
+    # resources list
+    resources_list_parser = resources_subparsers.add_parser("list", help="List shared resources")
+    resources_list_parser.add_argument(
+        "--type",
+        "-t",
+        choices=["prompt", "config", "pattern"],
+        help="Filter by resource type",
+    )
+    resources_list_parser.add_argument("--limit", "-n", type=int, default=50, help="Max results")
+    resources_list_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    # resources share
+    resources_share_parser = resources_subparsers.add_parser("share", help="Share a resource from a file")
+    resources_share_parser.add_argument("file", help="File to share (or - for stdin)")
+    resources_share_parser.add_argument(
+        "--type",
+        "-t",
+        required=True,
+        choices=["prompt", "config", "pattern"],
+        help="Resource type",
+    )
+    resources_share_parser.add_argument("--name", help="Resource name")
+    resources_share_parser.add_argument("--description", help="Resource description")
+    resources_share_parser.add_argument("--trust", type=float, default=0.5, help="Minimum trust level to access (0.0-1.0)")
+    resources_share_parser.add_argument("--author", help="Author DID (default: did:vkb:local)")
+    resources_share_parser.add_argument("--tag", action="append", help="Tag (repeatable)")
+
+    # resources get
+    resources_get_parser = resources_subparsers.add_parser("get", help="Get a resource by ID")
+    resources_get_parser.add_argument("id", help="Resource UUID")
+    resources_get_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+    resources_get_parser.add_argument("--requester", help="Requester DID (default: did:vkb:local)")
+
+    resources_parser.set_defaults(func=cmd_resources)
+
+
 def cmd_resources(args: argparse.Namespace) -> int:
     """Dispatch resources subcommands."""
     subcmd = getattr(args, "resources_command", None)

--- a/src/valence/cli/commands/schema.py
+++ b/src/valence/cli/commands/schema.py
@@ -13,6 +13,26 @@ import json
 import sys
 
 
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register schema commands on the CLI parser."""
+    schema_parser = subparsers.add_parser("schema", help="Dimension schema management")
+    schema_subparsers = schema_parser.add_subparsers(dest="schema_command", required=True)
+
+    # schema list
+    schema_subparsers.add_parser("list", help="List all registered dimension schemas")
+
+    # schema show
+    schema_show = schema_subparsers.add_parser("show", help="Show details of a dimension schema")
+    schema_show.add_argument("name", help="Schema name (e.g. v1.confidence.core)")
+
+    # schema validate
+    schema_validate = schema_subparsers.add_parser("validate", help="Validate dimensions against a schema")
+    schema_validate.add_argument("name", help="Schema name")
+    schema_validate.add_argument("dimensions_json", metavar="json", help="JSON object of dimension values")
+
+    schema_parser.set_defaults(func=cmd_schema)
+
+
 def cmd_schema(args: argparse.Namespace) -> int:
     """Router for schema sub-commands."""
     handlers = {

--- a/src/valence/cli/commands/stats.py
+++ b/src/valence/cli/commands/stats.py
@@ -10,6 +10,12 @@ from ..utils import get_db_connection
 logger = logging.getLogger(__name__)
 
 
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register the stats command on the CLI parser."""
+    stats_parser = subparsers.add_parser("stats", help="Show database statistics")
+    stats_parser.set_defaults(func=cmd_stats)
+
+
 def cmd_stats(args: argparse.Namespace) -> int:
     """Show database statistics."""
     conn = None

--- a/src/valence/cli/commands/trust.py
+++ b/src/valence/cli/commands/trust.py
@@ -6,6 +6,86 @@ import argparse
 import json
 
 
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register trust commands on the CLI parser."""
+    trust_parser = subparsers.add_parser("trust", help="Trust network management")
+    trust_subparsers = trust_parser.add_subparsers(dest="trust_command", required=True)
+
+    # trust check
+    trust_check_parser = trust_subparsers.add_parser("check", help="Check for trust concentration issues")
+    trust_check_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+    trust_check_parser.add_argument(
+        "--single-threshold",
+        type=float,
+        default=None,
+        help="Custom threshold for single node dominance (default: 30%%)",
+    )
+    trust_check_parser.add_argument(
+        "--top3-threshold",
+        type=float,
+        default=None,
+        help="Custom threshold for top 3 nodes dominance (default: 50%%)",
+    )
+    trust_check_parser.add_argument(
+        "--min-sources",
+        type=int,
+        default=None,
+        help="Minimum trusted sources (default: 3)",
+    )
+
+    # trust watch
+    trust_watch_parser = trust_subparsers.add_parser("watch", help="Watch an entity (see content without reputation boost)")
+    trust_watch_parser.add_argument("entity", help="DID of entity to watch")
+    trust_watch_parser.add_argument("--domain", "-d", help="Optional domain scope")
+
+    # trust unwatch
+    trust_unwatch_parser = trust_subparsers.add_parser("unwatch", help="Remove a watch relationship")
+    trust_unwatch_parser.add_argument("entity", help="DID of entity to unwatch")
+    trust_unwatch_parser.add_argument("--domain", "-d", help="Optional domain scope")
+
+    # trust distrust
+    trust_distrust_parser = trust_subparsers.add_parser("distrust", help="Mark an entity as distrusted (negative reputation)")
+    trust_distrust_parser.add_argument("entity", help="DID of entity to distrust")
+    trust_distrust_parser.add_argument("--domain", "-d", help="Optional domain scope")
+
+    # trust ignore
+    trust_ignore_parser = trust_subparsers.add_parser("ignore", help="Ignore an entity (block content)")
+    trust_ignore_parser.add_argument("entity", help="DID of entity to ignore")
+    trust_ignore_parser.add_argument("--domain", "-d", help="Optional domain scope")
+
+    # trust set (#268)
+    trust_set_parser = trust_subparsers.add_parser(
+        "set",
+        help="Set multi-dimensional epistemic trust on an entity",
+    )
+    trust_set_parser.add_argument("entity", help="Target entity DID")
+    trust_set_parser.add_argument("--source", default=None, help="Source DID (default: self)")
+    trust_set_parser.add_argument("--domain", default=None, help="Domain scope")
+    trust_set_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+    trust_set_parser.add_argument("--conclusions", type=float, default=None, help="Trust in their conclusions (0-1)")
+    trust_set_parser.add_argument("--reasoning", type=float, default=None, help="Trust in their reasoning (0-1)")
+    trust_set_parser.add_argument("--perspective", type=float, default=None, help="Trust in their perspective (0-1)")
+    trust_set_parser.add_argument("--honesty", type=float, default=None, help="Trust in their honesty (0-1)")
+    trust_set_parser.add_argument("--methodology", type=float, default=None, help="Trust in their methodology (0-1)")
+    trust_set_parser.add_argument("--predictive", type=float, default=None, help="Trust in their predictions (0-1)")
+    trust_set_parser.add_argument("--competence", type=float, default=None, help="Core competence score (0-1)")
+    trust_set_parser.add_argument("--integrity", type=float, default=None, help="Core integrity score (0-1)")
+    trust_set_parser.add_argument("--confidentiality", type=float, default=None, help="Core confidentiality score (0-1)")
+    trust_set_parser.add_argument("--judgment", type=float, default=None, help="Core judgment score (0-1)")
+
+    # trust show (#268)
+    trust_show_parser = trust_subparsers.add_parser(
+        "show",
+        help="Show trust dimensions for an entity",
+    )
+    trust_show_parser.add_argument("entity", help="Target entity DID")
+    trust_show_parser.add_argument("--source", default=None, help="Source DID (default: self)")
+    trust_show_parser.add_argument("--domain", default=None, help="Domain scope")
+    trust_show_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    trust_parser.set_defaults(func=cmd_trust)
+
+
 def cmd_trust_set(args: argparse.Namespace) -> int:
     """Set multi-dimensional epistemic trust on an entity (#268).
 

--- a/tests/cli/test_embeddings_cli.py
+++ b/tests/cli/test_embeddings_cli.py
@@ -382,11 +382,10 @@ class TestEmbeddingsRouting:
     """Test embeddings command routing."""
 
     def test_main_dispatches_to_embeddings(self):
-        """main() dispatches 'embeddings' to cmd_embeddings."""
-        from valence.cli.main import main
+        """main() dispatches 'embeddings' to cmd_embeddings via args.func."""
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "--dry-run"])
 
-        with patch("valence.cli.main.cmd_embeddings", return_value=0) as mock_cmd:
-            with patch("sys.argv", ["valence", "embeddings", "backfill", "--dry-run"]):
-                result = main()
-                assert result == 0
-                mock_cmd.assert_called_once()
+        # With modular registration, args.func is set by set_defaults()
+        assert hasattr(args, "func")
+        assert args.func is cmd_embeddings


### PR DESCRIPTION
Each command module now owns its own argparse definitions via a register(subparsers) function, using parser.set_defaults(func=handler) for dispatch.

**Before:** main.py was ~500 lines with all 15 command parsers centralized. Every PR adding CLI commands conflicted on this file.

**After:** main.py is ~114 lines. Each command module registers itself.

**Changes:** 13 files changed, +401/-398 lines (net +3 — pure structural move). All 161 CLI tests pass. Lint clean. No behavior changes.