### PR TITLE
feat: contribution-based QoS with dynamic deprioritization curve (#276)

### DIFF
--- a/src/valence/cli/commands/__init__.py
+++ b/src/valence/cli/commands/__init__.py
@@ -8,6 +8,7 @@ from .federation import cmd_query_federated
 from .io import cmd_export, cmd_import
 from .migration import cmd_migrate, cmd_migrate_visibility
 from .peers import cmd_peer, cmd_peer_add, cmd_peer_list, cmd_peer_remove
+from .qos import cmd_qos
 from .resources import cmd_resources
 from .schema import cmd_schema
 from .stats import cmd_stats
@@ -28,6 +29,7 @@ __all__ = [
     "cmd_peer_add",
     "cmd_peer_list",
     "cmd_peer_remove",
+    "cmd_qos",
     "cmd_query",
     "cmd_query_federated",
     "cmd_resources",

--- a/src/valence/cli/commands/qos.py
+++ b/src/valence/cli/commands/qos.py
@@ -1,0 +1,129 @@
+"""QoS management CLI commands.
+
+Provides ``valence qos status`` and ``valence qos score`` subcommands
+for inspecting contribution-based QoS state.
+
+Issue #276: Network: Contribution-based QoS with dynamic curve.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def cmd_qos_status(args: argparse.Namespace) -> int:
+    """Show QoS system status including policy, load, and tier summary."""
+    from ...network.qos import QoSPolicy
+    from ...network.qos_manager import QoSManager
+
+    try:
+        manager = QoSManager(policy=QoSPolicy())
+        status = manager.get_status()
+
+        if getattr(args, "json", False):
+            print(json.dumps(status, indent=2))
+            return 0
+
+        # Human-readable output
+        print("📊 QoS System Status")
+        print("─" * 50)
+
+        print("\n⚙️  Policy:")
+        policy = status["policy"]
+        print(f"   Min service floor:    {policy['min_service_floor']:.1%}")
+        print(f"   Steepness range:      {policy['min_steepness']:.1f} – {policy['max_steepness']:.1f}")
+        print(f"   New user grace:       {policy['new_user_grace_period']:.0f}s")
+        print(
+            f"   Tier thresholds:      high≥{policy['high_tier_threshold']:.0%}  normal≥{policy['normal_tier_threshold']:.0%}  low≥{policy['low_tier_threshold']:.0%}"
+        )
+
+        print("\n📈 Load:")
+        load = status["load"]
+        print(f"   Load factor:          {load['load_factor']:.1%}")
+        print(f"   Connections:          {load['active_connections']}/{load['max_connections']}")
+        print(f"   Avg queue depth:      {load['avg_queue_depth']:.1f}")
+        print(f"   Avg latency:          {load['avg_latency_ms']:.1f}ms")
+        print(f"   Current steepness:    {status['current_steepness']:.2f}")
+
+        print(f"\n🔢 Tracked Nodes: {status['node_count']}")
+        tiers = status["tier_summary"]
+        for tier_name, count in tiers.items():
+            bar = "█" * min(count, 40)
+            print(f"   {tier_name:10s} {count:5d}  {bar}")
+
+        print()
+        return 0
+
+    except Exception as e:
+        print(f"❌ QoS status failed: {e}")
+        return 1
+
+
+def cmd_qos_score(args: argparse.Namespace) -> int:
+    """Show contribution score for a node (or simulated default)."""
+    from ...network.qos import ContributionDimension, ContributionScore, QoSPolicy
+
+    try:
+        node_id = getattr(args, "node_id", None) or "self"
+        score = ContributionScore(node_id=node_id)
+
+        # If dimension values were provided, apply them.
+        for dim in ContributionDimension:
+            val = getattr(args, dim.value, None)
+            if val is not None:
+                score.set_dimension(dim, val)
+
+        policy = QoSPolicy()
+
+        if getattr(args, "json", False):
+            data = score.to_dict()
+            data["tier"] = policy.assign_tier(score.overall).value
+            data["priority_at_load_0"] = round(policy.compute_priority(score.overall, 0.0), 4)
+            data["priority_at_load_50"] = round(policy.compute_priority(score.overall, 0.5), 4)
+            data["priority_at_load_100"] = round(policy.compute_priority(score.overall, 1.0), 4)
+            print(json.dumps(data, indent=2))
+            return 0
+
+        # Human-readable output
+        print(f"📊 Contribution Score: {node_id}")
+        print("─" * 50)
+
+        print("\n📐 Dimensions:")
+        for dim in ContributionDimension:
+            val = score.dimensions.get(dim, 0.0)
+            weight = score.weights.get(dim, 0.0)
+            bar_len = int(val * 20)
+            bar = "█" * bar_len + "░" * (20 - bar_len)
+            print(f"   {dim.value:20s}  {bar}  {val:.2f}  (w={weight:.2f})")
+
+        overall = score.overall
+        tier = policy.assign_tier(overall)
+        print(f"\n   {'Overall':20s}  {'':20s}  {overall:.2f}")
+        print(f"   Tier: {tier.value}")
+
+        print("\n📈 Priority at different loads:")
+        for load_pct in [0, 25, 50, 75, 100]:
+            load = load_pct / 100.0
+            pri = policy.compute_priority(overall, load)
+            steep = policy.compute_steepness(load)
+            print(f"   Load {load_pct:3d}%: priority={pri:.3f}  steepness={steep:.2f}")
+
+        print()
+        return 0
+
+    except Exception as e:
+        print(f"❌ QoS score failed: {e}")
+        return 1
+
+
+def cmd_qos(args: argparse.Namespace) -> int:
+    """Dispatch QoS subcommands."""
+    qos_command = getattr(args, "qos_command", None)
+    if qos_command == "status":
+        return cmd_qos_status(args)
+    elif qos_command == "score":
+        return cmd_qos_score(args)
+    else:
+        print("Usage: valence qos {status|score}")
+        return 1

--- a/src/valence/cli/main.py
+++ b/src/valence/cli/main.py
@@ -34,6 +34,7 @@ from .commands import (
     cmd_peer_add,
     cmd_peer_list,
     cmd_peer_remove,
+    cmd_qos,
     cmd_query,
     cmd_query_federated,
     cmd_resources,
@@ -67,6 +68,7 @@ __all__ = [
     "cmd_peer_add",
     "cmd_peer_list",
     "cmd_peer_remove",
+    "cmd_qos",
     "cmd_query",
     "cmd_query_federated",
     "cmd_resources",
@@ -498,6 +500,57 @@ Federation (Week 2):
     schema_validate.add_argument("json", help="JSON object of dimension values")
 
     # ========================================================================
+    # QOS commands (Issue #276)
+    # ========================================================================
+
+    qos_parser = subparsers.add_parser("qos", help="Contribution-based QoS management")
+    qos_subparsers = qos_parser.add_subparsers(dest="qos_command", required=True)
+
+    # qos status
+    qos_status_parser = qos_subparsers.add_parser("status", help="Show QoS system status")
+    qos_status_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    # qos score
+    qos_score_parser = qos_subparsers.add_parser("score", help="Show contribution score for a node")
+    qos_score_parser.add_argument("node_id", nargs="?", default=None, help="Node ID (default: self)")
+    qos_score_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+    qos_score_parser.add_argument(
+        "--routing-capacity",
+        type=float,
+        default=None,
+        dest="routing_capacity",
+        help="Set routing_capacity score (0.0-1.0)",
+    )
+    qos_score_parser.add_argument(
+        "--uptime-reliability",
+        type=float,
+        default=None,
+        dest="uptime_reliability",
+        help="Set uptime_reliability score (0.0-1.0)",
+    )
+    qos_score_parser.add_argument(
+        "--belief-quality",
+        type=float,
+        default=None,
+        dest="belief_quality",
+        help="Set belief_quality score (0.0-1.0)",
+    )
+    qos_score_parser.add_argument(
+        "--resource-sharing",
+        type=float,
+        default=None,
+        dest="resource_sharing",
+        help="Set resource_sharing score (0.0-1.0)",
+    )
+    qos_score_parser.add_argument(
+        "--trust-received",
+        type=float,
+        default=None,
+        dest="trust_received",
+        help="Set trust_received score (0.0-1.0)",
+    )
+
+    # ========================================================================
     # MIGRATE-VISIBILITY command (legacy)
     # ========================================================================
 
@@ -529,6 +582,7 @@ def main() -> int:
         "embeddings": cmd_embeddings,
         "resources": cmd_resources,
         "schema": cmd_schema,
+        "qos": cmd_qos,
         "migrate": cmd_migrate,
         "migrate-visibility": cmd_migrate_visibility,
     }

--- a/src/valence/network/__init__.py
+++ b/src/valence/network/__init__.py
@@ -85,6 +85,21 @@ from valence.network.node import (
     StateConflictError,
     create_node_client,
 )
+from valence.network.qos import (
+    DEFAULT_DIMENSION_WEIGHTS,
+    MAX_CONTRIBUTION_SCORE,
+    NEW_USER_MINIMUM_SCORE,
+    TIER_WEIGHTS,
+    ContributionDimension,
+    ContributionScore,
+    PriorityTier,
+    QoSPolicy,
+)
+from valence.network.qos_manager import (
+    LoadMetrics,
+    NodeQoSState,
+    QoSManager,
+)
 from valence.network.router import (
     # Circuit state (Issue #115)
     CircuitHopState,
@@ -192,6 +207,18 @@ __all__ = [
     "RouterClientConfig",
     "HealthMonitor",
     "HealthMonitorConfig",
+    # QoS (Issue #276)
+    "ContributionDimension",
+    "ContributionScore",
+    "DEFAULT_DIMENSION_WEIGHTS",
+    "MAX_CONTRIBUTION_SCORE",
+    "NEW_USER_MINIMUM_SCORE",
+    "PriorityTier",
+    "QoSPolicy",
+    "TIER_WEIGHTS",
+    "LoadMetrics",
+    "NodeQoSState",
+    "QoSManager",
     # Traffic Analysis Mitigations (Issue #120)
     "TrafficAnalysisMitigationConfig",
     "PrivacyLevel",

--- a/src/valence/network/qos.py
+++ b/src/valence/network/qos.py
@@ -1,0 +1,245 @@
+"""
+Contribution-based Quality of Service (QoS) for Valence network.
+
+Prioritizes network traffic based on contribution reputation. Nodes that
+contribute more (routing, uptime, belief quality, resource sharing, trust)
+get better access under load.
+
+Issue #276: Network: Contribution-based QoS with dynamic curve.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class ContributionDimension(StrEnum):
+    """Dimensions of node contribution to the network."""
+
+    ROUTING_CAPACITY = "routing_capacity"
+    UPTIME_RELIABILITY = "uptime_reliability"
+    BELIEF_QUALITY = "belief_quality"
+    RESOURCE_SHARING = "resource_sharing"
+    TRUST_RECEIVED = "trust_received"
+
+
+#: Default weights for each contribution dimension (sum to 1.0).
+DEFAULT_DIMENSION_WEIGHTS: dict[ContributionDimension, float] = {
+    ContributionDimension.ROUTING_CAPACITY: 0.25,
+    ContributionDimension.UPTIME_RELIABILITY: 0.20,
+    ContributionDimension.BELIEF_QUALITY: 0.20,
+    ContributionDimension.RESOURCE_SHARING: 0.15,
+    ContributionDimension.TRUST_RECEIVED: 0.20,
+}
+
+#: Minimum score for new users — they start here, not at zero.
+NEW_USER_MINIMUM_SCORE = 0.1
+
+#: Maximum possible contribution score.
+MAX_CONTRIBUTION_SCORE = 1.0
+
+
+@dataclass
+class ContributionScore:
+    """Aggregated contribution score for a node.
+
+    Each dimension is a float in [0, 1]. The overall score is a weighted
+    average of all dimensions.
+
+    New users start with ``NEW_USER_MINIMUM_SCORE`` on all dimensions,
+    ensuring they always receive minimum service.
+    """
+
+    node_id: str
+    dimensions: dict[ContributionDimension, float] = field(default_factory=dict)
+    weights: dict[ContributionDimension, float] = field(default_factory=lambda: dict(DEFAULT_DIMENSION_WEIGHTS))
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+    def __post_init__(self) -> None:
+        # Ensure all dimensions exist with at least the minimum score.
+        for dim in ContributionDimension:
+            if dim not in self.dimensions:
+                self.dimensions[dim] = NEW_USER_MINIMUM_SCORE
+
+    @property
+    def overall(self) -> float:
+        """Weighted average of all contribution dimensions.
+
+        Returns a value in [0, 1]. Clamps to ``NEW_USER_MINIMUM_SCORE``
+        at the low end to ensure new users are never at zero.
+        """
+        total = 0.0
+        weight_sum = 0.0
+        for dim, weight in self.weights.items():
+            total += self.dimensions.get(dim, NEW_USER_MINIMUM_SCORE) * weight
+            weight_sum += weight
+        if weight_sum == 0:
+            return NEW_USER_MINIMUM_SCORE
+        raw = total / weight_sum
+        return max(raw, NEW_USER_MINIMUM_SCORE)
+
+    def set_dimension(self, dim: ContributionDimension, value: float) -> None:
+        """Set a dimension value, clamped to [0, 1]."""
+        self.dimensions[dim] = max(0.0, min(1.0, value))
+        self.updated_at = time.time()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "node_id": self.node_id,
+            "overall": round(self.overall, 4),
+            "dimensions": {dim.value: round(val, 4) for dim, val in self.dimensions.items()},
+            "weights": {dim.value: round(w, 4) for dim, w in self.weights.items()},
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ContributionScore:
+        """Deserialize from dictionary."""
+        dimensions = {ContributionDimension(k): v for k, v in data.get("dimensions", {}).items()}
+        weights = {ContributionDimension(k): v for k, v in data.get("weights", {}).items()}
+        return cls(
+            node_id=data["node_id"],
+            dimensions=dimensions,
+            weights=weights if weights else dict(DEFAULT_DIMENSION_WEIGHTS),
+            created_at=data.get("created_at", time.time()),
+            updated_at=data.get("updated_at", time.time()),
+        )
+
+
+class PriorityTier(StrEnum):
+    """Priority tiers for message handling."""
+
+    CRITICAL = "critical"  # Essential protocol messages
+    HIGH = "high"  # High-contribution nodes
+    NORMAL = "normal"  # Average contributors
+    LOW = "low"  # Low contribution / new users
+    MINIMUM = "minimum"  # Minimum service floor (never blocked)
+
+
+#: Maps tiers to relative queue weights.
+TIER_WEIGHTS: dict[PriorityTier, float] = {
+    PriorityTier.CRITICAL: 10.0,
+    PriorityTier.HIGH: 4.0,
+    PriorityTier.NORMAL: 2.0,
+    PriorityTier.LOW: 1.0,
+    PriorityTier.MINIMUM: 0.5,
+}
+
+
+@dataclass
+class QoSPolicy:
+    """Dynamic deprioritization policy based on network load.
+
+    The core idea: at low load, everyone is roughly equal. As load
+    increases, the deprioritization curve steepens — contributors get
+    prioritized more sharply.
+
+    The curve function:
+        priority = base + (score ^ steepness) * (1 - base)
+
+    Where:
+        - base is the minimum service floor (everyone gets at least this)
+        - score is the contribution score [0, 1]
+        - steepness is load-adaptive: higher load → steeper curve
+
+    Steepness mapping (load → steepness):
+        - load 0.0 → steepness 1.0 (linear, everyone roughly equal)
+        - load 0.5 → steepness 2.0 (quadratic, contributors get a boost)
+        - load 1.0 → steepness 4.0 (steep, strong prioritization)
+    """
+
+    #: Minimum service floor — even lowest-priority nodes get this fraction
+    #: of service. Prevents starvation. Range [0, 1].
+    min_service_floor: float = 0.1
+
+    #: Maximum steepness of the deprioritization curve. Reached at full load.
+    max_steepness: float = 4.0
+
+    #: Minimum steepness (at zero load). 1.0 = linear/equal treatment.
+    min_steepness: float = 1.0
+
+    #: Grace period (seconds) for new nodes. During grace, they receive
+    #: NORMAL priority regardless of contribution score.
+    new_user_grace_period: float = 3600.0  # 1 hour
+
+    #: Score threshold for HIGH priority tier.
+    high_tier_threshold: float = 0.7
+
+    #: Score threshold for NORMAL priority tier.
+    normal_tier_threshold: float = 0.3
+
+    #: Score threshold for LOW priority tier (below this → MINIMUM).
+    low_tier_threshold: float = 0.1
+
+    def compute_steepness(self, load_factor: float) -> float:
+        """Compute curve steepness from current network load.
+
+        Args:
+            load_factor: Network load in [0, 1] where 0 = idle, 1 = full.
+
+        Returns:
+            Steepness exponent for the priority curve.
+        """
+        load_factor = max(0.0, min(1.0, load_factor))
+        return self.min_steepness + (self.max_steepness - self.min_steepness) * (load_factor**2)
+
+    def compute_priority(self, score: float, load_factor: float = 0.0) -> float:
+        """Compute a node's priority value from its contribution score.
+
+        Args:
+            score: Contribution score in [0, 1].
+            load_factor: Current network load in [0, 1].
+
+        Returns:
+            Priority value in [min_service_floor, 1.0].
+        """
+        score = max(0.0, min(1.0, score))
+        steepness = self.compute_steepness(load_factor)
+        base = self.min_service_floor
+        return base + (score**steepness) * (1.0 - base)
+
+    def assign_tier(self, score: float, *, is_new_user: bool = False) -> PriorityTier:
+        """Assign a priority tier based on contribution score.
+
+        Args:
+            score: Contribution score in [0, 1].
+            is_new_user: If True, assign NORMAL regardless of score
+                         (grace period).
+
+        Returns:
+            The assigned ``PriorityTier``.
+        """
+        if is_new_user:
+            return PriorityTier.NORMAL
+
+        if score >= self.high_tier_threshold:
+            return PriorityTier.HIGH
+        elif score >= self.normal_tier_threshold:
+            return PriorityTier.NORMAL
+        elif score >= self.low_tier_threshold:
+            return PriorityTier.LOW
+        else:
+            return PriorityTier.MINIMUM
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize policy to dictionary."""
+        return {
+            "min_service_floor": self.min_service_floor,
+            "max_steepness": self.max_steepness,
+            "min_steepness": self.min_steepness,
+            "new_user_grace_period": self.new_user_grace_period,
+            "high_tier_threshold": self.high_tier_threshold,
+            "normal_tier_threshold": self.normal_tier_threshold,
+            "low_tier_threshold": self.low_tier_threshold,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> QoSPolicy:
+        """Deserialize from dictionary."""
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})

--- a/src/valence/network/qos_manager.py
+++ b/src/valence/network/qos_manager.py
@@ -1,0 +1,380 @@
+"""
+QoS Manager — orchestrates contribution-based traffic prioritization.
+
+Maintains per-node contribution scores, computes priorities using the
+dynamic deprioritization curve, and handles new-user grace periods.
+
+The manager adapts to network conditions:
+- Low load: flat curve, everyone roughly equal
+- High load: steep curve, heavy contributors prioritized
+- Attack conditions: naturally rate-limits bad actors (can't attack
+  AND contribute meaningfully at the same time)
+
+Issue #276: Network: Contribution-based QoS with dynamic curve.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from .qos import (
+    ContributionDimension,
+    ContributionScore,
+    PriorityTier,
+    QoSPolicy,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LoadMetrics:
+    """Current network load metrics used for curve adaptation.
+
+    These metrics come from network feedback: queue depth, latency,
+    peer reports, etc.
+    """
+
+    #: Overall load factor [0, 1].
+    load_factor: float = 0.0
+
+    #: Average message queue depth across connections.
+    avg_queue_depth: float = 0.0
+
+    #: Average round-trip latency in milliseconds.
+    avg_latency_ms: float = 0.0
+
+    #: Number of active peer connections.
+    active_connections: int = 0
+
+    #: Maximum capacity (connections).
+    max_connections: int = 100
+
+    #: Timestamp of last update.
+    updated_at: float = field(default_factory=time.time)
+
+    def compute_load_factor(self) -> float:
+        """Derive a composite load factor from metrics.
+
+        Combines connection saturation and queue depth into a single
+        factor in [0, 1].
+        """
+        if self.max_connections <= 0:
+            connection_load = 0.0
+        else:
+            connection_load = min(1.0, self.active_connections / self.max_connections)
+
+        # Queue depth: assume 100 = saturated (configurable via subclass).
+        queue_load = min(1.0, self.avg_queue_depth / 100.0)
+
+        # Weighted composite: connections matter more than queue depth.
+        composite = 0.6 * connection_load + 0.4 * queue_load
+        self.load_factor = max(0.0, min(1.0, composite))
+        self.updated_at = time.time()
+        return self.load_factor
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "load_factor": round(self.load_factor, 4),
+            "avg_queue_depth": round(self.avg_queue_depth, 2),
+            "avg_latency_ms": round(self.avg_latency_ms, 2),
+            "active_connections": self.active_connections,
+            "max_connections": self.max_connections,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
+class NodeQoSState:
+    """Per-node QoS state including score, tier, and grace tracking."""
+
+    node_id: str
+    score: ContributionScore
+    tier: PriorityTier = PriorityTier.NORMAL
+    priority_value: float = 0.5
+    first_seen: float = field(default_factory=time.time)
+    is_in_grace_period: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "node_id": self.node_id,
+            "score": self.score.to_dict(),
+            "tier": self.tier.value,
+            "priority_value": round(self.priority_value, 4),
+            "first_seen": self.first_seen,
+            "is_in_grace_period": self.is_in_grace_period,
+        }
+
+
+class QoSManager:
+    """Manages contribution-based QoS for all known nodes.
+
+    Responsibilities:
+    - Track contribution scores per node
+    - Compute dynamic priorities based on load
+    - Handle new-user grace periods
+    - Provide priority rankings for message scheduling
+
+    Usage::
+
+        manager = QoSManager()
+
+        # Update a node's contribution
+        manager.update_score("node-abc", ContributionDimension.UPTIME_RELIABILITY, 0.9)
+
+        # Get priority for scheduling
+        priority = manager.get_priority("node-abc")
+
+        # Update network load (from monitoring)
+        manager.update_load(active_connections=80, max_connections=100, avg_queue_depth=45)
+
+        # Get ranked nodes for scheduling
+        ranked = manager.get_ranked_nodes()
+    """
+
+    def __init__(
+        self,
+        policy: QoSPolicy | None = None,
+        *,
+        max_tracked_nodes: int = 10000,
+    ) -> None:
+        self._policy = policy or QoSPolicy()
+        self._nodes: dict[str, NodeQoSState] = {}
+        self._load = LoadMetrics()
+        self._max_tracked_nodes = max_tracked_nodes
+
+    @property
+    def policy(self) -> QoSPolicy:
+        """Current QoS policy."""
+        return self._policy
+
+    @property
+    def load_metrics(self) -> LoadMetrics:
+        """Current load metrics."""
+        return self._load
+
+    @property
+    def node_count(self) -> int:
+        """Number of tracked nodes."""
+        return len(self._nodes)
+
+    def get_or_create_node(self, node_id: str) -> NodeQoSState:
+        """Get existing node state or create new one with defaults.
+
+        New nodes start with ``NEW_USER_MINIMUM_SCORE`` on all dimensions
+        and enter a grace period where they receive NORMAL priority.
+        """
+        if node_id in self._nodes:
+            return self._nodes[node_id]
+
+        # Evict oldest node if at capacity.
+        if len(self._nodes) >= self._max_tracked_nodes:
+            self._evict_oldest()
+
+        score = ContributionScore(node_id=node_id)
+        now = time.time()
+        state = NodeQoSState(
+            node_id=node_id,
+            score=score,
+            tier=PriorityTier.NORMAL,
+            priority_value=self._policy.compute_priority(score.overall, self._load.load_factor),
+            first_seen=now,
+            is_in_grace_period=True,
+        )
+        self._nodes[node_id] = state
+        logger.debug("New node registered for QoS: %s (grace period active)", node_id)
+        return state
+
+    def update_score(
+        self,
+        node_id: str,
+        dimension: ContributionDimension,
+        value: float,
+    ) -> NodeQoSState:
+        """Update a contribution dimension for a node.
+
+        Triggers recomputation of priority and tier.
+
+        Args:
+            node_id: The node identifier.
+            dimension: Which contribution dimension to update.
+            value: New value in [0, 1].
+
+        Returns:
+            Updated ``NodeQoSState``.
+        """
+        state = self.get_or_create_node(node_id)
+        state.score.set_dimension(dimension, value)
+        self._recompute_node(state)
+        return state
+
+    def update_scores_batch(
+        self,
+        node_id: str,
+        updates: dict[ContributionDimension, float],
+    ) -> NodeQoSState:
+        """Update multiple dimensions at once for efficiency.
+
+        Args:
+            node_id: The node identifier.
+            updates: Mapping of dimensions to new values.
+
+        Returns:
+            Updated ``NodeQoSState``.
+        """
+        state = self.get_or_create_node(node_id)
+        for dim, value in updates.items():
+            state.score.set_dimension(dim, value)
+        self._recompute_node(state)
+        return state
+
+    def get_priority(self, node_id: str) -> float:
+        """Get the current priority value for a node.
+
+        Returns a value in [min_service_floor, 1.0]. Higher = more priority.
+        Unknown nodes get default (grace period) priority.
+        """
+        state = self.get_or_create_node(node_id)
+        return state.priority_value
+
+    def get_tier(self, node_id: str) -> PriorityTier:
+        """Get the current priority tier for a node."""
+        state = self.get_or_create_node(node_id)
+        return state.tier
+
+    def get_node_state(self, node_id: str) -> NodeQoSState | None:
+        """Get full state for a node, or None if untracked."""
+        return self._nodes.get(node_id)
+
+    def update_load(
+        self,
+        *,
+        active_connections: int | None = None,
+        max_connections: int | None = None,
+        avg_queue_depth: float | None = None,
+        avg_latency_ms: float | None = None,
+    ) -> float:
+        """Update network load metrics and recompute all priorities.
+
+        Args:
+            active_connections: Current number of active connections.
+            max_connections: Maximum connection capacity.
+            avg_queue_depth: Average message queue depth.
+            avg_latency_ms: Average round-trip latency in ms.
+
+        Returns:
+            Updated load factor.
+        """
+        if active_connections is not None:
+            self._load.active_connections = active_connections
+        if max_connections is not None:
+            self._load.max_connections = max_connections
+        if avg_queue_depth is not None:
+            self._load.avg_queue_depth = avg_queue_depth
+        if avg_latency_ms is not None:
+            self._load.avg_latency_ms = avg_latency_ms
+
+        load_factor = self._load.compute_load_factor()
+        self._recompute_all()
+        logger.debug(
+            "Load updated: factor=%.2f, connections=%d/%d, queue=%.1f",
+            load_factor,
+            self._load.active_connections,
+            self._load.max_connections,
+            self._load.avg_queue_depth,
+        )
+        return load_factor
+
+    def get_ranked_nodes(self) -> list[NodeQoSState]:
+        """Get all tracked nodes ranked by priority (highest first).
+
+        Returns:
+            List of ``NodeQoSState`` sorted by descending priority.
+        """
+        return sorted(
+            self._nodes.values(),
+            key=lambda s: s.priority_value,
+            reverse=True,
+        )
+
+    def get_tier_summary(self) -> dict[str, int]:
+        """Get count of nodes in each tier.
+
+        Returns:
+            Mapping of tier name to node count.
+        """
+        counts: dict[str, int] = {tier.value: 0 for tier in PriorityTier}
+        for state in self._nodes.values():
+            counts[state.tier.value] += 1
+        return counts
+
+    def get_status(self) -> dict[str, Any]:
+        """Get full QoS system status for CLI/monitoring.
+
+        Returns:
+            Dictionary with policy, load, tier summary, and stats.
+        """
+        tier_summary = self.get_tier_summary()
+        return {
+            "policy": self._policy.to_dict(),
+            "load": self._load.to_dict(),
+            "node_count": len(self._nodes),
+            "tier_summary": tier_summary,
+            "current_steepness": round(self._policy.compute_steepness(self._load.load_factor), 4),
+        }
+
+    def remove_node(self, node_id: str) -> bool:
+        """Remove a node from QoS tracking.
+
+        Returns:
+            True if the node was removed, False if not found.
+        """
+        if node_id in self._nodes:
+            del self._nodes[node_id]
+            return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _recompute_node(self, state: NodeQoSState) -> None:
+        """Recompute priority and tier for a single node."""
+        now = time.time()
+        age = now - state.first_seen
+
+        # Check grace period expiry.
+        if state.is_in_grace_period:
+            if age > self._policy.new_user_grace_period:
+                state.is_in_grace_period = False
+                logger.debug(
+                    "Grace period expired for node %s after %.0fs",
+                    state.node_id,
+                    age,
+                )
+
+        overall = state.score.overall
+        state.priority_value = self._policy.compute_priority(overall, self._load.load_factor)
+        state.tier = self._policy.assign_tier(overall, is_new_user=state.is_in_grace_period)
+
+    def _recompute_all(self) -> None:
+        """Recompute priorities for all tracked nodes."""
+        for state in self._nodes.values():
+            self._recompute_node(state)
+
+    def _evict_oldest(self) -> None:
+        """Evict the oldest node with the lowest priority."""
+        if not self._nodes:
+            return
+        # Evict the node with the lowest priority, breaking ties by oldest.
+        victim = min(
+            self._nodes.values(),
+            key=lambda s: (s.priority_value, -s.first_seen),
+        )
+        del self._nodes[victim.node_id]
+        logger.debug("Evicted node %s from QoS tracking (capacity limit)", victim.node_id)

--- a/tests/cli/test_qos_cli.py
+++ b/tests/cli/test_qos_cli.py
@@ -1,0 +1,132 @@
+"""Tests for QoS CLI commands.
+
+Covers:
+- ``valence qos status`` (human-readable + JSON)
+- ``valence qos score`` (default + with dimensions + JSON)
+- Dispatching and error handling
+
+Issue #276: Network: Contribution-based QoS with dynamic curve.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+from valence.cli.commands.qos import cmd_qos, cmd_qos_score, cmd_qos_status
+
+
+def _make_args(**kwargs: object) -> argparse.Namespace:
+    """Build a Namespace with defaults for QoS commands."""
+    defaults = {
+        "qos_command": None,
+        "json": False,
+        "node_id": None,
+        "routing_capacity": None,
+        "uptime_reliability": None,
+        "belief_quality": None,
+        "resource_sharing": None,
+        "trust_received": None,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class TestQoSStatusCLI:
+    """Tests for valence qos status."""
+
+    def test_status_human_readable(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = _make_args(qos_command="status")
+        rc = cmd_qos_status(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "QoS System Status" in out
+        assert "Policy" in out
+        assert "Load" in out
+
+    def test_status_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = _make_args(qos_command="status", json=True)
+        rc = cmd_qos_status(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert "policy" in data
+        assert "load" in data
+        assert "node_count" in data
+        assert "tier_summary" in data
+
+
+class TestQoSScoreCLI:
+    """Tests for valence qos score."""
+
+    def test_score_default(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = _make_args(qos_command="score")
+        rc = cmd_qos_score(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Contribution Score" in out
+        assert "Dimensions" in out
+        assert "Priority" in out
+
+    def test_score_with_node_id(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = _make_args(qos_command="score", node_id="my-node")
+        rc = cmd_qos_score(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "my-node" in out
+
+    def test_score_with_dimensions(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = _make_args(
+            qos_command="score",
+            routing_capacity=0.9,
+            uptime_reliability=0.8,
+        )
+        rc = cmd_qos_score(args)
+        assert rc == 0
+
+    def test_score_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = _make_args(qos_command="score", json=True)
+        rc = cmd_qos_score(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert "overall" in data
+        assert "tier" in data
+        assert "priority_at_load_0" in data
+        assert "priority_at_load_50" in data
+        assert "priority_at_load_100" in data
+
+    def test_score_json_with_custom_dimensions(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = _make_args(
+            qos_command="score",
+            json=True,
+            routing_capacity=1.0,
+            belief_quality=0.5,
+        )
+        rc = cmd_qos_score(args)
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["overall"] > 0
+
+
+class TestQoSDispatch:
+    """Tests for the cmd_qos dispatcher."""
+
+    def test_dispatch_status(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = _make_args(qos_command="status")
+        rc = cmd_qos(args)
+        assert rc == 0
+
+    def test_dispatch_score(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = _make_args(qos_command="score")
+        rc = cmd_qos(args)
+        assert rc == 0
+
+    def test_dispatch_unknown(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = _make_args(qos_command=None)
+        rc = cmd_qos(args)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Usage" in out

--- a/tests/network/test_qos.py
+++ b/tests/network/test_qos.py
@@ -1,0 +1,359 @@
+"""Tests for contribution-based QoS data structures and policy.
+
+Covers:
+- ContributionScore: creation, dimensions, overall score, serialization
+- QoSPolicy: steepness curve, priority computation, tier assignment
+- PriorityTier: ordering and weights
+- Edge cases: new users, clamping, empty weights
+
+Issue #276: Network: Contribution-based QoS with dynamic curve.
+"""
+
+from __future__ import annotations
+
+import time
+
+from valence.network.qos import (
+    DEFAULT_DIMENSION_WEIGHTS,
+    NEW_USER_MINIMUM_SCORE,
+    TIER_WEIGHTS,
+    ContributionDimension,
+    ContributionScore,
+    PriorityTier,
+    QoSPolicy,
+)
+
+# =============================================================================
+# ContributionDimension
+# =============================================================================
+
+
+class TestContributionDimension:
+    """Tests for the ContributionDimension enum."""
+
+    def test_all_dimensions_exist(self) -> None:
+        assert len(ContributionDimension) == 5
+
+    def test_dimension_values(self) -> None:
+        assert ContributionDimension.ROUTING_CAPACITY.value == "routing_capacity"
+        assert ContributionDimension.UPTIME_RELIABILITY.value == "uptime_reliability"
+        assert ContributionDimension.BELIEF_QUALITY.value == "belief_quality"
+        assert ContributionDimension.RESOURCE_SHARING.value == "resource_sharing"
+        assert ContributionDimension.TRUST_RECEIVED.value == "trust_received"
+
+    def test_is_string_enum(self) -> None:
+        for dim in ContributionDimension:
+            assert isinstance(dim, str)
+            assert isinstance(dim.value, str)
+
+
+# =============================================================================
+# ContributionScore
+# =============================================================================
+
+
+class TestContributionScore:
+    """Tests for the ContributionScore dataclass."""
+
+    def test_new_score_has_minimum_dimensions(self) -> None:
+        """New scores should have all dimensions initialized to minimum."""
+        score = ContributionScore(node_id="test-node")
+        for dim in ContributionDimension:
+            assert score.dimensions[dim] == NEW_USER_MINIMUM_SCORE
+
+    def test_overall_score_minimum(self) -> None:
+        """Overall score of a new user should be at least NEW_USER_MINIMUM_SCORE."""
+        score = ContributionScore(node_id="test-node")
+        assert score.overall >= NEW_USER_MINIMUM_SCORE
+
+    def test_overall_weighted_average(self) -> None:
+        """Overall should be a weighted average of dimensions."""
+        score = ContributionScore(node_id="test-node")
+        score.set_dimension(ContributionDimension.ROUTING_CAPACITY, 1.0)
+        score.set_dimension(ContributionDimension.UPTIME_RELIABILITY, 0.5)
+        score.set_dimension(ContributionDimension.BELIEF_QUALITY, 0.5)
+        score.set_dimension(ContributionDimension.RESOURCE_SHARING, 0.0)
+        score.set_dimension(ContributionDimension.TRUST_RECEIVED, 0.0)
+
+        # Manual calculation with default weights
+        expected = (
+            1.0 * 0.25  # routing
+            + 0.5 * 0.20  # uptime
+            + 0.5 * 0.20  # belief
+            + 0.0 * 0.15  # resource
+            + 0.0 * 0.20  # trust
+        )
+        assert abs(score.overall - expected) < 1e-6
+
+    def test_overall_max_score(self) -> None:
+        """A fully contributing node should have overall = 1.0."""
+        score = ContributionScore(node_id="test-node")
+        for dim in ContributionDimension:
+            score.set_dimension(dim, 1.0)
+        assert abs(score.overall - 1.0) < 1e-6
+
+    def test_set_dimension_clamps(self) -> None:
+        """Values should be clamped to [0, 1]."""
+        score = ContributionScore(node_id="test-node")
+        score.set_dimension(ContributionDimension.ROUTING_CAPACITY, 2.0)
+        assert score.dimensions[ContributionDimension.ROUTING_CAPACITY] == 1.0
+
+        score.set_dimension(ContributionDimension.ROUTING_CAPACITY, -0.5)
+        assert score.dimensions[ContributionDimension.ROUTING_CAPACITY] == 0.0
+
+    def test_set_dimension_updates_timestamp(self) -> None:
+        """Setting a dimension should update updated_at."""
+        score = ContributionScore(node_id="test-node")
+        old_ts = score.updated_at
+        time.sleep(0.01)
+        score.set_dimension(ContributionDimension.ROUTING_CAPACITY, 0.5)
+        assert score.updated_at >= old_ts
+
+    def test_overall_never_below_minimum(self) -> None:
+        """Overall should never go below NEW_USER_MINIMUM_SCORE."""
+        score = ContributionScore(node_id="test-node")
+        for dim in ContributionDimension:
+            score.set_dimension(dim, 0.0)
+        # With all zeros, the weighted average is 0, but it clamps to minimum
+        assert score.overall >= NEW_USER_MINIMUM_SCORE
+
+    def test_overall_with_zero_weights(self) -> None:
+        """Edge case: if all weights are zero, return minimum score."""
+        score = ContributionScore(
+            node_id="test-node",
+            weights={dim: 0.0 for dim in ContributionDimension},
+        )
+        assert score.overall == NEW_USER_MINIMUM_SCORE
+
+    def test_serialization_round_trip(self) -> None:
+        """to_dict -> from_dict should preserve data."""
+        score = ContributionScore(node_id="node-abc")
+        score.set_dimension(ContributionDimension.ROUTING_CAPACITY, 0.8)
+        score.set_dimension(ContributionDimension.BELIEF_QUALITY, 0.6)
+
+        data = score.to_dict()
+        restored = ContributionScore.from_dict(data)
+
+        assert restored.node_id == score.node_id
+        assert abs(restored.overall - score.overall) < 1e-3
+        assert abs(restored.dimensions[ContributionDimension.ROUTING_CAPACITY] - score.dimensions[ContributionDimension.ROUTING_CAPACITY]) < 1e-3
+
+    def test_to_dict_structure(self) -> None:
+        """to_dict should produce expected keys."""
+        score = ContributionScore(node_id="test")
+        data = score.to_dict()
+        assert "node_id" in data
+        assert "overall" in data
+        assert "dimensions" in data
+        assert "weights" in data
+        assert "created_at" in data
+        assert "updated_at" in data
+
+    def test_from_dict_with_missing_weights(self) -> None:
+        """from_dict with no weights should use defaults."""
+        data = {"node_id": "test", "dimensions": {}}
+        score = ContributionScore.from_dict(data)
+        assert score.weights == DEFAULT_DIMENSION_WEIGHTS
+
+    def test_custom_weights(self) -> None:
+        """Custom weights should affect overall score."""
+        # All weight on routing_capacity
+        weights = {dim: 0.0 for dim in ContributionDimension}
+        weights[ContributionDimension.ROUTING_CAPACITY] = 1.0
+
+        score = ContributionScore(node_id="test", weights=weights)
+        score.set_dimension(ContributionDimension.ROUTING_CAPACITY, 0.9)
+        score.set_dimension(ContributionDimension.BELIEF_QUALITY, 0.1)
+
+        # Overall should be dominated by routing_capacity
+        assert abs(score.overall - 0.9) < 1e-6
+
+
+# =============================================================================
+# QoSPolicy
+# =============================================================================
+
+
+class TestQoSPolicy:
+    """Tests for the QoSPolicy dynamic curve."""
+
+    def test_default_policy_values(self) -> None:
+        policy = QoSPolicy()
+        assert policy.min_service_floor == 0.1
+        assert policy.max_steepness == 4.0
+        assert policy.min_steepness == 1.0
+
+    def test_steepness_at_zero_load(self) -> None:
+        """At zero load, steepness should be min (linear)."""
+        policy = QoSPolicy()
+        assert policy.compute_steepness(0.0) == policy.min_steepness
+
+    def test_steepness_at_full_load(self) -> None:
+        """At full load, steepness should be max."""
+        policy = QoSPolicy()
+        assert policy.compute_steepness(1.0) == policy.max_steepness
+
+    def test_steepness_increases_with_load(self) -> None:
+        """Steepness should monotonically increase with load."""
+        policy = QoSPolicy()
+        prev = 0.0
+        for load in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            steep = policy.compute_steepness(load)
+            assert steep >= prev
+            prev = steep
+
+    def test_steepness_clamps_load(self) -> None:
+        """Load factor should be clamped to [0, 1]."""
+        policy = QoSPolicy()
+        assert policy.compute_steepness(-0.5) == policy.compute_steepness(0.0)
+        assert policy.compute_steepness(1.5) == policy.compute_steepness(1.0)
+
+    def test_priority_at_zero_load(self) -> None:
+        """At zero load with steepness=1 (linear), priority is proportional."""
+        policy = QoSPolicy()
+        # Score 1.0: priority = 0.1 + (1.0^1.0) * 0.9 = 1.0
+        assert abs(policy.compute_priority(1.0, 0.0) - 1.0) < 1e-6
+        # Score 0.5: priority = 0.1 + (0.5^1.0) * 0.9 = 0.55
+        assert abs(policy.compute_priority(0.5, 0.0) - 0.55) < 1e-6
+
+    def test_priority_minimum_floor(self) -> None:
+        """Priority should never go below min_service_floor."""
+        policy = QoSPolicy()
+        assert policy.compute_priority(0.0, 0.0) >= policy.min_service_floor
+        assert policy.compute_priority(0.0, 1.0) >= policy.min_service_floor
+
+    def test_priority_max_at_full_contribution(self) -> None:
+        """Score=1.0 should always give priority=1.0 regardless of load."""
+        policy = QoSPolicy()
+        for load in [0.0, 0.5, 1.0]:
+            assert abs(policy.compute_priority(1.0, load) - 1.0) < 1e-6
+
+    def test_priority_decreases_with_lower_score(self) -> None:
+        """Higher score → higher priority at any load."""
+        policy = QoSPolicy()
+        for load in [0.0, 0.5, 1.0]:
+            high = policy.compute_priority(0.9, load)
+            low = policy.compute_priority(0.2, load)
+            assert high > low
+
+    def test_high_load_steepens_curve(self) -> None:
+        """Under high load, low scorers lose more relative to high scorers.
+
+        The steep curve (exponent > 1) deprioritizes low scorers more.
+        Specifically: the ratio of high/low priority should increase.
+        """
+        policy = QoSPolicy()
+        score_high, score_low = 0.8, 0.2
+
+        ratio_low_load = policy.compute_priority(score_high, 0.0) / policy.compute_priority(score_low, 0.0)
+        ratio_high_load = policy.compute_priority(score_high, 1.0) / policy.compute_priority(score_low, 1.0)
+
+        assert ratio_high_load > ratio_low_load
+
+    def test_priority_clamps_score(self) -> None:
+        """Score should be clamped to [0, 1]."""
+        policy = QoSPolicy()
+        assert policy.compute_priority(-0.5, 0.0) == policy.compute_priority(0.0, 0.0)
+        assert policy.compute_priority(1.5, 0.0) == policy.compute_priority(1.0, 0.0)
+
+    def test_assign_tier_high(self) -> None:
+        policy = QoSPolicy()
+        assert policy.assign_tier(0.8) == PriorityTier.HIGH
+
+    def test_assign_tier_normal(self) -> None:
+        policy = QoSPolicy()
+        assert policy.assign_tier(0.5) == PriorityTier.NORMAL
+
+    def test_assign_tier_low(self) -> None:
+        policy = QoSPolicy()
+        assert policy.assign_tier(0.15) == PriorityTier.LOW
+
+    def test_assign_tier_minimum(self) -> None:
+        policy = QoSPolicy()
+        assert policy.assign_tier(0.05) == PriorityTier.MINIMUM
+
+    def test_assign_tier_new_user_gets_normal(self) -> None:
+        """New users always get NORMAL tier during grace period."""
+        policy = QoSPolicy()
+        assert policy.assign_tier(0.0, is_new_user=True) == PriorityTier.NORMAL
+        assert policy.assign_tier(0.05, is_new_user=True) == PriorityTier.NORMAL
+
+    def test_assign_tier_boundary_high(self) -> None:
+        """Exactly at the high threshold should be HIGH."""
+        policy = QoSPolicy()
+        assert policy.assign_tier(policy.high_tier_threshold) == PriorityTier.HIGH
+
+    def test_assign_tier_boundary_normal(self) -> None:
+        """Exactly at the normal threshold should be NORMAL."""
+        policy = QoSPolicy()
+        assert policy.assign_tier(policy.normal_tier_threshold) == PriorityTier.NORMAL
+
+    def test_assign_tier_boundary_low(self) -> None:
+        """Exactly at the low threshold should be LOW."""
+        policy = QoSPolicy()
+        assert policy.assign_tier(policy.low_tier_threshold) == PriorityTier.LOW
+
+    def test_policy_serialization_round_trip(self) -> None:
+        policy = QoSPolicy(min_service_floor=0.2, max_steepness=5.0)
+        data = policy.to_dict()
+        restored = QoSPolicy.from_dict(data)
+        assert restored.min_service_floor == policy.min_service_floor
+        assert restored.max_steepness == policy.max_steepness
+
+    def test_policy_from_dict_ignores_unknown(self) -> None:
+        """from_dict should ignore unknown keys."""
+        data = {"min_service_floor": 0.2, "unknown_field": 42}
+        policy = QoSPolicy.from_dict(data)
+        assert policy.min_service_floor == 0.2
+
+
+# =============================================================================
+# PriorityTier
+# =============================================================================
+
+
+class TestPriorityTier:
+    """Tests for PriorityTier enum and tier weights."""
+
+    def test_all_tiers_exist(self) -> None:
+        assert len(PriorityTier) == 5
+
+    def test_tier_weight_ordering(self) -> None:
+        """Higher tiers should have higher weights."""
+        assert TIER_WEIGHTS[PriorityTier.CRITICAL] > TIER_WEIGHTS[PriorityTier.HIGH]
+        assert TIER_WEIGHTS[PriorityTier.HIGH] > TIER_WEIGHTS[PriorityTier.NORMAL]
+        assert TIER_WEIGHTS[PriorityTier.NORMAL] > TIER_WEIGHTS[PriorityTier.LOW]
+        assert TIER_WEIGHTS[PriorityTier.LOW] > TIER_WEIGHTS[PriorityTier.MINIMUM]
+
+    def test_all_tiers_have_weights(self) -> None:
+        for tier in PriorityTier:
+            assert tier in TIER_WEIGHTS
+
+    def test_minimum_tier_weight_positive(self) -> None:
+        """Even MINIMUM tier should get some service (non-zero weight)."""
+        assert TIER_WEIGHTS[PriorityTier.MINIMUM] > 0
+
+    def test_is_string_enum(self) -> None:
+        for tier in PriorityTier:
+            assert isinstance(tier, str)
+
+
+# =============================================================================
+# Default weights
+# =============================================================================
+
+
+class TestDefaultWeights:
+    """Tests for DEFAULT_DIMENSION_WEIGHTS."""
+
+    def test_weights_sum_to_one(self) -> None:
+        total = sum(DEFAULT_DIMENSION_WEIGHTS.values())
+        assert abs(total - 1.0) < 1e-6
+
+    def test_all_dimensions_have_weights(self) -> None:
+        for dim in ContributionDimension:
+            assert dim in DEFAULT_DIMENSION_WEIGHTS
+
+    def test_all_weights_positive(self) -> None:
+        for weight in DEFAULT_DIMENSION_WEIGHTS.values():
+            assert weight > 0

--- a/tests/network/test_qos_manager.py
+++ b/tests/network/test_qos_manager.py
@@ -1,0 +1,340 @@
+"""Tests for the QoS Manager.
+
+Covers:
+- Node registration and tracking
+- Score updates (single and batch)
+- Priority and tier computation
+- Load metrics and adaptation
+- Grace period handling
+- Node eviction at capacity
+- Ranking and status reporting
+
+Issue #276: Network: Contribution-based QoS with dynamic curve.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from valence.network.qos import (
+    ContributionDimension,
+    ContributionScore,
+    PriorityTier,
+    QoSPolicy,
+)
+from valence.network.qos_manager import (
+    LoadMetrics,
+    NodeQoSState,
+    QoSManager,
+)
+
+# =============================================================================
+# LoadMetrics
+# =============================================================================
+
+
+class TestLoadMetrics:
+    """Tests for the LoadMetrics dataclass."""
+
+    def test_default_values(self) -> None:
+        metrics = LoadMetrics()
+        assert metrics.load_factor == 0.0
+        assert metrics.active_connections == 0
+        assert metrics.max_connections == 100
+
+    def test_compute_load_factor_idle(self) -> None:
+        """Idle system should have load factor ~0."""
+        metrics = LoadMetrics(active_connections=0, avg_queue_depth=0.0)
+        factor = metrics.compute_load_factor()
+        assert factor == 0.0
+
+    def test_compute_load_factor_saturated(self) -> None:
+        """Fully saturated should approach 1.0."""
+        metrics = LoadMetrics(
+            active_connections=100,
+            max_connections=100,
+            avg_queue_depth=100.0,
+        )
+        factor = metrics.compute_load_factor()
+        assert abs(factor - 1.0) < 1e-6
+
+    def test_compute_load_factor_partial(self) -> None:
+        """Partial load should be between 0 and 1."""
+        metrics = LoadMetrics(
+            active_connections=50,
+            max_connections=100,
+            avg_queue_depth=25.0,
+        )
+        factor = metrics.compute_load_factor()
+        # 0.6 * 0.5 + 0.4 * 0.25 = 0.3 + 0.1 = 0.4
+        assert abs(factor - 0.4) < 1e-6
+
+    def test_compute_load_factor_zero_max_connections(self) -> None:
+        """Zero max_connections should not divide by zero."""
+        metrics = LoadMetrics(max_connections=0, active_connections=10)
+        factor = metrics.compute_load_factor()
+        assert factor >= 0.0
+
+    def test_compute_load_factor_capped(self) -> None:
+        """Load factor should not exceed 1.0."""
+        metrics = LoadMetrics(
+            active_connections=200,
+            max_connections=100,
+            avg_queue_depth=500.0,
+        )
+        factor = metrics.compute_load_factor()
+        assert factor <= 1.0
+
+    def test_to_dict(self) -> None:
+        metrics = LoadMetrics(active_connections=50, max_connections=100)
+        data = metrics.to_dict()
+        assert "load_factor" in data
+        assert "active_connections" in data
+        assert data["active_connections"] == 50
+
+
+# =============================================================================
+# NodeQoSState
+# =============================================================================
+
+
+class TestNodeQoSState:
+    """Tests for per-node QoS state."""
+
+    def test_to_dict(self) -> None:
+        score = ContributionScore(node_id="test")
+        state = NodeQoSState(node_id="test", score=score)
+        data = state.to_dict()
+        assert data["node_id"] == "test"
+        assert "score" in data
+        assert "tier" in data
+        assert "priority_value" in data
+        assert "is_in_grace_period" in data
+
+    def test_default_grace_period(self) -> None:
+        score = ContributionScore(node_id="test")
+        state = NodeQoSState(node_id="test", score=score)
+        assert state.is_in_grace_period is True
+
+
+# =============================================================================
+# QoSManager
+# =============================================================================
+
+
+class TestQoSManager:
+    """Tests for the QoS Manager."""
+
+    def test_create_with_defaults(self) -> None:
+        manager = QoSManager()
+        assert manager.node_count == 0
+        assert manager.policy is not None
+
+    def test_create_with_custom_policy(self) -> None:
+        policy = QoSPolicy(min_service_floor=0.2)
+        manager = QoSManager(policy=policy)
+        assert manager.policy.min_service_floor == 0.2
+
+    def test_get_or_create_new_node(self) -> None:
+        """First access should create a new node with defaults."""
+        manager = QoSManager()
+        state = manager.get_or_create_node("node-1")
+        assert state.node_id == "node-1"
+        assert state.is_in_grace_period is True
+        assert state.tier == PriorityTier.NORMAL
+        assert manager.node_count == 1
+
+    def test_get_or_create_existing_node(self) -> None:
+        """Second access should return existing node."""
+        manager = QoSManager()
+        state1 = manager.get_or_create_node("node-1")
+        state2 = manager.get_or_create_node("node-1")
+        assert state1 is state2
+        assert manager.node_count == 1
+
+    def test_update_score_single_dimension(self) -> None:
+        manager = QoSManager()
+        state = manager.update_score("node-1", ContributionDimension.ROUTING_CAPACITY, 0.9)
+        assert state.score.dimensions[ContributionDimension.ROUTING_CAPACITY] == 0.9
+
+    def test_update_scores_batch(self) -> None:
+        manager = QoSManager()
+        state = manager.update_scores_batch(
+            "node-1",
+            {
+                ContributionDimension.ROUTING_CAPACITY: 0.9,
+                ContributionDimension.UPTIME_RELIABILITY: 0.8,
+                ContributionDimension.BELIEF_QUALITY: 0.7,
+            },
+        )
+        assert state.score.dimensions[ContributionDimension.ROUTING_CAPACITY] == 0.9
+        assert state.score.dimensions[ContributionDimension.UPTIME_RELIABILITY] == 0.8
+        assert state.score.dimensions[ContributionDimension.BELIEF_QUALITY] == 0.7
+
+    def test_update_score_recomputes_tier(self) -> None:
+        """Updating a score should recompute the tier."""
+        manager = QoSManager()
+        # New user starts NORMAL (grace period)
+        state = manager.get_or_create_node("node-1")
+        assert state.tier == PriorityTier.NORMAL
+
+        # After grace period, with high score → HIGH
+        state.is_in_grace_period = False
+        manager.update_scores_batch(
+            "node-1",
+            {dim: 0.9 for dim in ContributionDimension},
+        )
+        assert state.tier == PriorityTier.HIGH
+
+    def test_get_priority(self) -> None:
+        manager = QoSManager()
+        priority = manager.get_priority("node-1")
+        assert 0.0 < priority <= 1.0
+
+    def test_get_tier(self) -> None:
+        manager = QoSManager()
+        tier = manager.get_tier("node-1")
+        assert isinstance(tier, PriorityTier)
+
+    def test_get_node_state_existing(self) -> None:
+        manager = QoSManager()
+        manager.get_or_create_node("node-1")
+        assert manager.get_node_state("node-1") is not None
+
+    def test_get_node_state_missing(self) -> None:
+        manager = QoSManager()
+        assert manager.get_node_state("nonexistent") is None
+
+    def test_update_load(self) -> None:
+        manager = QoSManager()
+        factor = manager.update_load(active_connections=50, max_connections=100, avg_queue_depth=25.0)
+        assert factor == pytest.approx(0.4, abs=1e-6)
+        assert manager.load_metrics.active_connections == 50
+
+    def test_update_load_recomputes_priorities(self) -> None:
+        """Updating load should recompute all node priorities."""
+        manager = QoSManager()
+
+        # Create a high-scoring node (not in grace)
+        state = manager.get_or_create_node("node-1")
+        state.is_in_grace_period = False
+        manager.update_scores_batch("node-1", {dim: 0.9 for dim in ContributionDimension})
+        initial_priority = state.priority_value
+
+        # Increase load
+        manager.update_load(active_connections=90, max_connections=100, avg_queue_depth=80.0)
+
+        # Priority may change but for a high-scoring node it should still be high
+        assert state.priority_value > 0.5
+        # The value should have been recomputed (may or may not differ)
+        assert isinstance(state.priority_value, float)
+        assert initial_priority > 0
+
+    def test_get_ranked_nodes(self) -> None:
+        """Nodes should be ranked by descending priority."""
+        manager = QoSManager()
+
+        # Create nodes with different scores
+        for node_id in ["low", "mid", "high"]:
+            state = manager.get_or_create_node(node_id)
+            state.is_in_grace_period = False
+
+        manager.update_scores_batch("high", {dim: 0.9 for dim in ContributionDimension})
+        manager.update_scores_batch("mid", {dim: 0.5 for dim in ContributionDimension})
+        manager.update_scores_batch("low", {dim: 0.1 for dim in ContributionDimension})
+
+        ranked = manager.get_ranked_nodes()
+        assert len(ranked) == 3
+        assert ranked[0].node_id == "high"
+        assert ranked[-1].node_id == "low"
+
+    def test_get_tier_summary(self) -> None:
+        manager = QoSManager()
+        for i in range(3):
+            manager.get_or_create_node(f"node-{i}")
+        summary = manager.get_tier_summary()
+        assert isinstance(summary, dict)
+        total = sum(summary.values())
+        assert total == 3
+
+    def test_get_status(self) -> None:
+        manager = QoSManager()
+        manager.get_or_create_node("node-1")
+        status = manager.get_status()
+        assert "policy" in status
+        assert "load" in status
+        assert "node_count" in status
+        assert status["node_count"] == 1
+        assert "tier_summary" in status
+        assert "current_steepness" in status
+
+    def test_remove_node(self) -> None:
+        manager = QoSManager()
+        manager.get_or_create_node("node-1")
+        assert manager.node_count == 1
+        assert manager.remove_node("node-1") is True
+        assert manager.node_count == 0
+        assert manager.remove_node("node-1") is False
+
+    def test_eviction_at_capacity(self) -> None:
+        """When at max capacity, the lowest-priority node should be evicted."""
+        manager = QoSManager(max_tracked_nodes=3)
+        for i in range(3):
+            state = manager.get_or_create_node(f"node-{i}")
+            state.is_in_grace_period = False
+
+        # Give node-2 the highest score
+        manager.update_scores_batch("node-2", {dim: 0.9 for dim in ContributionDimension})
+        # node-0 and node-1 have default low scores
+
+        # Adding a 4th node should evict the lowest
+        manager.get_or_create_node("node-3")
+        assert manager.node_count == 3
+        # node-2 should still be there (high priority)
+        assert manager.get_node_state("node-2") is not None
+
+    def test_grace_period_expiry(self) -> None:
+        """Grace period should expire after configured duration."""
+        policy = QoSPolicy(new_user_grace_period=0.0)  # Immediate expiry
+        manager = QoSManager(policy=policy)
+
+        state = manager.get_or_create_node("node-1")
+        assert state.is_in_grace_period is True
+
+        # Trigger recomputation (grace should expire since duration=0)
+        time.sleep(0.01)
+        manager.update_score("node-1", ContributionDimension.ROUTING_CAPACITY, 0.5)
+        assert state.is_in_grace_period is False
+
+    def test_grace_period_still_active(self) -> None:
+        """Node should stay in grace period within duration."""
+        policy = QoSPolicy(new_user_grace_period=3600.0)  # 1 hour
+        manager = QoSManager(policy=policy)
+
+        state = manager.get_or_create_node("node-1")
+        manager.update_score("node-1", ContributionDimension.ROUTING_CAPACITY, 0.5)
+        assert state.is_in_grace_period is True
+        assert state.tier == PriorityTier.NORMAL
+
+    def test_multiple_nodes_independent(self) -> None:
+        """Each node's state should be independent."""
+        manager = QoSManager()
+        manager.update_score("node-a", ContributionDimension.ROUTING_CAPACITY, 0.9)
+        manager.update_score("node-b", ContributionDimension.ROUTING_CAPACITY, 0.1)
+
+        assert manager.get_node_state("node-a").score.dimensions[ContributionDimension.ROUTING_CAPACITY] == 0.9
+        assert manager.get_node_state("node-b").score.dimensions[ContributionDimension.ROUTING_CAPACITY] == 0.1
+
+    def test_load_update_partial(self) -> None:
+        """Partial load updates should only change specified fields."""
+        manager = QoSManager()
+        manager.update_load(active_connections=50, max_connections=200)
+        assert manager.load_metrics.active_connections == 50
+        assert manager.load_metrics.max_connections == 200
+
+        # Update only queue depth
+        manager.update_load(avg_queue_depth=30.0)
+        assert manager.load_metrics.active_connections == 50  # Unchanged
+        assert manager.load_metrics.avg_queue_depth == 30.0


### PR DESCRIPTION
## Summary

Implements contribution-based QoS with dynamic deprioritization curve for the Valence network (Issue #276).

### Core Idea
At **low load**, everyone is treated equally. As load **increases**, the curve steepens — contributors get prioritized more sharply while free-riders are naturally deprioritized.

### What's Included

**Models** (`src/valence/network/qos.py`):
- `ContributionDimension` enum: routing_capacity, uptime_reliability, belief_quality, resource_sharing, trust_received
- `ContributionScore`: per-node scores across 5 dimensions, weighted-mean overall
- `QoSPolicy`: load-adaptive steepness curve (linear at low load → exponential at high load)
- `PriorityTier` enum with queue weights (CRITICAL → MINIMUM)
- Curve: `priority = base + score^steepness * (1 - base)`

**Service** (`src/valence/network/qos_manager.py`):
- `QoSManager`: tracks per-node contribution scores, computes dynamic priorities
- `LoadMetrics`: composite load factor from connections + queue depth
- New user grace period (configurable, default 1 hour)
- Batch score updates, node eviction at capacity, ranked listings

**CLI** (`src/valence/cli/commands/qos.py`):
- `valence qos status`: policy config, load metrics, tier breakdown
- `valence qos score [node_id]`: dimension scores, priority at various load levels

**Wiring**: Integrated into `network/__init__.py`, `cli/commands/__init__.py`, and `cli/main.py`

**Tests**: 85 tests covering models, manager, CLI parsing, and edge cases

Closes #276