### PR TITLE
feat: map VFP protocol onto libp2p streams (#301)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ htmlcov/
 .pytest_cache/
 coverage/
 coverage.json
+.mypy_cache/

--- a/src/valence/transport/message_codec.py
+++ b/src/valence/transport/message_codec.py
@@ -1,0 +1,300 @@
+"""
+Serialization codecs for VFP messages over libp2p.
+
+Two framing strategies:
+
+* **StreamCodec** — length-prefixed binary framing for 1:1 stream protocols
+  (sync, auth, trust).  Each frame is ``<4-byte big-endian length><JSON payload>``.
+
+* **GossipSubCodec** — plain UTF-8 JSON for pub/sub topics (beliefs, peers).
+  GossipSub already handles message boundaries, so no length prefix is needed.
+
+Both codecs reuse the existing federation message ``to_dict()`` / ``parse_message()``
+round-trip defined in ``valence.federation.protocol``.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from dataclasses import dataclass
+from typing import Any
+
+from valence.federation.protocol import ProtocolMessage, parse_message
+
+# Maximum allowed frame payload (8 MiB).  Protects against OOM from a
+# malicious peer sending a huge length prefix.
+MAX_FRAME_SIZE: int = 8 * 1024 * 1024
+
+# 4-byte big-endian unsigned int
+_LENGTH_STRUCT = struct.Struct("!I")
+FRAME_HEADER_SIZE: int = _LENGTH_STRUCT.size  # 4
+
+
+class CodecError(Exception):
+    """Raised when encoding or decoding fails."""
+
+
+# ============================================================================
+# Stream codec (length-prefixed JSON)
+# ============================================================================
+
+
+class StreamCodec:
+    """Length-prefixed JSON framing for libp2p stream protocols.
+
+    Wire format::
+
+        +-------------------+-----------------------------+
+        | 4 bytes (BE u32)  |  JSON payload (UTF-8)       |
+        | = payload length  |                             |
+        +-------------------+-----------------------------+
+
+    Usage::
+
+        codec = StreamCodec()
+
+        # Encode
+        frame = codec.encode_message(some_protocol_message)
+
+        # Decode (from a buffer that may contain partial data)
+        msg, consumed = codec.decode_frame(buffer)
+    """
+
+    # ------------------------------------------------------------------
+    # Encoding
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def encode(data: dict[str, Any]) -> bytes:
+        """Encode a dict as a length-prefixed JSON frame.
+
+        Args:
+            data: JSON-serializable dictionary.
+
+        Returns:
+            ``<4-byte length><JSON payload>`` bytes.
+
+        Raises:
+            CodecError: If the payload exceeds ``MAX_FRAME_SIZE``.
+        """
+        payload = json.dumps(data, separators=(",", ":"), default=str).encode("utf-8")
+        if len(payload) > MAX_FRAME_SIZE:
+            raise CodecError(f"Payload size {len(payload)} exceeds maximum {MAX_FRAME_SIZE}")
+        return _LENGTH_STRUCT.pack(len(payload)) + payload
+
+    @staticmethod
+    def encode_message(message: ProtocolMessage) -> bytes:
+        """Encode a ``ProtocolMessage`` as a length-prefixed frame.
+
+        Convenience wrapper around :meth:`encode` that calls ``message.to_dict()``
+        first.
+        """
+        return StreamCodec.encode(message.to_dict())
+
+    # ------------------------------------------------------------------
+    # Decoding
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def decode_frame(buf: bytes | bytearray | memoryview) -> tuple[dict[str, Any], int]:
+        """Decode one frame from *buf*.
+
+        Args:
+            buf: Buffer that starts with a length-prefixed frame (may contain
+                 trailing data).
+
+        Returns:
+            ``(parsed_dict, bytes_consumed)`` — the decoded dict and how many
+            bytes of *buf* were consumed.
+
+        Raises:
+            CodecError: If the frame is incomplete, oversized, or contains
+                invalid JSON.
+        """
+        if len(buf) < FRAME_HEADER_SIZE:
+            raise CodecError("Incomplete frame header")
+
+        (payload_len,) = _LENGTH_STRUCT.unpack_from(buf, 0)
+
+        if payload_len > MAX_FRAME_SIZE:
+            raise CodecError(f"Frame payload size {payload_len} exceeds maximum {MAX_FRAME_SIZE}")
+
+        total = FRAME_HEADER_SIZE + payload_len
+        if len(buf) < total:
+            raise CodecError(f"Incomplete frame body: need {total} bytes, have {len(buf)}")
+
+        payload_bytes = bytes(buf[FRAME_HEADER_SIZE:total])
+        try:
+            data = json.loads(payload_bytes)
+        except json.JSONDecodeError as exc:
+            raise CodecError(f"Invalid JSON in frame payload: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise CodecError(f"Expected JSON object, got {type(data).__name__}")
+
+        return data, total
+
+    @staticmethod
+    def decode_message(buf: bytes | bytearray | memoryview) -> tuple[ProtocolMessage | None, int]:
+        """Decode one frame and parse into a ``ProtocolMessage``.
+
+        Returns:
+            ``(message_or_None, bytes_consumed)``.  The message is ``None``
+            when the JSON is valid but does not match a known VFP message type.
+        """
+        data, consumed = StreamCodec.decode_frame(buf)
+        return parse_message(data), consumed
+
+    @staticmethod
+    def try_decode_frame(buf: bytes | bytearray | memoryview) -> tuple[dict[str, Any] | None, int]:
+        """Non-raising variant of :meth:`decode_frame`.
+
+        Returns ``(None, 0)`` when the buffer does not yet contain a
+        complete frame (useful when reading from a stream incrementally).
+
+        Raises:
+            CodecError: Only for *irrecoverable* errors (oversized frame,
+                bad JSON).  Incomplete data returns ``(None, 0)`` instead.
+        """
+        if len(buf) < FRAME_HEADER_SIZE:
+            return None, 0
+
+        (payload_len,) = _LENGTH_STRUCT.unpack_from(buf, 0)
+
+        if payload_len > MAX_FRAME_SIZE:
+            raise CodecError(f"Frame payload size {payload_len} exceeds maximum {MAX_FRAME_SIZE}")
+
+        total = FRAME_HEADER_SIZE + payload_len
+        if len(buf) < total:
+            return None, 0
+
+        payload_bytes = bytes(buf[FRAME_HEADER_SIZE:total])
+        try:
+            data = json.loads(payload_bytes)
+        except json.JSONDecodeError as exc:
+            raise CodecError(f"Invalid JSON in frame payload: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise CodecError(f"Expected JSON object, got {type(data).__name__}")
+
+        return data, total
+
+
+# ============================================================================
+# GossipSub codec (plain JSON)
+# ============================================================================
+
+
+class GossipSubCodec:
+    """Plain JSON codec for GossipSub messages.
+
+    GossipSub already handles message delimiting, so we just need
+    JSON ↔ bytes conversion.
+    """
+
+    @staticmethod
+    def encode(data: dict[str, Any]) -> bytes:
+        """Encode a dict as compact JSON bytes.
+
+        Args:
+            data: JSON-serializable dictionary.
+
+        Returns:
+            UTF-8 encoded JSON bytes.
+
+        Raises:
+            CodecError: If the payload exceeds ``MAX_FRAME_SIZE``.
+        """
+        payload = json.dumps(data, separators=(",", ":"), default=str).encode("utf-8")
+        if len(payload) > MAX_FRAME_SIZE:
+            raise CodecError(f"Payload size {len(payload)} exceeds maximum {MAX_FRAME_SIZE}")
+        return payload
+
+    @staticmethod
+    def encode_message(message: ProtocolMessage) -> bytes:
+        """Encode a ``ProtocolMessage`` as GossipSub JSON."""
+        return GossipSubCodec.encode(message.to_dict())
+
+    @staticmethod
+    def decode(data: bytes) -> dict[str, Any]:
+        """Decode GossipSub message bytes into a dict.
+
+        Args:
+            data: UTF-8 JSON bytes.
+
+        Returns:
+            Parsed dictionary.
+
+        Raises:
+            CodecError: If the data is not valid JSON or exceeds size limits.
+        """
+        if len(data) > MAX_FRAME_SIZE:
+            raise CodecError(f"Message size {len(data)} exceeds maximum {MAX_FRAME_SIZE}")
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise CodecError(f"Invalid JSON in GossipSub message: {exc}") from exc
+
+        if not isinstance(parsed, dict):
+            raise CodecError(f"Expected JSON object, got {type(parsed).__name__}")
+
+        return parsed
+
+    @staticmethod
+    def decode_message(data: bytes) -> ProtocolMessage | None:
+        """Decode GossipSub bytes and parse into a ``ProtocolMessage``.
+
+        Returns ``None`` if the JSON is valid but not a recognised VFP type.
+        """
+        return parse_message(GossipSubCodec.decode(data))
+
+
+# ============================================================================
+# Streaming buffer helper
+# ============================================================================
+
+
+@dataclass
+class StreamBuffer:
+    """Accumulates bytes from a libp2p stream and yields complete frames.
+
+    Typical usage in an async read loop::
+
+        buf = StreamBuffer()
+        async for chunk in stream:
+            buf.feed(chunk)
+            for msg_dict in buf.drain():
+                handle(msg_dict)
+    """
+
+    _buf: bytearray
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+
+    def feed(self, data: bytes | bytearray | memoryview) -> None:
+        """Append incoming bytes."""
+        self._buf.extend(data)
+
+    def drain(self) -> list[dict[str, Any]]:
+        """Extract all complete frames currently in the buffer.
+
+        Returns:
+            List of decoded dicts (may be empty).
+
+        Raises:
+            CodecError: On irrecoverable decoding errors.
+        """
+        results: list[dict[str, Any]] = []
+        while True:
+            parsed, consumed = StreamCodec.try_decode_frame(self._buf)
+            if parsed is None:
+                break
+            results.append(parsed)
+            del self._buf[:consumed]
+        return results
+
+    def __len__(self) -> int:
+        """Current buffer size in bytes."""
+        return len(self._buf)

--- a/src/valence/transport/protocol_handler.py
+++ b/src/valence/transport/protocol_handler.py
@@ -1,0 +1,567 @@
+"""
+Protocol handlers that translate between VFP message types and libp2p streams.
+
+Each handler owns one libp2p protocol ID and implements:
+
+* ``protocol_id`` — the protocol string to register with the libp2p host.
+* ``handle_stream(stream)`` — called when a remote peer opens a stream for
+  this protocol (inbound).
+* ``open_stream(host, peer_id, request)`` — opens a new stream to *peer_id*
+  and sends *request*, returning the response (outbound).
+
+GossipSub handlers implement ``handle_message`` / ``publish`` instead.
+
+All handlers reuse the existing VFP request/response dataclasses from
+``valence.federation.protocol`` and the codecs from
+``valence.transport.message_codec``.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+from uuid import UUID
+
+from valence.federation.protocol import (
+    AuthChallengeRequest,
+    AuthVerifyRequest,
+    ErrorMessage,
+    MessageType,
+    ProtocolMessage,
+    RequestBeliefsRequest,
+    ShareBeliefRequest,
+    SyncRequest,
+    TrustAttestationRequest,
+    parse_message,
+)
+from valence.transport.message_codec import (
+    CodecError,
+    GossipSubCodec,
+    StreamBuffer,
+    StreamCodec,
+)
+from valence.transport.protocols import (
+    VALENCE_AUTH_PROTOCOL,
+    VALENCE_BELIEFS_TOPIC,
+    VALENCE_PEERS_TOPIC,
+    VALENCE_SYNC_PROTOCOL,
+    VALENCE_TRUST_PROTOCOL,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Abstract stream / libp2p interfaces (thin typing shims)
+# ============================================================================
+# These protocols define the minimal surface we need from a libp2p
+# implementation (e.g. py-libp2p, a Rust FFI bridge, or a mock in tests).
+
+
+@runtime_checkable
+class IStream(Protocol):
+    """Minimal async stream interface expected by handlers."""
+
+    async def read(self, n: int = -1) -> bytes: ...
+    async def write(self, data: bytes) -> None: ...
+    async def close(self) -> None: ...
+
+
+@runtime_checkable
+class IHost(Protocol):
+    """Minimal libp2p host interface expected by handlers."""
+
+    async def new_stream(self, peer_id: str, protocols: list[str]) -> IStream: ...
+
+
+@runtime_checkable
+class IPubSub(Protocol):
+    """Minimal GossipSub interface expected by handlers."""
+
+    async def publish(self, topic: str, data: bytes) -> None: ...
+    async def subscribe(self, topic: str) -> Any: ...
+
+
+# ============================================================================
+# Base handler
+# ============================================================================
+
+
+class BaseStreamHandler(ABC):
+    """Base class for libp2p stream protocol handlers.
+
+    Subclasses must implement :meth:`_dispatch` which receives a parsed
+    request dict and returns a response dict (or ``None`` to send nothing).
+    """
+
+    @property
+    @abstractmethod
+    def protocol_id(self) -> str:
+        """The libp2p protocol string this handler serves."""
+
+    async def handle_stream(self, stream: IStream) -> None:
+        """Read one request from *stream*, dispatch it, and write the response.
+
+        This follows the simple request/response pattern used by VFP stream
+        protocols.  Multi-message exchanges (e.g. auth challenge + verify)
+        are modelled as separate stream opens by the initiator.
+        """
+        buf = StreamBuffer()
+        try:
+            # Read until we have one complete frame
+            while True:
+                chunk = await stream.read(65536)
+                if not chunk:
+                    break
+                buf.feed(chunk)
+                frames = buf.drain()
+                if frames:
+                    break
+
+            if not frames:
+                logger.warning("%s: stream closed before a complete frame", self.protocol_id)
+                return
+
+            request_dict = frames[0]
+            response_dict = await self._dispatch(request_dict)
+
+            if response_dict is not None:
+                await stream.write(StreamCodec.encode(response_dict))
+        except CodecError as exc:
+            logger.warning("%s: codec error: %s", self.protocol_id, exc)
+            err = ErrorMessage(message=str(exc)).to_dict()
+            try:
+                await stream.write(StreamCodec.encode(err))
+            except Exception:
+                pass
+        except Exception:
+            logger.exception("%s: unhandled error in stream handler", self.protocol_id)
+        finally:
+            try:
+                await stream.close()
+            except Exception:
+                pass
+
+    async def send_request(
+        self,
+        host: IHost,
+        peer_id: str,
+        request: ProtocolMessage,
+    ) -> dict[str, Any] | None:
+        """Open a stream to *peer_id*, send *request*, and return the response dict.
+
+        Returns ``None`` if the peer closes the stream without a response.
+        """
+        stream = await host.new_stream(peer_id, [self.protocol_id])
+        try:
+            await stream.write(StreamCodec.encode_message(request))
+
+            buf = StreamBuffer()
+            while True:
+                chunk = await stream.read(65536)
+                if not chunk:
+                    break
+                buf.feed(chunk)
+                frames = buf.drain()
+                if frames:
+                    return frames[0]
+            return None
+        finally:
+            try:
+                await stream.close()
+            except Exception:
+                pass
+
+    @abstractmethod
+    async def _dispatch(self, request: dict[str, Any]) -> dict[str, Any] | None:
+        """Handle a parsed request dict and return the response dict."""
+
+
+# ============================================================================
+# Sync protocol handler
+# ============================================================================
+
+
+class SyncProtocolHandler(BaseStreamHandler):
+    """Handles belief sync, share, and request over ``/valence/sync/1.0.0``.
+
+    Dispatches to the existing VFP handlers in ``valence.federation.protocol``:
+
+    * ``SYNC_REQUEST`` → ``handle_sync_request``
+    * ``SHARE_BELIEF`` → ``handle_share_belief``
+    * ``REQUEST_BELIEFS`` → ``handle_request_beliefs``
+    """
+
+    def __init__(
+        self,
+        *,
+        get_sender_node_id: Any | None = None,
+        get_sender_trust: Any | None = None,
+    ) -> None:
+        self._get_sender_node_id = get_sender_node_id
+        self._get_sender_trust = get_sender_trust
+
+    @property
+    def protocol_id(self) -> str:
+        return VALENCE_SYNC_PROTOCOL
+
+    async def _dispatch(self, request: dict[str, Any]) -> dict[str, Any] | None:
+        msg = parse_message(request)
+        if msg is None:
+            return ErrorMessage(message="Unparseable message").to_dict()
+
+        sender_node_id = self._resolve_sender_node_id(request)
+        sender_trust = self._resolve_sender_trust(sender_node_id)
+
+        if sender_node_id is None:
+            return ErrorMessage(message="Sender identification required").to_dict()
+
+        if isinstance(msg, SyncRequest):
+            from valence.federation.protocol import handle_sync_request
+
+            result = handle_sync_request(msg, sender_node_id, sender_trust)
+            return result.to_dict()
+
+        if isinstance(msg, ShareBeliefRequest):
+            from valence.federation.protocol import handle_share_belief
+
+            share_result = handle_share_belief(msg, sender_node_id, sender_trust)
+            return share_result.to_dict()
+
+        if isinstance(msg, RequestBeliefsRequest):
+            from valence.federation.protocol import handle_request_beliefs
+
+            beliefs_result = handle_request_beliefs(msg, sender_node_id, sender_trust)
+            return beliefs_result.to_dict()
+
+        return ErrorMessage(message=f"Unexpected message type for sync protocol: {msg.type}").to_dict()
+
+    # -- sender resolution helpers (pluggable via constructor) ---------------
+
+    def _resolve_sender_node_id(self, request: dict[str, Any]) -> UUID | None:
+        if self._get_sender_node_id is not None:
+            return self._get_sender_node_id(request)
+        raw = request.get("sender_node_id")
+        if raw is not None:
+            return UUID(raw) if isinstance(raw, str) else raw
+        return None
+
+    def _resolve_sender_trust(self, node_id: UUID | None) -> float:
+        if self._get_sender_trust is not None and node_id is not None:
+            return self._get_sender_trust(node_id)
+        return 0.1  # Observer-level default
+
+
+# ============================================================================
+# Auth protocol handler
+# ============================================================================
+
+
+class AuthProtocolHandler(BaseStreamHandler):
+    """Handles DID auth challenge/verify over ``/valence/auth/1.0.0``.
+
+    Dispatches:
+
+    * ``AUTH_CHALLENGE`` → ``create_auth_challenge``
+    * ``AUTH_VERIFY`` → ``verify_auth_challenge``
+    """
+
+    @property
+    def protocol_id(self) -> str:
+        return VALENCE_AUTH_PROTOCOL
+
+    async def _dispatch(self, request: dict[str, Any]) -> dict[str, Any] | None:
+        msg = parse_message(request)
+        if msg is None:
+            return ErrorMessage(message="Unparseable auth message").to_dict()
+
+        if isinstance(msg, AuthChallengeRequest):
+            from valence.federation.protocol import create_auth_challenge
+
+            response = create_auth_challenge(msg.client_did)
+            return response.to_dict()
+
+        if isinstance(msg, AuthVerifyRequest):
+            # Look up the client's public key to verify the signature
+            public_key = self._lookup_public_key(msg.client_did)
+            if public_key is None:
+                return ErrorMessage(message=f"Unknown node: {msg.client_did}").to_dict()
+
+            from valence.federation.protocol import verify_auth_challenge
+
+            verify_response = verify_auth_challenge(
+                client_did=msg.client_did,
+                challenge=msg.challenge,
+                signature=msg.signature,
+                public_key_multibase=public_key,
+            )
+            return verify_response.to_dict()
+
+        return ErrorMessage(message=f"Unexpected message type for auth protocol: {msg.type}").to_dict()
+
+    @staticmethod
+    def _lookup_public_key(client_did: str) -> str | None:
+        """Look up a node's public key by DID.
+
+        Attempts a database lookup first; returns ``None`` if the node
+        is not known.
+        """
+        try:
+            from valence.core.db import get_cursor
+
+            with get_cursor() as cur:
+                cur.execute(
+                    "SELECT public_key_multibase FROM federation_nodes WHERE did = %s",
+                    (client_did,),
+                )
+                row = cur.fetchone()
+                return row["public_key_multibase"] if row else None
+        except Exception:
+            logger.debug("Could not look up public key for %s", client_did)
+            return None
+
+
+# ============================================================================
+# Trust protocol handler
+# ============================================================================
+
+
+class TrustProtocolHandler(BaseStreamHandler):
+    """Handles trust attestation exchange over ``/valence/trust/1.0.0``.
+
+    Dispatches:
+
+    * ``TRUST_ATTESTATION`` → internal trust processing
+    """
+
+    def __init__(
+        self,
+        *,
+        get_sender_node_id: Any | None = None,
+        get_sender_trust: Any | None = None,
+    ) -> None:
+        self._get_sender_node_id = get_sender_node_id
+        self._get_sender_trust = get_sender_trust
+
+    @property
+    def protocol_id(self) -> str:
+        return VALENCE_TRUST_PROTOCOL
+
+    async def _dispatch(self, request: dict[str, Any]) -> dict[str, Any] | None:
+        msg = parse_message(request)
+        if msg is None:
+            return ErrorMessage(message="Unparseable trust message").to_dict()
+
+        if isinstance(msg, TrustAttestationRequest):
+            sender_node_id = self._resolve_sender_node_id(request)
+            sender_trust = self._resolve_sender_trust(sender_node_id)
+
+            if sender_node_id is None:
+                return ErrorMessage(message="Sender identification required").to_dict()
+
+            # Delegate to the existing VFP handler (sync, not async)
+            from valence.federation.protocol import _handle_trust_attestation
+
+            result = _handle_trust_attestation(msg, sender_node_id, sender_trust)
+            return result.to_dict()
+
+        return ErrorMessage(message=f"Unexpected message type for trust protocol: {msg.type}").to_dict()
+
+    def _resolve_sender_node_id(self, request: dict[str, Any]) -> UUID | None:
+        if self._get_sender_node_id is not None:
+            return self._get_sender_node_id(request)
+        raw = request.get("sender_node_id")
+        if raw is not None:
+            return UUID(raw) if isinstance(raw, str) else raw
+        return None
+
+    def _resolve_sender_trust(self, node_id: UUID | None) -> float:
+        if self._get_sender_trust is not None and node_id is not None:
+            return self._get_sender_trust(node_id)
+        return 0.1
+
+
+# ============================================================================
+# GossipSub handler: belief propagation
+# ============================================================================
+
+
+@dataclass
+class BeliefPropagationHandler:
+    """GossipSub handler for the ``/valence/beliefs`` topic.
+
+    Encodes outbound beliefs as JSON for GossipSub publish and decodes
+    inbound messages, dispatching them through the VFP ``SHARE_BELIEF``
+    handler path.
+    """
+
+    topic: str = VALENCE_BELIEFS_TOPIC
+    _pubsub: IPubSub | None = None
+
+    # Optional hooks for sender resolution (same pattern as stream handlers)
+    get_sender_node_id: Any | None = None
+    get_sender_trust: Any | None = None
+
+    async def handle_message(self, data: bytes) -> dict[str, Any] | None:
+        """Process an inbound GossipSub message.
+
+        Args:
+            data: Raw bytes from the GossipSub subscription.
+
+        Returns:
+            The response dict from belief processing, or ``None`` on error.
+        """
+        try:
+            msg_dict = GossipSubCodec.decode(data)
+        except CodecError as exc:
+            logger.warning("beliefs topic: codec error: %s", exc)
+            return None
+
+        msg = parse_message(msg_dict)
+        if msg is None:
+            # Might be a raw belief dict rather than a wrapped VFP message.
+            # Wrap it as a SHARE_BELIEF for processing.
+            if "content" in msg_dict and "origin_node_did" in msg_dict:
+                msg_dict = {
+                    "type": MessageType.SHARE_BELIEF.value,
+                    "beliefs": [msg_dict],
+                }
+                msg = parse_message(msg_dict)
+
+        if not isinstance(msg, ShareBeliefRequest):
+            logger.debug("beliefs topic: ignoring non-SHARE_BELIEF message")
+            return None
+
+        sender_node_id = self._resolve_sender_node_id(msg_dict)
+        sender_trust = self._resolve_sender_trust(sender_node_id)
+
+        if sender_node_id is None:
+            logger.warning("beliefs topic: could not identify sender")
+            return None
+
+        from valence.federation.protocol import handle_share_belief
+
+        result = handle_share_belief(msg, sender_node_id, sender_trust)
+        return result.to_dict()
+
+    async def publish_belief(
+        self,
+        pubsub: IPubSub | None = None,
+        belief_dict: dict[str, Any] | None = None,
+        message: ProtocolMessage | None = None,
+    ) -> None:
+        """Publish a belief (or VFP message) to the beliefs topic.
+
+        Provide *either* ``belief_dict`` (raw belief data that will be
+        wrapped in a ``SHARE_BELIEF`` envelope) or ``message`` (a fully
+        formed ``ProtocolMessage``).
+        """
+        ps = pubsub or self._pubsub
+        if ps is None:
+            raise RuntimeError("No PubSub instance configured")
+
+        if message is not None:
+            payload = GossipSubCodec.encode_message(message)
+        elif belief_dict is not None:
+            envelope = {
+                "type": MessageType.SHARE_BELIEF.value,
+                "beliefs": [belief_dict],
+            }
+            payload = GossipSubCodec.encode(envelope)
+        else:
+            raise ValueError("Provide belief_dict or message")
+
+        await ps.publish(self.topic, payload)
+
+    def _resolve_sender_node_id(self, msg_dict: dict[str, Any]) -> UUID | None:
+        if self.get_sender_node_id is not None:
+            return self.get_sender_node_id(msg_dict)
+        raw = msg_dict.get("sender_node_id")
+        if raw is not None:
+            return UUID(raw) if isinstance(raw, str) else raw
+        return None
+
+    def _resolve_sender_trust(self, node_id: UUID | None) -> float:
+        if self.get_sender_trust is not None and node_id is not None:
+            return self.get_sender_trust(node_id)
+        return 0.1
+
+
+# ============================================================================
+# GossipSub handler: peer discovery
+# ============================================================================
+
+
+@dataclass
+class PeerDiscoveryHandler:
+    """GossipSub handler for the ``/valence/peers`` topic.
+
+    Handles peer announcement messages (node joining, capabilities update).
+    """
+
+    topic: str = VALENCE_PEERS_TOPIC
+    _pubsub: IPubSub | None = None
+
+    async def handle_message(self, data: bytes) -> dict[str, Any] | None:
+        """Process an inbound peer announcement.
+
+        Returns the parsed announcement dict for the caller to act on.
+        """
+        try:
+            return GossipSubCodec.decode(data)
+        except CodecError as exc:
+            logger.warning("peers topic: codec error: %s", exc)
+            return None
+
+    async def publish_announcement(
+        self,
+        pubsub: IPubSub | None = None,
+        announcement: dict[str, Any] | None = None,
+    ) -> None:
+        """Publish a peer announcement to the peers topic."""
+        ps = pubsub or self._pubsub
+        if ps is None:
+            raise RuntimeError("No PubSub instance configured")
+        if announcement is None:
+            raise ValueError("Provide announcement dict")
+        await ps.publish(self.topic, GossipSubCodec.encode(announcement))
+
+
+# ============================================================================
+# Registry convenience
+# ============================================================================
+
+
+def create_handlers(
+    *,
+    get_sender_node_id: Any | None = None,
+    get_sender_trust: Any | None = None,
+) -> dict[str, BaseStreamHandler | BeliefPropagationHandler | PeerDiscoveryHandler]:
+    """Create all protocol handlers with shared sender resolution hooks.
+
+    Returns a dict keyed by protocol ID / topic string.
+    """
+    sync = SyncProtocolHandler(
+        get_sender_node_id=get_sender_node_id,
+        get_sender_trust=get_sender_trust,
+    )
+    auth = AuthProtocolHandler()
+    trust = TrustProtocolHandler(
+        get_sender_node_id=get_sender_node_id,
+        get_sender_trust=get_sender_trust,
+    )
+    beliefs = BeliefPropagationHandler(
+        get_sender_node_id=get_sender_node_id,
+        get_sender_trust=get_sender_trust,
+    )
+    peers = PeerDiscoveryHandler()
+
+    return {
+        sync.protocol_id: sync,
+        auth.protocol_id: auth,
+        trust.protocol_id: trust,
+        beliefs.topic: beliefs,
+        peers.topic: peers,
+    }

--- a/src/valence/transport/protocols.py
+++ b/src/valence/transport/protocols.py
@@ -1,0 +1,86 @@
+"""
+Protocol identifiers for Valence over libp2p.
+
+Stream protocols follow the libp2p convention ``/<name>/<version>``.
+GossipSub topics use ``/<name>`` (no version; topic evolution is handled
+via message schema versions inside the payload).
+
+These constants are the canonical source of truth — import them from
+``valence.transport.protocols`` everywhere.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Stream protocols (request/response over a dedicated libp2p stream)
+# ---------------------------------------------------------------------------
+
+VALENCE_SYNC_PROTOCOL: str = "/valence/sync/1.0.0"
+"""Belief synchronisation between peers (SYNC_REQUEST / SYNC_RESPONSE)."""
+
+VALENCE_AUTH_PROTOCOL: str = "/valence/auth/1.0.0"
+"""DID-based authentication challenge/verify handshake."""
+
+VALENCE_TRUST_PROTOCOL: str = "/valence/trust/1.0.0"
+"""Trust attestation exchange (TRUST_ATTESTATION / response)."""
+
+# ---------------------------------------------------------------------------
+# GossipSub topics (pub/sub broadcast)
+# ---------------------------------------------------------------------------
+
+VALENCE_BELIEFS_TOPIC: str = "/valence/beliefs"
+"""GossipSub topic for broadcasting new/updated beliefs to the mesh."""
+
+VALENCE_PEERS_TOPIC: str = "/valence/peers"
+"""GossipSub topic for peer discovery announcements."""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ALL_STREAM_PROTOCOLS: list[str] = [
+    VALENCE_SYNC_PROTOCOL,
+    VALENCE_AUTH_PROTOCOL,
+    VALENCE_TRUST_PROTOCOL,
+]
+"""Every stream protocol this node should register on startup."""
+
+ALL_GOSSIPSUB_TOPICS: list[str] = [
+    VALENCE_BELIEFS_TOPIC,
+    VALENCE_PEERS_TOPIC,
+]
+"""Every GossipSub topic this node should subscribe to on startup."""
+
+
+def protocol_for_message_type(message_type: str) -> str | None:
+    """Map a VFP ``MessageType`` value to its libp2p protocol ID.
+
+    Returns ``None`` for message types that are carried over GossipSub
+    rather than a dedicated stream.
+
+    >>> protocol_for_message_type("SYNC_REQUEST")
+    '/valence/sync/1.0.0'
+    >>> protocol_for_message_type("AUTH_CHALLENGE")
+    '/valence/auth/1.0.0'
+    >>> protocol_for_message_type("TRUST_ATTESTATION")
+    '/valence/trust/1.0.0'
+    """
+    mapping: dict[str, str] = {
+        # Sync
+        "SYNC_REQUEST": VALENCE_SYNC_PROTOCOL,
+        "SYNC_RESPONSE": VALENCE_SYNC_PROTOCOL,
+        # Auth
+        "AUTH_CHALLENGE": VALENCE_AUTH_PROTOCOL,
+        "AUTH_CHALLENGE_RESPONSE": VALENCE_AUTH_PROTOCOL,
+        "AUTH_VERIFY": VALENCE_AUTH_PROTOCOL,
+        "AUTH_VERIFY_RESPONSE": VALENCE_AUTH_PROTOCOL,
+        # Trust
+        "TRUST_ATTESTATION": VALENCE_TRUST_PROTOCOL,
+        "TRUST_ATTESTATION_RESPONSE": VALENCE_TRUST_PROTOCOL,
+        # Beliefs (share/request also use sync stream)
+        "SHARE_BELIEF": VALENCE_SYNC_PROTOCOL,
+        "SHARE_BELIEF_RESPONSE": VALENCE_SYNC_PROTOCOL,
+        "REQUEST_BELIEFS": VALENCE_SYNC_PROTOCOL,
+        "BELIEFS_RESPONSE": VALENCE_SYNC_PROTOCOL,
+    }
+    return mapping.get(message_type)

--- a/tests/transport/test_message_codec.py
+++ b/tests/transport/test_message_codec.py
@@ -1,0 +1,262 @@
+"""Tests for valence.transport.message_codec — serialization codecs."""
+
+from __future__ import annotations
+
+import json
+import struct
+
+import pytest
+
+from valence.federation.protocol import (
+    AuthChallengeRequest,
+    SyncRequest,
+)
+from valence.transport.message_codec import (
+    MAX_FRAME_SIZE,
+    CodecError,
+    GossipSubCodec,
+    StreamBuffer,
+    StreamCodec,
+)
+
+# ============================================================================
+# StreamCodec — length-prefixed framing
+# ============================================================================
+
+
+class TestStreamCodecEncode:
+    """StreamCodec.encode / encode_message."""
+
+    def test_encode_basic_dict(self) -> None:
+        data = {"type": "SYNC_REQUEST", "page_size": 100}
+        frame = StreamCodec.encode(data)
+
+        # First 4 bytes = big-endian u32 length
+        payload_len = struct.unpack("!I", frame[:4])[0]
+        payload = frame[4:]
+        assert len(payload) == payload_len
+
+        # Payload is valid JSON
+        decoded = json.loads(payload)
+        assert decoded["type"] == "SYNC_REQUEST"
+        assert decoded["page_size"] == 100
+
+    def test_encode_message(self) -> None:
+        msg = SyncRequest(page_size=50, domains=["science"])
+        frame = StreamCodec.encode_message(msg)
+
+        payload = json.loads(frame[4:])
+        assert payload["type"] == "SYNC_REQUEST"
+        assert payload["page_size"] == 50
+        assert payload["domains"] == ["science"]
+
+    def test_encode_rejects_oversized_payload(self) -> None:
+        data = {"big": "x" * (MAX_FRAME_SIZE + 1)}
+        with pytest.raises(CodecError, match="exceeds maximum"):
+            StreamCodec.encode(data)
+
+
+class TestStreamCodecDecode:
+    """StreamCodec.decode_frame / decode_message."""
+
+    def test_roundtrip(self) -> None:
+        original = {"type": "AUTH_CHALLENGE", "client_did": "did:vkb:web:test"}
+        frame = StreamCodec.encode(original)
+        decoded, consumed = StreamCodec.decode_frame(frame)
+        assert decoded == original
+        assert consumed == len(frame)
+
+    def test_message_roundtrip(self) -> None:
+        msg = AuthChallengeRequest(client_did="did:vkb:web:alice")
+        frame = StreamCodec.encode_message(msg)
+        parsed, consumed = StreamCodec.decode_message(frame)
+        assert parsed is not None
+        assert isinstance(parsed, AuthChallengeRequest)
+        assert parsed.client_did == "did:vkb:web:alice"
+        assert consumed == len(frame)
+
+    def test_decode_with_trailing_data(self) -> None:
+        frame = StreamCodec.encode({"a": 1})
+        buf = frame + b"extra_data"
+        decoded, consumed = StreamCodec.decode_frame(buf)
+        assert decoded == {"a": 1}
+        assert consumed == len(frame)
+
+    def test_decode_incomplete_header_raises(self) -> None:
+        with pytest.raises(CodecError, match="Incomplete frame header"):
+            StreamCodec.decode_frame(b"\x00\x00")
+
+    def test_decode_incomplete_body_raises(self) -> None:
+        # Header says 100 bytes, but only 10 provided
+        header = struct.pack("!I", 100)
+        with pytest.raises(CodecError, match="Incomplete frame body"):
+            StreamCodec.decode_frame(header + b"x" * 10)
+
+    def test_decode_oversized_frame_raises(self) -> None:
+        header = struct.pack("!I", MAX_FRAME_SIZE + 1)
+        with pytest.raises(CodecError, match="exceeds maximum"):
+            StreamCodec.decode_frame(header + b"\x00" * 10)
+
+    def test_decode_invalid_json_raises(self) -> None:
+        bad_payload = b"not json"
+        header = struct.pack("!I", len(bad_payload))
+        with pytest.raises(CodecError, match="Invalid JSON"):
+            StreamCodec.decode_frame(header + bad_payload)
+
+    def test_decode_non_object_json_raises(self) -> None:
+        payload = b'"just a string"'
+        header = struct.pack("!I", len(payload))
+        with pytest.raises(CodecError, match="Expected JSON object"):
+            StreamCodec.decode_frame(header + payload)
+
+    def test_decode_unknown_message_type_returns_none(self) -> None:
+        frame = StreamCodec.encode({"type": "TOTALLY_UNKNOWN"})
+        msg, _ = StreamCodec.decode_message(frame)
+        assert msg is None
+
+
+class TestStreamCodecTryDecode:
+    """StreamCodec.try_decode_frame — non-raising variant."""
+
+    def test_returns_none_on_incomplete_header(self) -> None:
+        result, consumed = StreamCodec.try_decode_frame(b"\x00")
+        assert result is None
+        assert consumed == 0
+
+    def test_returns_none_on_incomplete_body(self) -> None:
+        header = struct.pack("!I", 100)
+        result, consumed = StreamCodec.try_decode_frame(header + b"x")
+        assert result is None
+        assert consumed == 0
+
+    def test_returns_data_on_complete_frame(self) -> None:
+        frame = StreamCodec.encode({"ok": True})
+        result, consumed = StreamCodec.try_decode_frame(frame)
+        assert result == {"ok": True}
+        assert consumed == len(frame)
+
+    def test_raises_on_bad_json(self) -> None:
+        payload = b"{bad"
+        header = struct.pack("!I", len(payload))
+        with pytest.raises(CodecError, match="Invalid JSON"):
+            StreamCodec.try_decode_frame(header + payload)
+
+
+# ============================================================================
+# GossipSubCodec — plain JSON
+# ============================================================================
+
+
+class TestGossipSubCodec:
+    """GossipSubCodec encode/decode."""
+
+    def test_roundtrip(self) -> None:
+        original = {"type": "SHARE_BELIEF", "beliefs": [{"content": "hello"}]}
+        encoded = GossipSubCodec.encode(original)
+        decoded = GossipSubCodec.decode(encoded)
+        assert decoded == original
+
+    def test_encode_is_compact(self) -> None:
+        data = {"a": 1, "b": 2}
+        encoded = GossipSubCodec.encode(data)
+        # No spaces in compact JSON
+        assert b" " not in encoded
+
+    def test_encode_rejects_oversized(self) -> None:
+        data = {"big": "x" * (MAX_FRAME_SIZE + 1)}
+        with pytest.raises(CodecError, match="exceeds maximum"):
+            GossipSubCodec.encode(data)
+
+    def test_decode_rejects_oversized(self) -> None:
+        with pytest.raises(CodecError, match="exceeds maximum"):
+            GossipSubCodec.decode(b"x" * (MAX_FRAME_SIZE + 1))
+
+    def test_decode_rejects_invalid_json(self) -> None:
+        with pytest.raises(CodecError, match="Invalid JSON"):
+            GossipSubCodec.decode(b"not json")
+
+    def test_decode_rejects_non_object(self) -> None:
+        with pytest.raises(CodecError, match="Expected JSON object"):
+            GossipSubCodec.decode(b"[1, 2, 3]")
+
+    def test_message_roundtrip(self) -> None:
+        msg = AuthChallengeRequest(client_did="did:vkb:web:bob")
+        encoded = GossipSubCodec.encode_message(msg)
+        parsed = GossipSubCodec.decode_message(encoded)
+        assert parsed is not None
+        assert isinstance(parsed, AuthChallengeRequest)
+        assert parsed.client_did == "did:vkb:web:bob"
+
+    def test_decode_unknown_type_returns_none(self) -> None:
+        encoded = GossipSubCodec.encode({"type": "UNKNOWN"})
+        assert GossipSubCodec.decode_message(encoded) is None
+
+
+# ============================================================================
+# StreamBuffer — incremental frame decoder
+# ============================================================================
+
+
+class TestStreamBuffer:
+    """StreamBuffer accumulation and draining."""
+
+    def test_single_complete_frame(self) -> None:
+        buf = StreamBuffer()
+        frame = StreamCodec.encode({"msg": "hello"})
+        buf.feed(frame)
+        results = buf.drain()
+        assert len(results) == 1
+        assert results[0]["msg"] == "hello"
+
+    def test_incremental_feeding(self) -> None:
+        buf = StreamBuffer()
+        frame = StreamCodec.encode({"step": "incremental"})
+
+        # Feed byte by byte (worst case)
+        for i in range(len(frame) - 1):
+            buf.feed(frame[i : i + 1])
+            assert buf.drain() == []  # Not complete yet
+
+        buf.feed(frame[-1:])
+        results = buf.drain()
+        assert len(results) == 1
+        assert results[0]["step"] == "incremental"
+
+    def test_multiple_frames_in_one_feed(self) -> None:
+        buf = StreamBuffer()
+        f1 = StreamCodec.encode({"n": 1})
+        f2 = StreamCodec.encode({"n": 2})
+        f3 = StreamCodec.encode({"n": 3})
+
+        buf.feed(f1 + f2 + f3)
+        results = buf.drain()
+        assert len(results) == 3
+        assert [r["n"] for r in results] == [1, 2, 3]
+
+    def test_partial_frame_preserved(self) -> None:
+        buf = StreamBuffer()
+        f1 = StreamCodec.encode({"n": 1})
+        f2 = StreamCodec.encode({"n": 2})
+
+        # Feed first frame + half of second
+        half = len(f2) // 2
+        buf.feed(f1 + f2[:half])
+        results = buf.drain()
+        assert len(results) == 1
+        assert results[0]["n"] == 1
+
+        # Feed rest of second frame
+        buf.feed(f2[half:])
+        results = buf.drain()
+        assert len(results) == 1
+        assert results[0]["n"] == 2
+
+    def test_len_tracks_buffer_size(self) -> None:
+        buf = StreamBuffer()
+        assert len(buf) == 0
+        buf.feed(b"hello")
+        assert len(buf) == 5
+
+    def test_empty_drain(self) -> None:
+        buf = StreamBuffer()
+        assert buf.drain() == []

--- a/tests/transport/test_protocol_handler.py
+++ b/tests/transport/test_protocol_handler.py
@@ -1,0 +1,435 @@
+"""Tests for valence.transport.protocol_handler — handler dispatch."""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+
+from valence.federation.protocol import (
+    AuthChallengeRequest,
+    ShareBeliefRequest,
+    SyncRequest,
+    TrustAttestationRequest,
+)
+from valence.transport.message_codec import GossipSubCodec, StreamCodec
+from valence.transport.protocol_handler import (
+    AuthProtocolHandler,
+    BeliefPropagationHandler,
+    PeerDiscoveryHandler,
+    SyncProtocolHandler,
+    TrustProtocolHandler,
+    create_handlers,
+)
+from valence.transport.protocols import (
+    VALENCE_AUTH_PROTOCOL,
+    VALENCE_BELIEFS_TOPIC,
+    VALENCE_PEERS_TOPIC,
+    VALENCE_SYNC_PROTOCOL,
+    VALENCE_TRUST_PROTOCOL,
+)
+
+# ============================================================================
+# Helpers — fake stream / host / pubsub
+# ============================================================================
+
+
+class FakeStream:
+    """In-memory async stream for testing."""
+
+    def __init__(self, inbound: bytes = b"") -> None:
+        self._inbound = bytearray(inbound)
+        self._outbound = bytearray()
+        self._closed = False
+
+    async def read(self, n: int = -1) -> bytes:
+        if not self._inbound:
+            return b""
+        if n < 0:
+            data = bytes(self._inbound)
+            self._inbound.clear()
+            return data
+        data = bytes(self._inbound[:n])
+        del self._inbound[:n]
+        return data
+
+    async def write(self, data: bytes) -> None:
+        self._outbound.extend(data)
+
+    async def close(self) -> None:
+        self._closed = True
+
+    @property
+    def outbound_bytes(self) -> bytes:
+        return bytes(self._outbound)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+
+class FakeHost:
+    """In-memory host that returns a FakeStream with predetermined response."""
+
+    def __init__(self, response_data: bytes = b"") -> None:
+        self._response_data = response_data
+        self.opened_streams: list[tuple[str, list[str]]] = []
+
+    async def new_stream(self, peer_id: str, protocols: list[str]) -> FakeStream:
+        self.opened_streams.append((peer_id, protocols))
+        return FakeStream(inbound=self._response_data)
+
+
+class FakePubSub:
+    """In-memory PubSub for testing."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes]] = []
+
+    async def publish(self, topic: str, data: bytes) -> None:
+        self.published.append((topic, data))
+
+    async def subscribe(self, topic: str) -> None:
+        return None
+
+
+# ============================================================================
+# Protocol IDs
+# ============================================================================
+
+
+class TestProtocolIds:
+    """Each handler exposes the correct protocol_id."""
+
+    def test_sync_handler_protocol_id(self) -> None:
+        handler = SyncProtocolHandler()
+        assert handler.protocol_id == VALENCE_SYNC_PROTOCOL
+
+    def test_auth_handler_protocol_id(self) -> None:
+        handler = AuthProtocolHandler()
+        assert handler.protocol_id == VALENCE_AUTH_PROTOCOL
+
+    def test_trust_handler_protocol_id(self) -> None:
+        handler = TrustProtocolHandler()
+        assert handler.protocol_id == VALENCE_TRUST_PROTOCOL
+
+    def test_belief_propagation_topic(self) -> None:
+        handler = BeliefPropagationHandler()
+        assert handler.topic == VALENCE_BELIEFS_TOPIC
+
+    def test_peer_discovery_topic(self) -> None:
+        handler = PeerDiscoveryHandler()
+        assert handler.topic == VALENCE_PEERS_TOPIC
+
+
+# ============================================================================
+# SyncProtocolHandler dispatch
+# ============================================================================
+
+
+class TestSyncProtocolHandler:
+    """SyncProtocolHandler._dispatch with mocked sender resolution."""
+
+    @pytest.fixture()
+    def handler(self) -> SyncProtocolHandler:
+        node_id = uuid4()
+        return SyncProtocolHandler(
+            get_sender_node_id=lambda req: node_id,
+            get_sender_trust=lambda nid: 0.5,
+        )
+
+    @pytest.mark.asyncio
+    async def test_dispatch_unparseable_returns_error(self, handler: SyncProtocolHandler) -> None:
+        result = await handler._dispatch({"type": "GARBAGE"})
+        assert result is not None
+        assert result["type"] == "ERROR"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_without_sender_returns_error(self) -> None:
+        handler = SyncProtocolHandler()  # No sender hooks
+        request = SyncRequest(page_size=10).to_dict()
+        result = await handler._dispatch(request)
+        assert result is not None
+        assert result["type"] == "ERROR"
+        assert "Sender" in result.get("message", "")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_wrong_message_type_returns_error(self, handler: SyncProtocolHandler) -> None:
+        # AUTH_CHALLENGE is not a sync message
+        request = AuthChallengeRequest(client_did="did:vkb:web:test").to_dict()
+        result = await handler._dispatch(request)
+        assert result is not None
+        assert result["type"] == "ERROR"
+        assert "Unexpected" in result.get("message", "")
+
+
+# ============================================================================
+# AuthProtocolHandler dispatch
+# ============================================================================
+
+
+class TestAuthProtocolHandler:
+    """AuthProtocolHandler._dispatch."""
+
+    @pytest.fixture()
+    def handler(self) -> AuthProtocolHandler:
+        return AuthProtocolHandler()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_unparseable_returns_error(self, handler: AuthProtocolHandler) -> None:
+        result = await handler._dispatch({"type": "GARBAGE"})
+        assert result is not None
+        assert result["type"] == "ERROR"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_wrong_type_returns_error(self, handler: AuthProtocolHandler) -> None:
+        request = SyncRequest(page_size=10).to_dict()
+        result = await handler._dispatch(request)
+        assert result is not None
+        assert result["type"] == "ERROR"
+
+
+# ============================================================================
+# TrustProtocolHandler dispatch
+# ============================================================================
+
+
+class TestTrustProtocolHandler:
+    """TrustProtocolHandler._dispatch."""
+
+    @pytest.fixture()
+    def handler(self) -> TrustProtocolHandler:
+        node_id = uuid4()
+        return TrustProtocolHandler(
+            get_sender_node_id=lambda req: node_id,
+            get_sender_trust=lambda nid: 0.5,
+        )
+
+    @pytest.mark.asyncio
+    async def test_dispatch_unparseable_returns_error(self, handler: TrustProtocolHandler) -> None:
+        result = await handler._dispatch({"type": "GARBAGE"})
+        assert result is not None
+        assert result["type"] == "ERROR"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_without_sender_returns_error(self) -> None:
+        handler = TrustProtocolHandler()
+        request = TrustAttestationRequest(
+            attestation={"subject_did": "did:vkb:web:bob"},
+            issuer_signature="abc",
+        ).to_dict()
+        result = await handler._dispatch(request)
+        assert result is not None
+        assert result["type"] == "ERROR"
+        assert "Sender" in result.get("message", "")
+
+
+# ============================================================================
+# BeliefPropagationHandler
+# ============================================================================
+
+
+class TestBeliefPropagationHandler:
+    """BeliefPropagationHandler GossipSub handling."""
+
+    @pytest.fixture()
+    def handler(self) -> BeliefPropagationHandler:
+        node_id = uuid4()
+        return BeliefPropagationHandler(
+            get_sender_node_id=lambda msg: node_id,
+            get_sender_trust=lambda nid: 0.4,
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_invalid_json(self, handler: BeliefPropagationHandler) -> None:
+        result = await handler.handle_message(b"not json")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_handle_non_share_belief_ignored(self, handler: BeliefPropagationHandler) -> None:
+        data = GossipSubCodec.encode({"type": "SYNC_REQUEST"})
+        result = await handler.handle_message(data)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_handle_without_sender_returns_none(self) -> None:
+        handler = BeliefPropagationHandler()  # No sender hooks
+        data = GossipSubCodec.encode(
+            {
+                "type": "SHARE_BELIEF",
+                "beliefs": [{"content": "test", "origin_node_did": "did:vkb:web:x"}],
+            }
+        )
+        result = await handler.handle_message(data)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_publish_belief_dict(self) -> None:
+        pubsub = FakePubSub()
+        handler = BeliefPropagationHandler()
+        await handler.publish_belief(
+            pubsub=pubsub,
+            belief_dict={"content": "Earth is round", "origin_node_did": "did:vkb:web:me"},
+        )
+        assert len(pubsub.published) == 1
+        topic, data = pubsub.published[0]
+        assert topic == VALENCE_BELIEFS_TOPIC
+        decoded = json.loads(data)
+        assert decoded["type"] == "SHARE_BELIEF"
+        assert len(decoded["beliefs"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_publish_message(self) -> None:
+        pubsub = FakePubSub()
+        handler = BeliefPropagationHandler()
+        msg = ShareBeliefRequest(beliefs=[{"content": "test"}])
+        await handler.publish_belief(pubsub=pubsub, message=msg)
+        assert len(pubsub.published) == 1
+
+    @pytest.mark.asyncio
+    async def test_publish_without_pubsub_raises(self) -> None:
+        handler = BeliefPropagationHandler()
+        with pytest.raises(RuntimeError, match="No PubSub"):
+            await handler.publish_belief(belief_dict={"content": "x"})
+
+    @pytest.mark.asyncio
+    async def test_publish_without_data_raises(self) -> None:
+        pubsub = FakePubSub()
+        handler = BeliefPropagationHandler()
+        with pytest.raises(ValueError, match="Provide"):
+            await handler.publish_belief(pubsub=pubsub)
+
+
+# ============================================================================
+# PeerDiscoveryHandler
+# ============================================================================
+
+
+class TestPeerDiscoveryHandler:
+    """PeerDiscoveryHandler GossipSub handling."""
+
+    @pytest.mark.asyncio
+    async def test_handle_valid_announcement(self) -> None:
+        handler = PeerDiscoveryHandler()
+        announcement = {"did": "did:vkb:web:new-node", "capabilities": ["sync"]}
+        data = GossipSubCodec.encode(announcement)
+        result = await handler.handle_message(data)
+        assert result == announcement
+
+    @pytest.mark.asyncio
+    async def test_handle_invalid_json(self) -> None:
+        handler = PeerDiscoveryHandler()
+        result = await handler.handle_message(b"bad")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_publish_announcement(self) -> None:
+        pubsub = FakePubSub()
+        handler = PeerDiscoveryHandler()
+        ann = {"did": "did:vkb:web:me", "status": "active"}
+        await handler.publish_announcement(pubsub=pubsub, announcement=ann)
+        assert len(pubsub.published) == 1
+        assert pubsub.published[0][0] == VALENCE_PEERS_TOPIC
+
+    @pytest.mark.asyncio
+    async def test_publish_without_pubsub_raises(self) -> None:
+        handler = PeerDiscoveryHandler()
+        with pytest.raises(RuntimeError, match="No PubSub"):
+            await handler.publish_announcement(announcement={"did": "x"})
+
+    @pytest.mark.asyncio
+    async def test_publish_without_data_raises(self) -> None:
+        pubsub = FakePubSub()
+        handler = PeerDiscoveryHandler()
+        with pytest.raises(ValueError, match="Provide"):
+            await handler.publish_announcement(pubsub=pubsub)
+
+
+# ============================================================================
+# BaseStreamHandler — handle_stream and send_request
+# ============================================================================
+
+
+class TestBaseStreamHandler:
+    """Test the stream I/O wiring via handle_stream / send_request."""
+
+    @pytest.mark.asyncio
+    async def test_handle_stream_codec_error(self) -> None:
+        """Handler sends an error frame on bad input and closes the stream."""
+        handler = SyncProtocolHandler(
+            get_sender_node_id=lambda r: uuid4(),
+            get_sender_trust=lambda n: 0.5,
+        )
+        # Feed garbage that has a valid length header but bad JSON
+        import struct
+
+        bad_payload = b"{bad json"
+        bad_frame = struct.pack("!I", len(bad_payload)) + bad_payload
+        stream = FakeStream(inbound=bad_frame)
+        await handler.handle_stream(stream)
+        assert stream.closed
+
+    @pytest.mark.asyncio
+    async def test_handle_stream_empty_close(self) -> None:
+        """Handler handles a stream that closes without sending data."""
+        handler = SyncProtocolHandler()
+        stream = FakeStream(inbound=b"")
+        await handler.handle_stream(stream)
+        assert stream.closed
+
+    @pytest.mark.asyncio
+    async def test_send_request_returns_none_on_empty_response(self) -> None:
+        """send_request returns None when the peer closes without responding."""
+        handler = SyncProtocolHandler()
+        host = FakeHost(response_data=b"")
+        msg = SyncRequest(page_size=10)
+        result = await handler.send_request(host, "peer123", msg)
+        assert result is None
+        assert len(host.opened_streams) == 1
+        assert host.opened_streams[0] == ("peer123", [VALENCE_SYNC_PROTOCOL])
+
+    @pytest.mark.asyncio
+    async def test_send_request_returns_response(self) -> None:
+        """send_request decodes a valid response from the peer."""
+        handler = SyncProtocolHandler()
+        response_dict = {"type": "SYNC_RESPONSE", "changes": [], "has_more": False}
+        response_frame = StreamCodec.encode(response_dict)
+        host = FakeHost(response_data=response_frame)
+        msg = SyncRequest(page_size=10)
+        result = await handler.send_request(host, "peer456", msg)
+        assert result is not None
+        assert result["type"] == "SYNC_RESPONSE"
+
+
+# ============================================================================
+# create_handlers registry
+# ============================================================================
+
+
+class TestCreateHandlers:
+    """create_handlers factory function."""
+
+    def test_returns_all_handlers(self) -> None:
+        handlers = create_handlers()
+        assert VALENCE_SYNC_PROTOCOL in handlers
+        assert VALENCE_AUTH_PROTOCOL in handlers
+        assert VALENCE_TRUST_PROTOCOL in handlers
+        assert VALENCE_BELIEFS_TOPIC in handlers
+        assert VALENCE_PEERS_TOPIC in handlers
+
+    def test_handlers_have_correct_types(self) -> None:
+        handlers = create_handlers()
+        assert isinstance(handlers[VALENCE_SYNC_PROTOCOL], SyncProtocolHandler)
+        assert isinstance(handlers[VALENCE_AUTH_PROTOCOL], AuthProtocolHandler)
+        assert isinstance(handlers[VALENCE_TRUST_PROTOCOL], TrustProtocolHandler)
+        assert isinstance(handlers[VALENCE_BELIEFS_TOPIC], BeliefPropagationHandler)
+        assert isinstance(handlers[VALENCE_PEERS_TOPIC], PeerDiscoveryHandler)
+
+    def test_shared_hooks_propagated(self) -> None:
+        node_id = uuid4()
+        hook = lambda req: node_id  # noqa: E731
+        handlers = create_handlers(get_sender_node_id=hook)
+        sync = handlers[VALENCE_SYNC_PROTOCOL]
+        assert isinstance(sync, SyncProtocolHandler)
+        assert sync._get_sender_node_id is hook

--- a/tests/transport/test_protocols.py
+++ b/tests/transport/test_protocols.py
@@ -1,0 +1,90 @@
+"""Tests for valence.transport.protocols — protocol IDs and helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from valence.transport.protocols import (
+    ALL_GOSSIPSUB_TOPICS,
+    ALL_STREAM_PROTOCOLS,
+    VALENCE_AUTH_PROTOCOL,
+    VALENCE_BELIEFS_TOPIC,
+    VALENCE_PEERS_TOPIC,
+    VALENCE_SYNC_PROTOCOL,
+    VALENCE_TRUST_PROTOCOL,
+    protocol_for_message_type,
+)
+
+# ============================================================================
+# Protocol ID constants
+# ============================================================================
+
+
+class TestProtocolConstants:
+    """Verify that protocol ID strings are well-formed."""
+
+    def test_sync_protocol_format(self) -> None:
+        assert VALENCE_SYNC_PROTOCOL == "/valence/sync/1.0.0"
+        assert VALENCE_SYNC_PROTOCOL.startswith("/")
+
+    def test_auth_protocol_format(self) -> None:
+        assert VALENCE_AUTH_PROTOCOL == "/valence/auth/1.0.0"
+
+    def test_trust_protocol_format(self) -> None:
+        assert VALENCE_TRUST_PROTOCOL == "/valence/trust/1.0.0"
+
+    def test_beliefs_topic_format(self) -> None:
+        assert VALENCE_BELIEFS_TOPIC == "/valence/beliefs"
+
+    def test_peers_topic_format(self) -> None:
+        assert VALENCE_PEERS_TOPIC == "/valence/peers"
+
+    def test_all_stream_protocols_list(self) -> None:
+        assert len(ALL_STREAM_PROTOCOLS) == 3
+        assert VALENCE_SYNC_PROTOCOL in ALL_STREAM_PROTOCOLS
+        assert VALENCE_AUTH_PROTOCOL in ALL_STREAM_PROTOCOLS
+        assert VALENCE_TRUST_PROTOCOL in ALL_STREAM_PROTOCOLS
+
+    def test_all_gossipsub_topics_list(self) -> None:
+        assert len(ALL_GOSSIPSUB_TOPICS) == 2
+        assert VALENCE_BELIEFS_TOPIC in ALL_GOSSIPSUB_TOPICS
+        assert VALENCE_PEERS_TOPIC in ALL_GOSSIPSUB_TOPICS
+
+    def test_no_overlap_between_streams_and_topics(self) -> None:
+        """Stream protocols and GossipSub topics must not collide."""
+        assert set(ALL_STREAM_PROTOCOLS).isdisjoint(set(ALL_GOSSIPSUB_TOPICS))
+
+
+# ============================================================================
+# protocol_for_message_type
+# ============================================================================
+
+
+class TestProtocolForMessageType:
+    """Map VFP MessageType values to libp2p protocol IDs."""
+
+    @pytest.mark.parametrize(
+        ("message_type", "expected"),
+        [
+            ("SYNC_REQUEST", VALENCE_SYNC_PROTOCOL),
+            ("SYNC_RESPONSE", VALENCE_SYNC_PROTOCOL),
+            ("AUTH_CHALLENGE", VALENCE_AUTH_PROTOCOL),
+            ("AUTH_CHALLENGE_RESPONSE", VALENCE_AUTH_PROTOCOL),
+            ("AUTH_VERIFY", VALENCE_AUTH_PROTOCOL),
+            ("AUTH_VERIFY_RESPONSE", VALENCE_AUTH_PROTOCOL),
+            ("TRUST_ATTESTATION", VALENCE_TRUST_PROTOCOL),
+            ("TRUST_ATTESTATION_RESPONSE", VALENCE_TRUST_PROTOCOL),
+            ("SHARE_BELIEF", VALENCE_SYNC_PROTOCOL),
+            ("SHARE_BELIEF_RESPONSE", VALENCE_SYNC_PROTOCOL),
+            ("REQUEST_BELIEFS", VALENCE_SYNC_PROTOCOL),
+            ("BELIEFS_RESPONSE", VALENCE_SYNC_PROTOCOL),
+        ],
+    )
+    def test_known_types_map_correctly(self, message_type: str, expected: str) -> None:
+        assert protocol_for_message_type(message_type) == expected
+
+    def test_error_type_returns_none(self) -> None:
+        assert protocol_for_message_type("ERROR") is None
+
+    def test_unknown_type_returns_none(self) -> None:
+        assert protocol_for_message_type("BOGUS_TYPE") is None


### PR DESCRIPTION
## Summary

Maps existing Valence Federation Protocol (VFP) message types onto libp2p stream protocols and GossipSub topics. This is the foundational protocol layer for P2P transport.

## New module: `valence.transport`

### `protocols.py` — Protocol IDs
- `VALENCE_SYNC_PROTOCOL = "/valence/sync/1.0.0"` — belief sync, share, request
- `VALENCE_AUTH_PROTOCOL = "/valence/auth/1.0.0"` — DID auth challenge/verify
- `VALENCE_TRUST_PROTOCOL = "/valence/trust/1.0.0"` — trust attestation exchange
- `VALENCE_BELIEFS_TOPIC = "/valence/beliefs"` — GossipSub broadcast for new beliefs
- `VALENCE_PEERS_TOPIC = "/valence/peers"` — GossipSub peer discovery

### `message_codec.py` — Serialization
- **StreamCodec** — length-prefixed binary framing (4-byte BE u32 + JSON payload) for 1:1 stream protocols
- **GossipSubCodec** — plain UTF-8 JSON for pub/sub (GossipSub handles message boundaries)
- **StreamBuffer** — incremental frame accumulator for async stream reads
- Max frame size: 8 MiB with proper error handling for oversized/malformed frames

### `protocol_handler.py` — Async Handlers
- **SyncProtocolHandler** — dispatches SYNC_REQUEST, SHARE_BELIEF, REQUEST_BELIEFS to existing VFP handlers
- **AuthProtocolHandler** — dispatches AUTH_CHALLENGE, AUTH_VERIFY to existing federation auth
- **TrustProtocolHandler** — dispatches TRUST_ATTESTATION to existing trust processing
- **BeliefPropagationHandler** — GossipSub handler for `/valence/beliefs`, wraps raw beliefs in SHARE_BELIEF envelope
- **PeerDiscoveryHandler** — GossipSub handler for `/valence/peers`
- `create_handlers()` — factory that creates all handlers with shared sender resolution hooks

### Design Decisions
- Handlers use abstract `IStream`/`IHost`/`IPubSub` protocols (typing shims), making them testable without a real libp2p stack
- Reuses existing VFP `parse_message()` / `to_dict()` roundtrip — no message format duplication
- Sender resolution is pluggable via constructor hooks (will integrate with libp2p peer ID -> node ID mapping in future PRs)

## Tests
83 new tests covering:
- Protocol constant correctness and message type mapping
- StreamCodec/GossipSubCodec encode/decode roundtrips
- Frame boundary edge cases (partial feeds, oversized frames, bad JSON)
- StreamBuffer incremental accumulation
- Handler dispatch (correct routing, error handling, missing sender)
- GossipSub publish/subscribe wiring
- `create_handlers()` registry

Closes #301