### PR TITLE
fix: generate embeddings inline during belief_create/supersede (#377)

### DIFF
--- a/tests/substrate/test_sharing_tools.py
+++ b/tests/substrate/test_sharing_tools.py
@@ -539,8 +539,8 @@ class TestBeliefCreateVisibility:
 
         # The share_policy param should be JSON with intent info
         params = insert_call[0][1]
-        # share_policy is the last param
-        share_policy_param = params[-1]
+        # share_policy is second-to-last param (embedding is last)
+        share_policy_param = params[-2]
         assert share_policy_param is not None
         policy_data = json.loads(share_policy_param)
         assert policy_data["intent"] == "use_this"
@@ -591,8 +591,8 @@ class TestBeliefCreateVisibility:
                 break
         assert insert_call is not None
         params = insert_call[0][1]
-        # share_policy param should be None
-        assert params[-1] is None
+        # share_policy param should be None (second-to-last, embedding is last)
+        assert params[-2] is None
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- `belief_create` already generated an embedding vector for dedup matching — now reuses it in the INSERT so new beliefs are immediately searchable via `belief_search`
- `belief_supersede` now generates and stores an embedding for the new belief
- Both fall back gracefully to `NULL` if embedding model is unavailable (backfill still works as safety net)

Fixes #377

## Test plan
- [x] 119 substrate tests pass (including dedup, sharing, and tools)
- [x] Full suite: 2657 passed, 0 failed
- [ ] Create a belief via MCP and verify `belief_search` finds it immediately without backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)