### PR TITLE
docs: add principles and governance foundation (#273)

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,126 @@
+# Valence Governance
+
+How Valence is governed today, and how that will change as the network grows. This is a transition plan, not a constitution — it will be revised as we learn.
+
+## Guiding Principle
+
+Governance should be as decentralized as the network can sustain. Premature decentralization produces chaos; permanent centralization produces capture. The goal is to move authority outward as the community develops the capacity to hold it.
+
+---
+
+## Phase 1: BDFL (Now)
+
+**Condition:** Early development, small contributor base, rapid iteration needed.
+
+The Valence org (Orobobos) acts as benevolent dictator. This is honest about where we are: a small team making fast decisions.
+
+**What this means:**
+- Core team makes architectural and protocol decisions
+- Community input is welcomed but not binding
+- Roadmap is set by the core team
+- Principles (see `PRINCIPLES.md`) constrain all decisions, including the core team's
+
+**Accountability:**
+- All decisions documented in public (GitHub issues, ADRs, this repo)
+- Principles are already binding — not aspirational
+- The core team can be challenged on principle violations by anyone
+
+**Exit criteria → Phase 2:**
+- 5+ sustained external contributors (code, not just issues)
+- Stable protocol specification (post-v1.0)
+- At least one independent node operator
+
+## Phase 2: Shared Stewardship
+
+**Condition:** Growing contributor base, stable core protocol, multiple stakeholders.
+
+Authority expands from core team to include sustained contributors. Think Apache-style meritocratic governance.
+
+**What this means:**
+- Contributor council with commit/merge authority over their domains
+- Protocol changes require council review (not just core team approval)
+- Core team retains veto on principle violations only
+- Formal ADR (Architecture Decision Record) process for significant changes
+
+**Roles:**
+- **Core maintainers** — original team, shrinking authority over time
+- **Domain stewards** — earned through sustained contribution to specific areas
+- **Community members** — voice in discussions, proposal rights
+
+**Decision process:**
+- Routine changes: maintainer approval
+- Significant changes: ADR + council review
+- Principle-affecting changes: broad community input + supermajority
+
+**Exit criteria → Phase 3:**
+- Multiple independent implementations or deployments
+- Governance disputes successfully resolved through process (not fiat)
+- Community demonstrates capacity for self-governance
+
+## Phase 3: Network Governance
+
+**Condition:** Mature network, multiple independent operators, the system is bigger than any one org.
+
+Governance follows the IETF model: rough consensus and running code. The Valence org becomes one participant among many.
+
+**What this means:**
+- Protocol changes through open RFC process
+- Rough consensus — not unanimity, not majority vote
+- Running code matters — proposals backed by working implementations carry more weight
+- No single entity has veto power (including the original team)
+- Governance of the protocol is separate from governance of individual nodes
+
+**Dispute resolution:**
+- Technical disputes: resolved by evidence and running code
+- Governance disputes: escalation process with rotating mediators
+- Principle violations: community enforcement through trust network (not central authority)
+
+---
+
+## Network Model: One Network, Trust-Gated Visibility
+
+Valence is one network, not a federation of isolated instances. But visibility within that network is controlled by trust relationships.
+
+### Why One Network
+
+Fragmentation defeats the purpose. If beliefs only propagate within isolated clusters, you get echo chambers with extra steps. A single network with permeable boundaries keeps the knowledge substrate connected.
+
+### How Trust Gates Work
+
+- **Public commons** — Beliefs explicitly shared publicly are visible to all network participants. This is the shared substrate: the baseline of common knowledge.
+- **Trust circles** — Beliefs shared within trust relationships are visible only to those relationships. Trust is directional (I can trust you without you trusting me) and domain-specific (I trust your technical judgment, not your music taste).
+- **Node operators** set their own policies for what they host and relay, but cannot see encrypted private beliefs.
+
+### What This Avoids
+
+- **Walled gardens** — No instance admin decides what their users can see from outside
+- **Forced openness** — You're not choosing between "public" and "nothing"
+- **Balkanization** — The network doesn't split along political/social lines into non-communicating shards
+
+### What This Requires
+
+- End-to-end encryption for private beliefs
+- A trust protocol that works across node boundaries
+- Careful design of the public commons (spam resistance, quality signals)
+
+---
+
+## Open Questions
+
+Things we haven't figured out yet. Documenting them honestly is better than pretending we have answers.
+
+1. **How are governance transitions triggered?** The exit criteria above are qualitative, not quantitative. How do we avoid either premature transition or clinging to authority?
+2. **Economic sustainability.** Who pays for infrastructure? How do node operators sustain themselves without creating perverse incentives?
+3. **Legal entity structure.** What legal form supports Phase 3 governance? Foundation? Cooperative? Something new?
+4. **Sybil resistance in governance.** How do we prevent governance capture through fake identities, especially in Phase 3?
+
+---
+
+## Amendments
+
+This document will change. When it does:
+
+- Changes go through the process appropriate to the current phase
+- Rationale is documented
+- Previous versions remain in git history
+- Principle violations require the extraordinary justification described in `PRINCIPLES.md`

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -1,54 +1,76 @@
-# Principles
+# Valence Principles
 
-*The constitution. These constrain what this system can become.*
+These are non-negotiable. They define what Valence is and constrain what it can become. Any proposal that violates these principles requires extraordinary justification and broad consensus to even discuss.
+
+## 1. Privacy by Default
+
+Your beliefs are yours. Period.
+
+- Beliefs are private unless explicitly shared by their owner
+- No bulk surveillance of the belief graph
+- Sharing is granular: you choose what to share, with whom, under what conditions
+- The system must not infer private beliefs from public activity patterns
+- "Default private" means exactly that — not "private unless you forget to toggle a setting"
+
+**Test:** Can a new user add beliefs without any of them being visible to anyone else? If not, the system is broken.
+
+## 2. Reputation from Rigor
+
+Credibility comes from the quality of your reasoning, not the size of your audience.
+
+- Reputation scores reflect accuracy, calibration, and intellectual honesty
+- Popularity, volume, and social proof are not inputs to reputation
+- A single well-sourced, carefully reasoned belief outweighs a thousand confident assertions
+- Reputation is domain-specific — expertise in one area doesn't transfer automatically
+- Gaming reputation (sockpuppets, coordinated amplification) is treated as a system integrity threat
+
+**Test:** Can a new participant with zero followers establish credibility purely through accurate, well-reasoned contributions? If not, the incentives are wrong.
+
+## 3. Exit Rights
+
+You can always leave, and you can take your data with you.
+
+- Full data export in standard, documented formats at any time
+- No lock-in through proprietary data formats or network effects that trap data
+- Leaving does not destroy your contribution history (but you can request anonymization)
+- Third-party tools can build on the export format without permission
+- Exit should be a single action, not a bureaucratic process
+
+**Test:** Can a user export everything, delete their account, and import into a competing system? If not, we've built a roach motel.
+
+## 4. No Central Censor
+
+No single entity — including the Valence org — can unilaterally silence participants or suppress beliefs.
+
+- Content moderation happens through trust networks, not central authority
+- You control your own filters; the system doesn't decide what you can see
+- Disputes are resolved through transparent processes, not executive fiat
+- Even the core team is subject to governance processes, not above them
+- There is a difference between "I don't trust this" and "nobody should see this" — the system supports the former, not the latter
+
+**Test:** Can the Valence org suppress a belief that criticizes Valence? If yes, the architecture is wrong.
+
+## 5. Transparency
+
+The system's behavior must be understandable and auditable.
+
+- Algorithms that affect belief visibility, reputation, or trust are open source
+- Governance decisions are documented with rationale
+- Changes to core systems go through public review
+- Users can understand why they see what they see
+- "Trust us" is never an acceptable answer to "how does this work?"
+
+**Test:** Can an outsider read the code and governance docs and understand how decisions get made? If not, we're not transparent — we're just saying we are.
 
 ---
 
-## User Sovereignty
+## Tensions and Tradeoffs
 
-- **Users own their data.** Full stop. No exceptions, no asterisks.
-- **Your agent represents you.** Representation, not manipulation. The agent's loyalty is to the user, never to the platform or service providers.
-- **Data never leaves user control without explicit, informed consent.** Users decide what is shared, when, and with whom.
+These principles sometimes conflict. Privacy and transparency pull in opposite directions. Exit rights and network integrity can clash. When they do:
 
----
+1. Name the tension explicitly
+2. Prefer the principle that protects individual agency
+3. Document the tradeoff and the reasoning
+4. Revisit as the system evolves
 
-## Collective Emergence
-
-- **Emergence over prescription.** Patterns arise from users, not from design. The system creates conditions; users create outcomes.
-- **Individual value drives adoption.** Collective action is emergent, not demanded. Users don't need to care about changing the world—they just need their lives to be better.
-- **Aggregation exists only to increase value for users.** This is the sole valid purpose. If aggregation doesn't serve users, it doesn't happen.
-
----
-
-## Structural Integrity
-
-- **Structurally incapable of betrayal.** Not promises—architecture. The system cannot be turned against users because the design makes it impossible, not because someone chose not to.
-- **Security through structure, not policy.** Trust is enforced by how things work, not by what we say about how they work.
-- **N integrations, not N!** The agent layer is the universal interface. Users connect to one thing; that thing connects to everything.
-
----
-
-## Openness as Resilience
-
-- **Transparency by default.** The system's workings are visible. Opacity is the exception, not the rule.
-- **Designed to survive being stolen.** If the model propagates and still achieves the goal, that's success. We optimize for the pattern existing in the world, not for capture.
-- **Invites criticism.** If it doesn't stand up to scrutiny, it needs to be better. Defensiveness is a sign of weakness, not strength.
-- **AI-centric from the ground up.** Not retrofitted. Built for what's coming, not what was.
-
----
-
-## Mission Permanence
-
-- **Structure prevents capture.** PBC or equivalent. The entity cannot be sold, pivoted, or hollowed out. The mission is load-bearing.
-- **Principles are constitutional.** They constrain evolution. Changes that violate principles aren't evolution—they're corruption.
-
----
-
-## Principles as Foundation
-
-- **Principles-based at every level.** Design, development, governance, evolution—all derive from principles.
-- **When in doubt, derive from principles.** They are the source of truth. If a decision can't be justified from principles, it's the wrong decision.
-
----
-
-*These principles are not aspirations. They are constraints. Anything that violates them is not this thing, regardless of what it calls itself.*
+Perfection isn't the goal. Honest navigation of hard tradeoffs is.


### PR DESCRIPTION
Add two foundational documents:

- PRINCIPLES.md: Five non-negotiable principles (privacy by default,
  reputation from rigor, exit rights, no central censor, transparency)
  with concrete tests for each.

- GOVERNANCE.md: Three-phase governance transition plan (BDFL → shared
  stewardship → network governance) plus the one-network trust-gated
  visibility model.

Closes #273
