### PR TITLE
fix: add db_port to ServerSettings (#376)

### DIFF
--- a/src/valence/server/config.py
+++ b/src/valence/server/config.py
@@ -86,6 +86,7 @@ class ServerSettings(BaseSettings):
 
     # Database settings (inherited from existing VKB config)
     db_host: str = Field(default="localhost", alias="VKB_DB_HOST")
+    db_port: int = Field(default=5432, alias="VKB_DB_PORT")
     db_name: str = Field(default="valence", alias="VKB_DB_NAME")
     db_user: str = Field(default="valence", alias="VKB_DB_USER")
     db_password: str = Field(default="", alias="VKB_DB_PASSWORD")
@@ -241,7 +242,7 @@ class ServerSettings(BaseSettings):
     @property
     def database_url(self) -> str:
         """Construct database URL."""
-        return f"postgresql://{self.db_user}:{self.db_password}@{self.db_host}:5432/{self.db_name}"
+        return f"postgresql://{self.db_user}:{self.db_password}@{self.db_host}:{self.db_port}/{self.db_name}"
 
     @property
     def base_url(self) -> str:


### PR DESCRIPTION
## Summary
- Added `db_port` field to `ServerSettings` with `VKB_DB_PORT` env var support
- Changed `database_url` property to use `self.db_port` instead of hardcoded `5432`

Fixes #376

## Test plan
- [x] Existing server tests pass (418/418)
- [ ] Verify HTTP server connects on non-standard port (e.g. 5433)

🤖 Generated with [Claude Code](https://claude.com/claude-code)