### PR TITLE
feat: CLI as pure REST client (#396)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "PyJWT>=2.11.0",
     "PyYAML>=6.0",
+    "httpx>=0.27.0",
     "aiohttp>=3.9.0",
     "dnspython>=2.4.0",
     "cryptography>=42.0",

--- a/src/valence/cli/commands/__init__.py
+++ b/src/valence/cli/commands/__init__.py
@@ -30,7 +30,7 @@ from .federation import cmd_query_federated
 from .identity import cmd_identity, register_identity_commands
 from .io import cmd_export, cmd_import
 from .maintenance import cmd_maintenance
-from .migration import cmd_migrate, cmd_migrate_visibility
+from .migration import cmd_migrate
 from .peers import cmd_peer, cmd_peer_add, cmd_peer_list, cmd_peer_remove
 from .qos import cmd_qos
 from .resources import cmd_resources
@@ -70,7 +70,6 @@ __all__ = [
     "cmd_init",
     "cmd_list",
     "cmd_migrate",
-    "cmd_migrate_visibility",
     "cmd_peer",
     "cmd_peer_add",
     "cmd_peer_list",

--- a/src/valence/cli/commands/beliefs.py
+++ b/src/valence/cli/commands/beliefs.py
@@ -1,26 +1,20 @@
-"""Belief management commands: init, add, query, list."""
+"""Belief management commands: init, add, query, list, verify-chains."""
 
 from __future__ import annotations
 
 import argparse
 import json
-from pathlib import Path
 
-from ..utils import (
-    compute_confidence_score,
-    format_age,
-    format_confidence,
-    get_db_connection,
-    get_embedding,
-    multi_signal_rank,
-)
+from ..config import get_cli_config
+from ..http_client import ValenceAPIError, ValenceConnectionError, get_client
+from ..output import output_error, output_result
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
     """Register belief commands (init, add, query, list) on the CLI parser."""
     # init
-    init_parser = subparsers.add_parser("init", help="Initialize database schema")
-    init_parser.add_argument("--force", "-f", action="store_true", help="Recreate schema even if exists")
+    init_parser = subparsers.add_parser("init", help="Initialize database schema (apply all migrations)")
+    init_parser.add_argument("--dry-run", action="store_true", help="Show what would be applied")
     init_parser.set_defaults(func=cmd_init)
 
     # add
@@ -43,29 +37,19 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         default="observation",
         help="How this belief was derived",
     )
-    add_parser.add_argument("--derived-from", help="UUID of source belief this was derived from")
-    add_parser.add_argument("--method", "-m", help="Method description for derivation")
+    add_parser.add_argument("--visibility", "-v", default="private", help="Visibility: private, federated, public")
     add_parser.set_defaults(func=cmd_add)
 
     # query
     query_parser = subparsers.add_parser("query", help="Search beliefs with multi-signal ranking")
     query_parser.add_argument("query", help="Search query")
     query_parser.add_argument("--limit", "-n", type=int, default=10, help="Max results")
-    query_parser.add_argument("--threshold", "-t", type=float, default=0.3, help="Min semantic similarity")
     query_parser.add_argument("--domain", "-d", help="Filter by domain")
-    query_parser.add_argument("--chain", action="store_true", help="Show full supersession chains")
-    query_parser.add_argument(
-        "--scope",
-        "-s",
-        choices=["local", "federated"],
-        default="local",
-        help="Search scope: local (default) or federated (include peer beliefs)",
-    )
     query_parser.add_argument(
         "--recency-weight",
         "-r",
         type=float,
-        default=0.15,
+        default=None,
         help="Recency weight 0.0-1.0 (default 0.15). Higher = prefer newer beliefs",
     )
     query_parser.add_argument(
@@ -81,6 +65,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Show detailed score breakdown per result",
     )
+    query_parser.add_argument("--include-archived", action="store_true", help="Include archived beliefs")
     query_parser.set_defaults(func=cmd_query)
 
     # list
@@ -91,596 +76,146 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 
     # verify-chains
     verify_parser = subparsers.add_parser("verify-chains", help="Verify supersession chain integrity")
-    verify_parser.add_argument("--limit", "-n", type=int, default=None, help="Max chains to verify (default: all)")
-    verify_parser.add_argument("--json", action="store_true", dest="output_json", help="Output as JSON")
     verify_parser.set_defaults(func=cmd_verify_chains)
 
 
 def cmd_init(args: argparse.Namespace) -> int:
-    """Initialize valence database."""
-    import psycopg2
-
-    from ...core.config import get_config
-
-    print("🔧 Initializing Valence database...")
-
-    # Check if we need to create the database
-    config = get_config()
-    db_name = config.db_name
-    db_host = config.db_host
-    db_port = str(config.db_port)
-    db_user = config.db_user
-    db_pass = config.db_password
-
-    # First, try to connect to the database
+    """Initialize valence database via server migration endpoint."""
+    client = get_client()
     try:
-        conn = get_db_connection()
-        cur = conn.cursor()
-
-        # Check if beliefs table exists
-        cur.execute(
-            """
-            SELECT EXISTS (
-                SELECT FROM information_schema.tables
-                WHERE table_name = 'beliefs'
-            )
-        """
-        )
-        exists = cur.fetchone()["exists"]
-
-        if exists and not args.force:
-            print(f"✅ Database already initialized at {db_host}:{db_port}/{db_name}")
-            cur.execute("SELECT COUNT(*) as count FROM beliefs")
-            count = cur.fetchone()["count"]
-            print(f"   📊 {count} beliefs stored")
-            conn.close()
-            return 0
-
-        conn.close()
-    except psycopg2.OperationalError as e:
-        print(f"⚠️  Cannot connect to database: {e}")
-        print("\nTo create a new database, run:")
-        print(f"  createdb -h {db_host} -p {db_port} -U {db_user} {db_name}")
-        print("  # Or with Docker:")
-        print(f"  docker run -d --name valence-db -e POSTGRES_USER={db_user} \\")
-        print(f"    -e POSTGRES_PASSWORD={db_pass or 'valence'} -e POSTGRES_DB={db_name} \\")
-        print(f"    -p {db_port}:5432 pgvector/pgvector:pg16")
-        return 1
-
-    print("🔨 Creating schema...")
-
-    # Read and execute schema
-    Path(__file__).parent.parent.parent / "substrate"
-    Path(__file__).parent.parent.parent.parent / "migrations"
-
-    conn = get_db_connection()
-    cur = conn.cursor()
-
-    try:
-        # Enable required extensions
-        cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
-        cur.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
-        cur.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
-
-        # Create core tables if they don't exist
-        cur.execute(
-            """
-            CREATE TABLE IF NOT EXISTS sources (
-                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                type TEXT NOT NULL,
-                title TEXT,
-                url TEXT,
-                content_hash TEXT,
-                session_id UUID,
-                metadata JSONB DEFAULT '{}',
-                created_at TIMESTAMPTZ DEFAULT NOW()
-            )
-        """
-        )
-
-        cur.execute(
-            """
-            CREATE TABLE IF NOT EXISTS beliefs (
-                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                content TEXT NOT NULL,
-                content_hash CHAR(64),
-                embedding vector(1536),
-                confidence JSONB DEFAULT '{"overall": 0.7}',
-                domain_path TEXT[] DEFAULT '{}',
-                source_id UUID REFERENCES sources(id),
-                extraction_method TEXT,
-                valid_from TIMESTAMPTZ,
-                valid_until TIMESTAMPTZ,
-                supersedes_id UUID REFERENCES beliefs(id),
-                superseded_by_id UUID REFERENCES beliefs(id),
-                status TEXT DEFAULT 'active',
-                holder_id UUID DEFAULT '00000000-0000-0000-0000-000000000001',
-                visibility TEXT DEFAULT 'private',
-                version INTEGER DEFAULT 1,
-                is_local BOOLEAN DEFAULT TRUE,
-                corroboration_count INTEGER DEFAULT 0,
-                corroborating_sources JSONB DEFAULT '[]',
-                confidence_source REAL DEFAULT 0.5,
-                confidence_method REAL DEFAULT 0.5,
-                confidence_consistency REAL DEFAULT 1.0,
-                confidence_freshness REAL DEFAULT 1.0,
-                confidence_corroboration REAL DEFAULT 0.1,
-                confidence_applicability REAL DEFAULT 0.8,
-                created_at TIMESTAMPTZ DEFAULT NOW(),
-                modified_at TIMESTAMPTZ DEFAULT NOW()
-            )
-        """
-        )
-
-        cur.execute(
-            """
-            CREATE TABLE IF NOT EXISTS entities (
-                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                name TEXT NOT NULL,
-                type TEXT NOT NULL,
-                description TEXT,
-                aliases TEXT[] DEFAULT '{}',
-                canonical_id UUID REFERENCES entities(id),
-                created_at TIMESTAMPTZ DEFAULT NOW(),
-                modified_at TIMESTAMPTZ DEFAULT NOW()
-            )
-        """
-        )
-
-        # Partial unique index for non-aliased entities
-        cur.execute(
-            """
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_entities_name_type_unique
-            ON entities(name, type) WHERE canonical_id IS NULL
-        """
-        )
-
-        cur.execute(
-            """
-            CREATE TABLE IF NOT EXISTS belief_entities (
-                belief_id UUID REFERENCES beliefs(id) ON DELETE CASCADE,
-                entity_id UUID REFERENCES entities(id) ON DELETE CASCADE,
-                role TEXT DEFAULT 'subject',
-                created_at TIMESTAMPTZ DEFAULT NOW(),
-                PRIMARY KEY (belief_id, entity_id)
-            )
-        """
-        )
-
-        cur.execute(
-            """
-            CREATE TABLE IF NOT EXISTS tensions (
-                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                belief_a_id UUID REFERENCES beliefs(id) ON DELETE CASCADE,
-                belief_b_id UUID REFERENCES beliefs(id) ON DELETE CASCADE,
-                type TEXT DEFAULT 'contradiction',
-                description TEXT,
-                severity TEXT DEFAULT 'medium',
-                status TEXT DEFAULT 'detected',
-                resolution TEXT,
-                resolved_at TIMESTAMPTZ,
-                detected_at TIMESTAMPTZ DEFAULT NOW()
-            )
-        """
-        )
-
-        # Create indexes
-        cur.execute("CREATE INDEX IF NOT EXISTS idx_beliefs_embedding ON beliefs USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)")
-        cur.execute("CREATE INDEX IF NOT EXISTS idx_beliefs_status ON beliefs(status)")
-        cur.execute("CREATE INDEX IF NOT EXISTS idx_beliefs_domain ON beliefs USING GIN(domain_path)")
-        cur.execute("CREATE INDEX IF NOT EXISTS idx_beliefs_created ON beliefs(created_at DESC)")
-
-        # Create text search
-        cur.execute(
-            """
-            DO $$ BEGIN
-                ALTER TABLE beliefs ADD COLUMN content_tsv tsvector
-                    GENERATED ALWAYS AS (to_tsvector('english', content)) STORED;
-            EXCEPTION WHEN duplicate_column THEN NULL;
-            END $$
-        """
-        )
-        cur.execute("CREATE INDEX IF NOT EXISTS idx_beliefs_tsv ON beliefs USING GIN(content_tsv)")
-
-        conn.commit()
-        print("✅ Schema created successfully!")
-
-        # Show connection info
-        print(f"\n📍 Connected to: {db_host}:{db_port}/{db_name}")
-        print("\n💡 Quick start:")
-        print("   valence add 'Your first belief here' -d general")
-        print("   valence query 'search terms'")
-        print("   valence list")
-
+        dry_run = getattr(args, "dry_run", False)
+        result = client.post("/admin/migrate/up", body={"dry_run": dry_run})
+        output_result(result)
         return 0
-
-    except Exception as e:
-        conn.rollback()
-        print(f"❌ Schema creation failed: {e}")
+    except ValenceConnectionError as e:
+        output_error(str(e))
         return 1
-    finally:
-        cur.close()
-        conn.close()
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1
 
 
 def cmd_add(args: argparse.Namespace) -> int:
-    """Add a new belief."""
+    """Add a new belief via REST API."""
     content = args.content
-
     if not content:
-        print("❌ Content is required")
+        output_error("Content is required")
         return 1
 
     # Parse confidence
-    confidence = {"overall": 0.7}
+    confidence = None
     if args.confidence:
         try:
-            confidence = json.loads(args.confidence)
-        except json.JSONDecodeError:
-            # Try parsing as simple float
+            parsed = json.loads(args.confidence)
+            if isinstance(parsed, dict):
+                confidence = parsed
+            else:
+                confidence = {"overall": float(parsed)}
+        except (json.JSONDecodeError, TypeError, ValueError):
             try:
                 confidence = {"overall": float(args.confidence)}
             except ValueError:
-                print(f"❌ Invalid confidence: {args.confidence}")
+                output_error(f"Invalid confidence: {args.confidence}")
                 return 1
 
-    # Parse domains
-    domains = args.domain or []
+    # Build request body
+    body: dict = {"content": content}
+    if confidence:
+        body["confidence"] = confidence
+    if args.domain:
+        body["domain_path"] = args.domain
+    if args.derivation_type:
+        body["source_type"] = args.derivation_type
+    if args.visibility:
+        body["visibility"] = args.visibility
 
-    # Generate embedding
-    embedding = get_embedding(content)
-    embedding_str = None
-    if embedding:
-        embedding_str = f"[{','.join(str(x) for x in embedding)}]"
-
-    # Parse derivation info
-    derivation_type = args.derivation_type or "observation"
-
-    conn = None
-    cur = None
+    client = get_client()
     try:
-        conn = get_db_connection()
-        cur = conn.cursor()
-
-        # Insert belief
-        cur.execute(
-            """
-            INSERT INTO beliefs (content, confidence, domain_path, embedding, extraction_method)
-            VALUES (%s, %s, %s, %s::vector, %s)
-            RETURNING id, created_at
-        """,
-            (content, json.dumps(confidence), domains, embedding_str, derivation_type),
-        )
-
-        row = cur.fetchone()
-        belief_id = row["id"]
-
-        conn.commit()
-
-        print(f"✅ Belief added: {str(belief_id)[:8]}...")
-        print(f"   📝 {content[:60]}{'...' if len(content) > 60 else ''}")
-        print(f"   🎯 Confidence: {format_confidence(confidence)}")
-        if domains:
-            print(f"   📁 Domains: {', '.join(domains)}")
-        if embedding:
-            print("   🧠 Embedding: generated")
-        else:
-            print("   ⚠️  No embedding (set OPENAI_API_KEY)")
-
+        result = client.post("/beliefs", body=body)
+        output_result(result)
         return 0
-
-    except Exception as e:
-        print(f"❌ Failed to add belief: {e}")
+    except ValenceConnectionError as e:
+        output_error(str(e))
         return 1
-    finally:
-        if cur:
-            cur.close()
-        if conn:
-            conn.close()
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1
 
 
 def cmd_query(args: argparse.Namespace) -> int:
-    """Search beliefs with multi-signal ranking and derivation chains."""
-    from .federation import cmd_query_federated
+    """Search beliefs via REST API."""
+    config = get_cli_config()
+    params: dict = {
+        "query": args.query,
+        "limit": str(args.limit),
+        "output": config.output,
+    }
+    if args.domain:
+        params["domain_filter"] = args.domain
+    if getattr(args, "include_archived", False):
+        params["include_archived"] = "true"
 
-    query = args.query
+    # Build ranking config
+    ranking: dict = {}
+    if args.recency_weight is not None:
+        ranking["recency_weight"] = args.recency_weight
+    if args.min_confidence is not None:
+        ranking["min_confidence"] = args.min_confidence
+    if args.explain:
+        ranking["explain"] = True
+    if ranking:
+        params["ranking"] = json.dumps(ranking)
 
-    # Use federated query if scope is federated
-    if hasattr(args, "scope") and args.scope == "federated":
-        return cmd_query_federated(args)
-
-    conn = None
-    cur = None
+    client = get_client()
     try:
-        conn = get_db_connection()
-        cur = conn.cursor()
-
-        # Try semantic search first if we can get an embedding
-        embedding = get_embedding(query)
-
-        results = []
-
-        # Get ranking weights from args (with defaults)
-        recency_weight = getattr(args, "recency_weight", 0.15) or 0.15
-        min_confidence = getattr(args, "min_confidence", None)
-        explain = getattr(args, "explain", False)
-
-        # Semantic weight adjusts based on recency weight
-        # Default: semantic=0.50, confidence=0.35, recency=0.15
-        semantic_weight = 0.50
-        confidence_weight = 0.35
-
-        # If recency_weight is overridden, scale others proportionally
-        if recency_weight != 0.15:
-            remaining = 1.0 - recency_weight
-            ratio = remaining / 0.85  # 0.85 = default semantic + confidence
-            semantic_weight = 0.50 * ratio
-            confidence_weight = 0.35 * ratio
-
-        if embedding:
-            embedding_str = f"[{','.join(str(x) for x in embedding)}]"
-
-            # Semantic search with 6D confidence columns
-            cur.execute(
-                """
-                SELECT
-                    b.id,
-                    b.content,
-                    b.confidence,
-                    b.domain_path,
-                    b.created_at,
-                    b.extraction_method,
-                    b.supersedes_id,
-                    b.confidence_source,
-                    b.confidence_method,
-                    b.confidence_consistency,
-                    b.confidence_freshness,
-                    b.confidence_corroboration,
-                    b.confidence_applicability,
-                    1 - (b.embedding <=> %s::vector) as similarity
-                FROM beliefs b
-                WHERE b.embedding IS NOT NULL
-                  AND b.status = 'active'
-                  AND b.superseded_by_id IS NULL
-                  AND 1 - (b.embedding <=> %s::vector) >= %s
-                ORDER BY b.embedding <=> %s::vector
-                LIMIT %s
-            """,
-                (embedding_str, embedding_str, args.threshold, embedding_str, args.limit * 2),
-            )  # Get extra for filtering
-
-            results = cur.fetchall()
-
-        # Fallback to text search if no embedding or no results
-        if not results:
-            cur.execute(
-                """
-                SELECT
-                    b.id,
-                    b.content,
-                    b.confidence,
-                    b.domain_path,
-                    b.created_at,
-                    b.extraction_method,
-                    b.supersedes_id,
-                    b.confidence_source,
-                    b.confidence_method,
-                    b.confidence_consistency,
-                    b.confidence_freshness,
-                    b.confidence_corroboration,
-                    b.confidence_applicability,
-                    ts_rank(b.content_tsv, websearch_to_tsquery('english', %s)) as similarity
-                FROM beliefs b
-                WHERE b.content_tsv @@ websearch_to_tsquery('english', %s)
-                  AND b.status = 'active'
-                  AND b.superseded_by_id IS NULL
-                ORDER BY ts_rank(b.content_tsv, websearch_to_tsquery('english', %s)) DESC
-                LIMIT %s
-            """,
-                (query, query, query, args.limit * 2),
-            )
-
-            results = cur.fetchall()
-
-        # Convert to list of dicts for processing
-        results = [dict(r) for r in results]
-
-        # Domain filter
-        if args.domain:
-            results = [r for r in results if args.domain in (r.get("domain_path") or [])]
-
-        # Apply multi-signal ranking
-        results = multi_signal_rank(
-            results,
-            semantic_weight=semantic_weight,
-            confidence_weight=confidence_weight,
-            recency_weight=recency_weight,
-            min_confidence=min_confidence,
-            explain=explain,
-        )
-
-        # Limit results after ranking
-        results = results[: args.limit]
-
-        if not results:
-            print(f"🔍 No beliefs found for: {query}")
-            return 0
-
-        print(f"🔍 Found {len(results)} belief(s) for: {query}")
-        if explain:
-            print(f"   Weights: semantic={semantic_weight:.2f}, confidence={confidence_weight:.2f}, recency={recency_weight:.2f}")
-        print()
-
-        for i, r in enumerate(results, 1):
-            final_score = r.get("final_score", 0)
-            sim = r.get("similarity", 0)
-
-            # Header
-            print(f"{'─' * 60}")
-            print(f"[{i}] {r['content'][:70]}{'...' if len(r['content']) > 70 else ''}")
-
-            # Show final score and components
-            conf_score = compute_confidence_score(r)
-            created_at = r.get("created_at")
-            age_str = format_age(created_at) if created_at else "unknown"
-            print(f"    ID: {str(r['id'])[:8]}  Score: {final_score:.0%}  Confidence: {conf_score:.0%}  Semantic: {sim:.0%}  Age: {age_str}")
-
-            if r.get("domain_path"):
-                print(f"    Domains: {', '.join(r['domain_path'])}")
-
-            # Show score breakdown if explain mode
-            if explain and r.get("score_breakdown"):
-                bd = r["score_breakdown"]
-                print("    ┌─ Score Breakdown:")
-                print(f"    │  Semantic:   {bd['semantic']['value']:.2f} × {bd['semantic']['weight']:.2f} = {bd['semantic']['contribution']:.3f}")
-                print(
-                    f"    │  Confidence: {bd['confidence']['value']:.2f} × {bd['confidence']['weight']:.2f} = {bd['confidence']['contribution']:.3f}"
-                )
-                print(f"    │  Recency:    {bd['recency']['value']:.2f} × {bd['recency']['weight']:.2f} = {bd['recency']['contribution']:.3f}")
-                print(f"    │  Final:      {bd['final']:.3f}")
-                print("    └─")
-
-            # === EXTRACTION METHOD ===
-            extraction_method = r.get("extraction_method") or "unknown"
-            print(f"    ┌─ Method: {extraction_method}")
-
-            # Show supersession chain if exists
-            if r.get("supersedes_id"):
-                print(f"    │  ⟳ Supersedes: {str(r['supersedes_id'])[:8]}...")
-                # Optionally walk the chain
-                if args.chain:
-                    chain = []
-                    current = r["supersedes_id"]
-                    depth = 0
-                    while current and depth < 5:
-                        cur.execute(
-                            "SELECT id, content, supersedes_id FROM beliefs WHERE id = %s",
-                            (current,),
-                        )
-                        chain_row = cur.fetchone()
-                        if chain_row:
-                            chain.append(f"{chain_row['content'][:40]}...")
-                            current = chain_row["supersedes_id"]
-                            depth += 1
-                        else:
-                            break
-                    for j, c in enumerate(chain):
-                        print(f"    │    {'└' if j == len(chain) - 1 else '├'}─ {c}")
-
-            print("    └─")
-
-        print(f"{'─' * 60}")
-
+        result = client.get("/beliefs", params=params)
+        output_result(result)
         return 0
-
-    except Exception as e:
-        print(f"❌ Query failed: {e}")
-        import traceback
-
-        traceback.print_exc()
+    except ValenceConnectionError as e:
+        output_error(str(e))
         return 1
-    finally:
-        if cur:
-            cur.close()
-        if conn:
-            conn.close()
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1
 
 
 def cmd_list(args: argparse.Namespace) -> int:
-    """List recent beliefs."""
-    conn = None
-    cur = None
+    """List recent beliefs via REST API."""
+    config = get_cli_config()
+    params: dict = {
+        "query": "*",
+        "limit": str(args.limit),
+        "output": config.output,
+    }
+    if args.domain:
+        params["domain_filter"] = args.domain
+
+    client = get_client()
     try:
-        conn = get_db_connection()
-        cur = conn.cursor()
-
-        sql = """
-            SELECT
-                b.id,
-                b.content,
-                b.confidence,
-                b.domain_path,
-                b.created_at,
-                b.extraction_method
-            FROM beliefs b
-            WHERE b.status = 'active'
-              AND b.superseded_by_id IS NULL
-        """
-        params = []
-
-        if args.domain:
-            sql += " AND %s = ANY(b.domain_path)"
-            params.append(args.domain)
-
-        sql += " ORDER BY b.created_at DESC LIMIT %s"
-        params.append(args.limit)
-
-        cur.execute(sql, params)
-        results = cur.fetchall()
-
-        if not results:
-            print("📭 No beliefs found")
-            return 0
-
-        print(f"📚 {len(results)} belief(s)" + (f" in domain '{args.domain}'" if args.domain else "") + "\n")
-
-        for r in results:
-            conf = format_confidence(r.get("confidence", {}))
-            age = format_age(r.get("created_at"))
-            deriv_raw = r.get("extraction_method") or "?"
-            deriv = deriv_raw[:6] if deriv_raw else "?"
-            content = r["content"][:55] + "..." if len(r["content"]) > 55 else r["content"]
-
-            print(f"  {str(r['id'])[:8]}  [{conf:>4}] [{age:>3}] [{deriv:>6}]  {content}")
-
+        result = client.get("/beliefs", params=params)
+        output_result(result)
         return 0
-
-    except Exception as e:
-        print(f"❌ List failed: {e}")
+    except ValenceConnectionError as e:
+        output_error(str(e))
         return 1
-    finally:
-        if cur:
-            cur.close()
-        if conn:
-            conn.close()
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1
 
 
 def cmd_verify_chains(args: argparse.Namespace) -> int:
-    """Verify supersession chain integrity."""
-    import json as json_mod
+    """Verify supersession chain integrity via REST API."""
+    config = get_cli_config()
+    params: dict = {"output": config.output}
 
-    from ...core.verification.chain_integrity import verify_chains
-
-    conn = None
-    cur = None
+    client = get_client()
     try:
-        conn = get_db_connection()
-        cur = conn.cursor()
-
-        report = verify_chains(cur, limit=args.limit)
-
-        if args.output_json:
-            print(json_mod.dumps(report.to_dict(), indent=2))
-        else:
-            print(report)
-            if report.issues:
-                print()
-                for issue in report.issues:
-                    ids = ", ".join(bid[:8] for bid in issue.belief_ids)
-                    print(f"  [{issue.issue_type}] {issue.description}")
-                    if ids:
-                        print(f"    beliefs: {ids}")
-
-        return 0 if not report.issues else 1
-
-    except Exception as e:
-        print(f"Failed to verify chains: {e}")
-        import traceback
-
-        traceback.print_exc()
+        result = client.get("/admin/verify-chains", params=params)
+        output_result(result)
+        return 0
+    except ValenceConnectionError as e:
+        output_error(str(e))
         return 1
-    finally:
-        if cur:
-            cur.close()
-        if conn:
-            conn.close()
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1

--- a/src/valence/cli/commands/conflicts.py
+++ b/src/valence/cli/commands/conflicts.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 
-from ..utils import get_db_connection
+from ..config import get_cli_config
+from ..http_client import ValenceAPIError, ValenceConnectionError, get_client
+from ..output import output_error, output_result
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
@@ -27,193 +29,22 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 
 
 def cmd_conflicts(args: argparse.Namespace) -> int:
-    """Detect beliefs that may contradict each other.
+    """Detect beliefs that may contradict each other via REST API."""
+    config = get_cli_config()
+    params: dict = {"output": config.output}
+    if args.threshold:
+        params["threshold"] = str(args.threshold)
+    if args.auto_record:
+        params["auto_record"] = "true"
 
-    Uses semantic similarity > threshold combined with:
-    - Opposite sentiment signals (negation words)
-    - Different conclusions about same entities
-    """
-    conn = None
-    cur = None
+    client = get_client()
     try:
-        conn = get_db_connection()
-        cur = conn.cursor()
-
-        threshold = args.threshold
-
-        print(f"🔍 Scanning for conflicts (similarity > {threshold:.0%})...\n")
-
-        # Find pairs of beliefs with high semantic similarity
-        # that might be contradictions
-        cur.execute(
-            """
-            WITH belief_pairs AS (
-                SELECT
-                    b1.id as id_a,
-                    b1.content as content_a,
-                    b1.confidence as confidence_a,
-                    b1.created_at as created_a,
-                    b2.id as id_b,
-                    b2.content as content_b,
-                    b2.confidence as confidence_b,
-                    b2.created_at as created_b,
-                    1 - (b1.embedding <=> b2.embedding) as similarity
-                FROM beliefs b1
-                CROSS JOIN beliefs b2
-                WHERE b1.id < b2.id
-                  AND b1.embedding IS NOT NULL
-                  AND b2.embedding IS NOT NULL
-                  AND b1.status = 'active'
-                  AND b2.status = 'active'
-                  AND b1.superseded_by_id IS NULL
-                  AND b2.superseded_by_id IS NULL
-                  AND 1 - (b1.embedding <=> b2.embedding) > %s
-                ORDER BY similarity DESC
-                LIMIT 50
-            )
-            SELECT * FROM belief_pairs
-            WHERE NOT EXISTS (
-                SELECT 1 FROM tensions t
-                WHERE (t.belief_a_id = belief_pairs.id_a AND t.belief_b_id = belief_pairs.id_b)
-                   OR (t.belief_a_id = belief_pairs.id_b AND t.belief_b_id = belief_pairs.id_a)
-            )
-        """,
-            (threshold,),
-        )
-
-        pairs = cur.fetchall()
-
-        if not pairs:
-            print("✅ No potential conflicts detected")
-            return 0
-
-        # Analyze each pair for contradiction signals
-        conflicts = []
-        negation_words = {
-            "not",
-            "never",
-            "no",
-            "n't",
-            "cannot",
-            "without",
-            "neither",
-            "none",
-            "nobody",
-            "nothing",
-            "nowhere",
-            "false",
-            "incorrect",
-            "wrong",
-            "fail",
-            "reject",
-            "deny",
-            "refuse",
-            "avoid",
-        }
-
-        for pair in pairs:
-            content_a = pair["content_a"].lower()
-            content_b = pair["content_b"].lower()
-
-            words_a = set(content_a.split())
-            words_b = set(content_b.split())
-
-            # Check for negation asymmetry
-            neg_a = bool(words_a & negation_words)
-            neg_b = bool(words_b & negation_words)
-
-            # Higher conflict score if one has negation and other doesn't
-            conflict_signal = 0.0
-            reason = []
-
-            if neg_a != neg_b:
-                conflict_signal += 0.4
-                reason.append("negation asymmetry")
-
-            # Check for opposite conclusions (simple heuristic)
-            # e.g., "X is good" vs "X is bad"
-            opposites = [
-                ("good", "bad"),
-                ("right", "wrong"),
-                ("true", "false"),
-                ("should", "should not"),
-                ("always", "never"),
-                ("prefer", "avoid"),
-                ("like", "dislike"),
-                ("works", "fails"),
-                ("correct", "incorrect"),
-            ]
-
-            for pos, neg in opposites:
-                if (pos in content_a and neg in content_b) or (neg in content_a and pos in content_b):
-                    conflict_signal += 0.3
-                    reason.append(f"opposite: {pos}/{neg}")
-                    break
-
-            # High similarity + some conflict signal = potential contradiction
-            if conflict_signal > 0.2 or pair["similarity"] > 0.92:
-                conflicts.append(
-                    {
-                        **pair,
-                        "conflict_score": conflict_signal + (pair["similarity"] - threshold) * 0.5,
-                        "reason": ", ".join(reason) if reason else "high similarity",
-                    }
-                )
-
-        if not conflicts:
-            print("✅ Found similar beliefs but no likely contradictions")
-            return 0
-
-        # Sort by conflict score
-        conflicts.sort(key=lambda x: x["conflict_score"], reverse=True)
-
-        print(f"⚠️  Found {len(conflicts)} potential conflict(s):\n")
-
-        for i, c in enumerate(conflicts[:10], 1):
-            print(f"{'═' * 60}")
-            print(f"Conflict #{i} (similarity: {c['similarity']:.1%}, signal: {c['conflict_score']:.2f})")
-            print(f"Reason: {c['reason']}")
-            print()
-            print(f"  A [{str(c['id_a'])[:8]}] {c['content_a'][:70]}...")
-            print(f"  B [{str(c['id_b'])[:8]}] {c['content_b'][:70]}...")
-            print()
-
-            if args.auto_record:
-                # Record as tension
-                cur.execute(
-                    """
-                    INSERT INTO tensions (belief_a_id, belief_b_id, type, description, severity)
-                    VALUES (%s, %s, 'contradiction', %s, %s)
-                    ON CONFLICT DO NOTHING
-                    RETURNING id
-                """,
-                    (
-                        c["id_a"],
-                        c["id_b"],
-                        f"Auto-detected: {c['reason']}",
-                        "high" if c["conflict_score"] > 0.5 else "medium",
-                    ),
-                )
-                tension_row = cur.fetchone()
-                if tension_row:
-                    print(f"  📝 Recorded as tension: {str(tension_row['id'])[:8]}")
-
-        if args.auto_record:
-            conn.commit()
-
-        print(f"{'═' * 60}")
-        print("\n💡 Use 'valence tension resolve <id>' to resolve conflicts")
-
+        result = client.get("/beliefs/conflicts", params=params)
+        output_result(result)
         return 0
-
-    except Exception as e:
-        print(f"❌ Conflict detection failed: {e}")
-        import traceback
-
-        traceback.print_exc()
+    except ValenceConnectionError as e:
+        output_error(str(e))
         return 1
-    finally:
-        if cur:
-            cur.close()
-        if conn:
-            conn.close()
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1

--- a/src/valence/cli/commands/embeddings.py
+++ b/src/valence/cli/commands/embeddings.py
@@ -3,22 +3,11 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
 
-from ..utils import get_db_connection
-
-logger = logging.getLogger(__name__)
-
-VALID_CONTENT_TYPES = ("belief", "exchange", "pattern")
-
-# Known embedding models and their dimensions
-KNOWN_MODELS = {
-    "BAAI/bge-small-en-v1.5": {"provider": "local", "dims": 384, "type_id": "local_bge_small"},
-    "text-embedding-3-small": {"provider": "openai", "dims": 1536, "type_id": "openai_text3_small"},
-    "text-embedding-3-large": {"provider": "openai", "dims": 3072, "type_id": "openai_text3_large"},
-    "text-embedding-ada-002": {"provider": "openai", "dims": 1536, "type_id": "openai_ada_002"},
-}
+from ..config import get_cli_config
+from ..http_client import ValenceAPIError, ValenceConnectionError, get_client
+from ..output import output_error, output_result
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
@@ -27,43 +16,30 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     embeddings_subparsers = embeddings_parser.add_subparsers(dest="embeddings_command", required=True)
 
     # embeddings backfill
-    backfill_parser = embeddings_subparsers.add_parser("backfill", help="Backfill missing or outdated embeddings")
+    backfill_parser = embeddings_subparsers.add_parser("backfill", help="Backfill missing embeddings")
     backfill_parser.add_argument(
         "--batch-size",
         "-b",
         type=int,
-        default=100,
-        help="Number of records to process per batch (default: 100)",
+        default=50,
+        help="Number of records to process per batch (default: 50)",
     )
     backfill_parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Show what would be backfilled without making changes",
     )
-    backfill_parser.add_argument(
-        "--content-type",
-        "-t",
-        choices=["belief", "exchange", "pattern"],
-        default=None,
-        help="Content type to backfill (default: all)",
-    )
-    backfill_parser.add_argument(
-        "--force",
-        "-f",
-        action="store_true",
-        help="Re-embed all records even if embedding exists (for provider migration)",
-    )
 
     # embeddings migrate
     migrate_parser = embeddings_subparsers.add_parser(
         "migrate",
-        help="Migrate to a different embedding model (changes VECTOR dimensions, clears old embeddings)",
+        help="Migrate to a different embedding model",
     )
     migrate_parser.add_argument(
         "--model",
         "-m",
         required=True,
-        help=f"Embedding model name. Known models: {', '.join(KNOWN_MODELS.keys())}. Or use custom with --dims.",
+        help="Embedding model name",
     )
     migrate_parser.add_argument(
         "--dims",
@@ -73,52 +49,15 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         help="Vector dimensions (auto-detected for known models)",
     )
     migrate_parser.add_argument(
-        "--provider",
-        "-p",
-        default=None,
-        help="Provider name (auto-detected for known models, e.g. 'local', 'openai')",
-    )
-    migrate_parser.add_argument(
-        "--type-id",
-        default=None,
-        help="Embedding type ID for the DB (auto-generated if not specified)",
-    )
-    migrate_parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Show what would change without making changes",
     )
 
     # embeddings status
-    embeddings_subparsers.add_parser("status", help="Show current embedding configuration and coverage")
+    embeddings_subparsers.add_parser("status", help="Show embedding configuration and coverage")
 
     embeddings_parser.set_defaults(func=cmd_embeddings)
-
-
-def _count_missing_embeddings(cur, content_type: str) -> int:
-    """Count records missing embeddings for a given content type."""
-    if content_type == "belief":
-        cur.execute("SELECT COUNT(*) as count FROM beliefs WHERE embedding IS NULL AND status = 'active'")
-    elif content_type == "exchange":
-        cur.execute("SELECT COUNT(*) as count FROM vkb_exchanges WHERE embedding IS NULL")
-    elif content_type == "pattern":
-        cur.execute("SELECT COUNT(*) as count FROM vkb_patterns WHERE embedding IS NULL")
-    else:
-        return 0
-    return cur.fetchone()["count"]
-
-
-def _count_all_embeddings(cur, content_type: str) -> int:
-    """Count all records (for --force mode)."""
-    if content_type == "belief":
-        cur.execute("SELECT COUNT(*) as count FROM beliefs WHERE status = 'active'")
-    elif content_type == "exchange":
-        cur.execute("SELECT COUNT(*) as count FROM vkb_exchanges")
-    elif content_type == "pattern":
-        cur.execute("SELECT COUNT(*) as count FROM vkb_patterns")
-    else:
-        return 0
-    return cur.fetchone()["count"]
 
 
 def cmd_embeddings(args: argparse.Namespace) -> int:
@@ -130,300 +69,64 @@ def cmd_embeddings(args: argparse.Namespace) -> int:
     elif args.embeddings_command == "status":
         return cmd_embeddings_status(args)
 
-    print("❌ Unknown embeddings command. Use 'valence embeddings {backfill,migrate,status}'.", file=sys.stderr)
+    print("Unknown embeddings command. Use 'valence embeddings {backfill,migrate,status}'.", file=sys.stderr)
     return 1
 
 
 def cmd_embeddings_backfill(args: argparse.Namespace) -> int:
-    """Backfill missing or outdated embeddings.
+    """Backfill missing embeddings via REST API."""
+    body: dict = {
+        "batch_size": args.batch_size,
+        "dry_run": args.dry_run,
+    }
 
-    Wraps the backfill_embeddings() service function with CLI niceties:
-    progress output, dry-run mode, content type filtering, and force re-embed.
-    """
-    from our_embeddings.service import backfill_embeddings, embed_content
-
-    batch_size: int = args.batch_size
-    dry_run: bool = args.dry_run
-    force: bool = args.force
-    content_type_filter: str | None = args.content_type
-
-    # Determine which content types to process
-    if content_type_filter:
-        if content_type_filter not in VALID_CONTENT_TYPES:
-            print(
-                f"❌ Invalid content type '{content_type_filter}'. Must be one of: {', '.join(VALID_CONTENT_TYPES)}",
-                file=sys.stderr,
-            )
-            return 1
-        content_types = [content_type_filter]
-    else:
-        content_types = list(VALID_CONTENT_TYPES)
-
-    conn = None
-    cur = None
+    client = get_client()
     try:
-        conn = get_db_connection()
-        cur = conn.cursor()
-
-        # Gather counts
-        total_to_process = 0
-        type_counts: dict[str, int] = {}
-        for ct in content_types:
-            if force:
-                count = _count_all_embeddings(cur, ct)
-            else:
-                count = _count_missing_embeddings(cur, ct)
-            type_counts[ct] = count
-            total_to_process += count
-
-        # Show summary
-        print("🧠 Embeddings Backfill")
-        print("─" * 40)
-        for ct in content_types:
-            label = "total" if force else "missing"
-            print(f"  {ct:>10}: {type_counts[ct]} {label}")
-        print(f"  {'total':>10}: {total_to_process}")
-        if force:
-            print("  ⚡ Force mode: re-embedding all records")
-        print(f"  📦 Batch size: {batch_size}")
-        print()
-
-        if total_to_process == 0:
-            print("✅ Nothing to backfill — all embeddings are up to date.")
-            return 0
-
-        if dry_run:
-            print("🔍 Dry run — no changes made.")
-            return 0
-
-        # Process each content type
-        grand_total = 0
-        for ct in content_types:
-            if type_counts[ct] == 0:
-                continue
-
-            if force:
-                # Force mode: fetch all records and re-embed them
-                count = _backfill_force(cur, conn, ct, batch_size, embed_content)
-            else:
-                # Normal mode: use the service function
-                count = backfill_embeddings(ct, batch_size=batch_size)
-
-            grand_total += count
-            print(f"  ✅ {ct}: {count} embedded")
-
-        print()
-        print(f"🎉 Backfill complete: {grand_total} embeddings generated.")
+        result = client.post("/admin/embeddings/backfill", body=body)
+        output_result(result)
         return 0
-
-    except Exception as e:
-        print(f"❌ Backfill failed: {e}", file=sys.stderr)
-        logger.exception("Backfill error")
+    except ValenceConnectionError as e:
+        output_error(str(e))
         return 1
-    finally:
-        if cur:
-            cur.close()
-        if conn:
-            conn.close()
-
-
-def _backfill_force(cur, conn, content_type: str, batch_size: int, embed_fn) -> int:
-    """Force re-embed all records of a given content type."""
-    from ...core.exceptions import DatabaseException, EmbeddingException
-
-    if content_type == "belief":
-        cur.execute(
-            "SELECT id, content FROM beliefs WHERE status = 'active' LIMIT %s",
-            (batch_size,),
-        )
-    elif content_type == "exchange":
-        cur.execute(
-            "SELECT id, content FROM vkb_exchanges LIMIT %s",
-            (batch_size,),
-        )
-    elif content_type == "pattern":
-        cur.execute(
-            "SELECT id, description as content FROM vkb_patterns LIMIT %s",
-            (batch_size,),
-        )
-    else:
-        return 0
-
-    rows = cur.fetchall()
-    count = 0
-
-    for row in rows:
-        try:
-            embed_fn(content_type, str(row["id"]), row["content"])
-            count += 1
-        except (EmbeddingException, DatabaseException) as e:
-            logger.error(f"Failed to embed {content_type} {row['id']}: {e}")
-
-    return count
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1
 
 
 def cmd_embeddings_migrate(args: argparse.Namespace) -> int:
-    """Migrate embedding dimensions to a different model.
+    """Migrate embedding model/dimensions via REST API."""
+    body: dict = {"dry_run": args.dry_run}
+    if args.model:
+        body["model"] = args.model
+    if args.dims:
+        body["dims"] = args.dims
 
-    Changes VECTOR column dimensions, clears old embeddings, and updates
-    the embedding_types table. Run `valence embeddings backfill --force`
-    after migration to re-embed all content.
-    """
-    model: str = args.model
-    dims: int | None = args.dims
-    provider: str | None = args.provider
-    type_id: str | None = args.type_id
-    dry_run: bool = args.dry_run
-
-    # Resolve model info
-    if model in KNOWN_MODELS:
-        info = KNOWN_MODELS[model]
-        dims = dims or info["dims"]
-        provider = provider or info["provider"]
-        type_id = type_id or info["type_id"]
-    else:
-        if dims is None:
-            print(f"❌ Unknown model '{model}'. Specify --dims for custom models.", file=sys.stderr)
-            return 1
-        provider = provider or "custom"
-        type_id = type_id or model.replace("/", "_").replace("-", "_").lower()
-
-    print("🔄 Embedding Migration")
-    print("─" * 40)
-    print(f"  Model:      {model}")
-    print(f"  Provider:   {provider}")
-    print(f"  Dimensions: {dims}")
-    print(f"  Type ID:    {type_id}")
-    print()
-
-    if dry_run:
-        print("🔍 Dry run — showing what would happen:")
-        print("  1. Register new embedding type in embedding_types table")
-        print("  2. Drop existing embedding indexes")
-        print(f"  3. ALTER VECTOR columns to VECTOR({dims})")
-        print("  4. NULL out all existing embeddings (incompatible dimensions)")
-        print("  5. Clear old embedding coverage records")
-        print("  6. Recreate embedding indexes")
-        print()
-        print("  After migration, run: valence embeddings backfill --force")
-        return 0
-
-    conn = None
+    client = get_client()
     try:
-        conn = get_db_connection()
-        conn.autocommit = False
-        cur = conn.cursor()
-
-        # Check current state
-        cur.execute("SELECT id, dimensions, is_default FROM embedding_types WHERE is_default = TRUE")
-        current = cur.fetchone()
-        if current:
-            if current["dimensions"] == dims and current["id"] == type_id:
-                print(f"✅ Already configured for {model} ({dims} dims). No migration needed.")
-                return 0
-            print(f"  Current: {current['id']} ({current['dimensions']} dims)")
-
-        # Execute migration via the helper function
-        cur.execute(
-            "SELECT * FROM migrate_embedding_dimensions(%s, %s, %s, %s)",
-            (dims, type_id, provider, model),
-        )
-        steps = cur.fetchall()
-        for step_row in steps:
-            print(f"  ✅ {step_row['step']}: {step_row['detail']}")
-
-        conn.commit()
-        print()
-        print(f"🎉 Migration to {model} ({dims} dims) complete.")
-        print("   Run: valence embeddings backfill --force")
+        result = client.post("/admin/embeddings/migrate", body=body)
+        output_result(result)
         return 0
-
-    except Exception as e:
-        if conn:
-            conn.rollback()
-        print(f"❌ Migration failed: {e}", file=sys.stderr)
-        logger.exception("Embedding migration error")
+    except ValenceConnectionError as e:
+        output_error(str(e))
         return 1
-    finally:
-        if conn:
-            conn.close()
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1
 
 
 def cmd_embeddings_status(args: argparse.Namespace) -> int:
-    """Show current embedding configuration and coverage."""
-    conn = None
+    """Show embedding status via REST API."""
+    config = get_cli_config()
+    params: dict = {"output": config.output}
+
+    client = get_client()
     try:
-        conn = get_db_connection()
-        cur = conn.cursor()
-
-        # Get embedding types
-        cur.execute("SELECT id, provider, model, dimensions, is_default, status FROM embedding_types ORDER BY is_default DESC, id")
-        types = cur.fetchall()
-
-        print("🧠 Embedding Status")
-        print("─" * 50)
-
-        if not types:
-            print("  No embedding types configured.")
-        else:
-            print("  Configured Models:")
-            for t in types:
-                default_marker = " ★" if t["is_default"] else ""
-                print(f"    {t['id']}: {t['provider']}/{t['model']} ({t['dimensions']} dims) [{t['status']}]{default_marker}")
-
-        # Get column dimensions from information_schema
-        cur.execute("""
-            SELECT c.table_name, c.column_name, c.udt_name,
-                   CASE WHEN c.udt_name = 'vector' THEN
-                       (SELECT atttypmod FROM pg_attribute a JOIN pg_class cl ON a.attrelid = cl.oid
-                        WHERE cl.relname = c.table_name AND a.attname = c.column_name AND a.atttypmod > 0)
-                   END as dims
-            FROM information_schema.columns c
-            WHERE c.udt_name = 'vector'
-              AND c.table_schema = 'public'
-            ORDER BY c.table_name
-        """)
-        vector_cols = cur.fetchall()
-
-        if vector_cols:
-            print()
-            print("  VECTOR Columns:")
-            for vc in vector_cols:
-                dims_str = f"VECTOR({vc['dims']})" if vc["dims"] else "VECTOR(?)"
-                print(f"    {vc['table_name']}.{vc['column_name']}: {dims_str}")
-
-        # Get coverage stats
-        cur.execute("""
-            SELECT ec.embedding_type_id, ec.content_type, COUNT(*) as count
-            FROM embedding_coverage ec
-            GROUP BY ec.embedding_type_id, ec.content_type
-            ORDER BY ec.embedding_type_id, ec.content_type
-        """)
-        coverage = cur.fetchall()
-
-        # Get totals
-        cur.execute("SELECT COUNT(*) as count FROM beliefs WHERE status = 'active'")
-        total_beliefs = cur.fetchone()["count"]
-        cur.execute("SELECT COUNT(*) as count FROM beliefs WHERE embedding IS NOT NULL AND status = 'active'")
-        embedded_beliefs = cur.fetchone()["count"]
-
-        print()
-        print("  Coverage:")
-        print(f"    Beliefs: {embedded_beliefs}/{total_beliefs} embedded")
-
-        if coverage:
-            print()
-            print("  Coverage by Type:")
-            for c in coverage:
-                print(f"    {c['embedding_type_id']}/{c['content_type']}: {c['count']}")
-
-        print()
+        result = client.get("/admin/embeddings/status", params=params)
+        output_result(result)
         return 0
-
-    except Exception as e:
-        print(f"❌ Status check failed: {e}", file=sys.stderr)
-        logger.exception("Embedding status error")
+    except ValenceConnectionError as e:
+        output_error(str(e))
         return 1
-    finally:
-        if conn:
-            conn.close()
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1

--- a/src/valence/cli/commands/maintenance.py
+++ b/src/valence/cli/commands/maintenance.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import argparse
-import json
 
-from ..utils import get_db_connection
+from ..config import get_cli_config
+from ..http_client import ValenceAPIError, ValenceConnectionError, get_client
+from ..output import output_error, output_result
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
@@ -19,28 +20,33 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     maint_parser.add_argument("--vacuum", action="store_true", help="Run VACUUM ANALYZE on key tables")
     maint_parser.add_argument("--all", action="store_true", dest="run_all", help="Run full maintenance cycle")
     maint_parser.add_argument("--dry-run", action="store_true", help="Report what would happen without making changes")
-    maint_parser.add_argument("--json", action="store_true", dest="output_json", help="Output as JSON")
     maint_parser.set_defaults(func=cmd_maintenance)
 
 
 def cmd_maintenance(args: argparse.Namespace) -> int:
-    """Run maintenance operations."""
-    from ...core.maintenance import (
-        MaintenanceResult,
-        apply_retention,
-        archive_beliefs,
-        cleanup_tombstones,
-        compact_exchanges,
-        refresh_views,
-        run_full_maintenance,
-        vacuum_analyze,
-    )
+    """Run maintenance operations via REST API."""
+    config = get_cli_config()
 
-    # Determine what to run
-    run_all = args.run_all
-    specific = args.retention or args.archive or args.tombstones or args.compact or args.views or args.vacuum
+    # Build request body from flags
+    body: dict = {}
+    if args.run_all:
+        body["all"] = True
+    if args.retention:
+        body["retention"] = True
+    if args.archive:
+        body["archive"] = True
+    if args.tombstones:
+        body["tombstones"] = True
+    if args.compact:
+        body["compact"] = True
+    if args.views:
+        body["views"] = True
+    if args.vacuum:
+        body["vacuum"] = True
+    if args.dry_run:
+        body["dry_run"] = True
 
-    if not run_all and not specific:
+    if not args.run_all and not any(getattr(args, op) for op in ("retention", "archive", "tombstones", "compact", "views", "vacuum")):
         print("No operation specified. Use --all for full cycle, or specify individual operations.")
         print("  --retention   Apply retention policies")
         print("  --archive     Archive stale beliefs")
@@ -52,80 +58,16 @@ def cmd_maintenance(args: argparse.Namespace) -> int:
         print("  --dry-run     Preview without changes")
         return 1
 
-    conn = None
-    cur = None
-    results: list[MaintenanceResult] = []
+    params: dict = {"output": config.output}
 
+    client = get_client()
     try:
-        conn = get_db_connection()
-
-        if run_all:
-            # Full maintenance needs autocommit for VACUUM
-            if not args.dry_run:
-                conn.autocommit = True
-            cur = conn.cursor()
-            results = run_full_maintenance(cur, dry_run=args.dry_run)
-        else:
-            # Individual operations
-            cur = conn.cursor()
-
-            if args.retention:
-                results.extend(apply_retention(cur, dry_run=args.dry_run))
-
-            if args.archive:
-                results.append(archive_beliefs(cur, dry_run=args.dry_run))
-
-            if args.tombstones:
-                results.append(cleanup_tombstones(cur, dry_run=args.dry_run))
-
-            if args.compact:
-                results.append(compact_exchanges(cur, dry_run=args.dry_run))
-
-            if args.views and not args.dry_run:
-                results.append(refresh_views(cur))
-            elif args.views and args.dry_run:
-                results.append(MaintenanceResult(
-                    operation="refresh_views",
-                    details={"note": "skipped in dry-run mode"},
-                    dry_run=True,
-                ))
-
-            if args.vacuum and not args.dry_run:
-                conn.autocommit = True
-                results.append(vacuum_analyze(cur))
-            elif args.vacuum and args.dry_run:
-                results.append(MaintenanceResult(
-                    operation="vacuum_analyze",
-                    details={"note": "skipped in dry-run mode"},
-                    dry_run=True,
-                ))
-
-            if not conn.autocommit:
-                conn.commit()
-
-        # Output results
-        if args.output_json:
-            output = [{"operation": r.operation, "dry_run": r.dry_run, **r.details} for r in results]
-            print(json.dumps(output, indent=2, default=str))
-        else:
-            dry_label = " (dry run)" if args.dry_run else ""
-            print(f"Maintenance Report{dry_label}")
-            print("=" * 50)
-            for r in results:
-                print(f"  {r}")
-            print("=" * 50)
-            print(f"  {len(results)} operation(s) completed")
-
+        result = client.post("/admin/maintenance", body=body, params=params)
+        output_result(result)
         return 0
-
-    except Exception as e:
-        print(f"Maintenance failed: {e}")
-        import traceback
-
-        traceback.print_exc()
+    except ValenceConnectionError as e:
+        output_error(str(e))
         return 1
-    finally:
-        if cur:
-            cur.close()
-        if conn:
-            conn.close()
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1

--- a/src/valence/cli/commands/migration.py
+++ b/src/valence/cli/commands/migration.py
@@ -1,89 +1,51 @@
 """Migration commands for Valence CLI.
 
 Provides:
-  valence migrate up [--to VERSION] [--dry-run]
-  valence migrate down [--to VERSION] [--dry-run]
+  valence migrate up [--dry-run]
+  valence migrate down [--dry-run]
   valence migrate status
-  valence migrate create NAME
-  valence migrate bootstrap [--dry-run]
-  valence migrate-visibility  (legacy)
+  valence migrate create NAME  (local-only, scaffolds migration file)
 """
 
 from __future__ import annotations
 
 import argparse
-import logging
 import sys
 from pathlib import Path
 
-from ..utils import get_db_connection
-
-logger = logging.getLogger(__name__)
+from ..config import get_cli_config
+from ..http_client import ValenceAPIError, ValenceConnectionError, get_client
+from ..output import output_error, output_result
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
-    """Register migrate and migrate-visibility commands on the CLI parser."""
-    # migrate
+    """Register migrate commands on the CLI parser."""
     migrate_parser = subparsers.add_parser("migrate", help="Database migration management")
     migrate_subparsers = migrate_parser.add_subparsers(dest="migrate_command", required=True)
 
     # migrate up
     migrate_up = migrate_subparsers.add_parser("up", help="Apply pending migrations")
-    migrate_up.add_argument("--to", help="Apply up to this version (inclusive)")
     migrate_up.add_argument("--dry-run", action="store_true", help="Show what would be applied")
 
     # migrate down
-    migrate_down = migrate_subparsers.add_parser("down", help="Rollback migrations")
-    migrate_down.add_argument("--to", help="Rollback to this version (exclusive — it stays applied)")
+    migrate_down = migrate_subparsers.add_parser("down", help="Rollback the last migration")
     migrate_down.add_argument("--dry-run", action="store_true", help="Show what would be rolled back")
 
     # migrate status
     migrate_subparsers.add_parser("status", help="Show migration status")
 
-    # migrate create
+    # migrate create (local-only — scaffolds a file, no server call)
     migrate_create = migrate_subparsers.add_parser("create", help="Scaffold a new migration")
     migrate_create.add_argument("name", help="Migration name (e.g. add_users_table)")
 
-    # migrate bootstrap
-    migrate_bootstrap = migrate_subparsers.add_parser("bootstrap", help="Bootstrap fresh database")
-    migrate_bootstrap.add_argument("--dry-run", action="store_true", help="Show what would be applied")
-
     migrate_parser.set_defaults(func=cmd_migrate)
-
-    # migrate-visibility (legacy)
-    mv_parser = subparsers.add_parser(
-        "migrate-visibility",
-        help="Migrate existing beliefs from visibility to SharePolicy",
-    )
-    mv_parser.set_defaults(func=cmd_migrate_visibility)
-
-
-def _get_migrations_dir() -> Path:
-    """Resolve the migrations directory (repo root / migrations)."""
-    # Walk up from this file to find the repo root
-    # This file: src/valence/cli/commands/migration.py
-    # Repo root: ../../../../
-    here = Path(__file__).resolve()
-    repo_root = here.parent.parent.parent.parent.parent
-    migrations_dir = repo_root / "migrations"
-    return migrations_dir
-
-
-def _make_runner():
-    """Create a MigrationRunner with CLI-appropriate connection factory."""
-    from ...core.migrations import MigrationRunner
-
-    return MigrationRunner(
-        migrations_dir=_get_migrations_dir(),
-        connection_factory=get_db_connection,
-    )
 
 
 def cmd_migrate(args: argparse.Namespace) -> int:
     """Dispatch migrate subcommands."""
     subcmd = getattr(args, "migrate_command", None)
     if subcmd is None:
-        print("Usage: valence migrate {up|down|status|create|bootstrap}", file=sys.stderr)
+        print("Usage: valence migrate {up|down|status|create}", file=sys.stderr)
         return 1
 
     handlers = {
@@ -91,7 +53,6 @@ def cmd_migrate(args: argparse.Namespace) -> int:
         "down": cmd_migrate_down,
         "status": cmd_migrate_status,
         "create": cmd_migrate_create,
-        "bootstrap": cmd_migrate_bootstrap,
     }
     handler = handlers.get(subcmd)
     if handler is None:
@@ -101,73 +62,57 @@ def cmd_migrate(args: argparse.Namespace) -> int:
 
 
 def cmd_migrate_up(args: argparse.Namespace) -> int:
-    """Apply pending migrations."""
-    runner = _make_runner()
-    target = getattr(args, "to", None)
+    """Apply pending migrations via REST API."""
     dry_run = getattr(args, "dry_run", False)
-
+    client = get_client()
     try:
-        applied = runner.up(target=target, dry_run=dry_run)
-        if not applied:
-            print("✅ No pending migrations.")
-        else:
-            prefix = "[DRY RUN] " if dry_run else ""
-            print(f"\n{prefix}Applied {len(applied)} migration(s):")
-            for v in applied:
-                print(f"  ✓ {v}")
+        result = client.post("/admin/migrate/up", body={"dry_run": dry_run})
+        output_result(result)
         return 0
-    except Exception as e:
-        print(f"❌ Migration failed: {e}", file=sys.stderr)
+    except ValenceConnectionError as e:
+        output_error(str(e))
+        return 1
+    except ValenceAPIError as e:
+        output_error(e.message)
         return 1
 
 
 def cmd_migrate_down(args: argparse.Namespace) -> int:
-    """Rollback migrations."""
-    runner = _make_runner()
-    target = getattr(args, "to", None)
+    """Rollback the last migration via REST API."""
     dry_run = getattr(args, "dry_run", False)
-
+    client = get_client()
     try:
-        rolled_back = runner.down(target=target, dry_run=dry_run)
-        if not rolled_back:
-            print("✅ Nothing to rollback.")
-        else:
-            prefix = "[DRY RUN] " if dry_run else ""
-            print(f"\n{prefix}Rolled back {len(rolled_back)} migration(s):")
-            for v in rolled_back:
-                print(f"  ↩ {v}")
+        result = client.post("/admin/migrate/down", body={"dry_run": dry_run})
+        output_result(result)
         return 0
-    except Exception as e:
-        print(f"❌ Rollback failed: {e}", file=sys.stderr)
+    except ValenceConnectionError as e:
+        output_error(str(e))
+        return 1
+    except ValenceAPIError as e:
+        output_error(e.message)
         return 1
 
 
 def cmd_migrate_status(args: argparse.Namespace) -> int:
-    """Show migration status."""
-    runner = _make_runner()
+    """Show migration status via REST API."""
+    config = get_cli_config()
+    params: dict = {"output": config.output}
 
+    client = get_client()
     try:
-        statuses = runner.status()
-        if not statuses:
-            print("No migrations found.")
-            return 0
-
-        print(f"\n{'Version':<10} {'Description':<30} {'State':<20} {'Applied At'}")
-        print("─" * 85)
-        for s in statuses:
-            applied_str = s.applied_at.strftime("%Y-%m-%d %H:%M:%S") if s.applied_at else ""
-            state_icon = {"applied": "✓", "pending": "•", "checksum_mismatch": "⚠"}
-            icon = state_icon.get(s.state, "?")
-            print(f"  {icon} {s.version:<8} {s.description:<30} {s.state:<20} {applied_str}")
-        print()
+        result = client.get("/admin/migrate/status", params=params)
+        output_result(result)
         return 0
-    except Exception as e:
-        print(f"❌ Failed to get status: {e}", file=sys.stderr)
+    except ValenceConnectionError as e:
+        output_error(str(e))
+        return 1
+    except ValenceAPIError as e:
+        output_error(e.message)
         return 1
 
 
 def cmd_migrate_create(args: argparse.Namespace) -> int:
-    """Create a new migration scaffold."""
+    """Create a new migration scaffold (local-only, no server call)."""
     from ...core.migrations import MigrationRunner
 
     name = args.name
@@ -175,88 +120,16 @@ def cmd_migrate_create(args: argparse.Namespace) -> int:
 
     try:
         path = MigrationRunner.create_migration(migrations_dir, name)
-        print(f"✅ Created migration: {path.name}")
+        print(f"Created migration: {path.name}")
         print(f"   Edit: {path}")
         return 0
     except Exception as e:
-        print(f"❌ Failed to create migration: {e}", file=sys.stderr)
+        output_error(f"Failed to create migration: {e}")
         return 1
 
 
-def cmd_migrate_bootstrap(args: argparse.Namespace) -> int:
-    """Bootstrap a fresh database with all migrations."""
-    runner = _make_runner()
-    dry_run = getattr(args, "dry_run", False)
-
-    try:
-        applied = runner.bootstrap(dry_run=dry_run)
-        if not applied:
-            print("✅ No migrations to apply.")
-        else:
-            prefix = "[DRY RUN] " if dry_run else ""
-            print(f"\n{prefix}Bootstrapped with {len(applied)} migration(s):")
-            for v in applied:
-                print(f"  ✓ {v}")
-        return 0
-    except RuntimeError as e:
-        print(f"❌ {e}", file=sys.stderr)
-        return 1
-    except Exception as e:
-        print(f"❌ Bootstrap failed: {e}", file=sys.stderr)
-        return 1
-
-
-# --------------------------------------------------------------------------
-# Legacy command (kept for backward compat)
-# --------------------------------------------------------------------------
-
-
-def cmd_migrate_visibility(args: argparse.Namespace) -> int:
-    """Migrate existing beliefs from old visibility to SharePolicy."""
-    from our_privacy.migration import migrate_all_beliefs_sync
-
-    print("🔄 Migrating visibility to SharePolicy...")
-
-    try:
-        conn = get_db_connection()
-
-        cur = conn.cursor()
-        cur.execute(
-            """
-            SELECT EXISTS (
-                SELECT FROM information_schema.columns
-                WHERE table_name = 'beliefs' AND column_name = 'share_policy'
-            )
-        """
-        )
-        has_column = cur.fetchone()["exists"]
-
-        if not has_column:
-            print("⚠️  share_policy column not found. Adding it...")
-            cur.execute("ALTER TABLE beliefs ADD COLUMN IF NOT EXISTS share_policy JSONB")
-            conn.commit()
-            print("✅ share_policy column added")
-
-        cur.close()
-
-        result = migrate_all_beliefs_sync(conn)
-
-        print("\n📊 Migration Results:")
-        print(f"   Total beliefs:     {result['total']}")
-        print(f"   Needed migration:  {result['needed_migration']}")
-        print(f"   Migrated:          {result['migrated']}")
-
-        if result["needed_migration"] == 0:
-            print("\n✅ All beliefs already have share_policy set")
-        else:
-            print(f"\n✅ Successfully migrated {result['needed_migration']} beliefs")
-
-        conn.close()
-        return 0
-
-    except Exception as e:
-        print(f"❌ Migration failed: {e}")
-        import traceback
-
-        traceback.print_exc()
-        return 1
+def _get_migrations_dir() -> Path:
+    """Resolve the migrations directory (repo root / migrations)."""
+    here = Path(__file__).resolve()
+    repo_root = here.parent.parent.parent.parent.parent
+    return repo_root / "migrations"

--- a/src/valence/cli/commands/stats.py
+++ b/src/valence/cli/commands/stats.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import argparse
-import logging
 
-from ..utils import get_db_connection
-
-logger = logging.getLogger(__name__)
+from ..config import get_cli_config
+from ..http_client import ValenceAPIError, ValenceConnectionError, get_client
+from ..output import output_error, output_result
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
@@ -17,57 +16,18 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 
 
 def cmd_stats(args: argparse.Namespace) -> int:
-    """Show database statistics."""
-    conn = None
-    cur = None
+    """Show database statistics via REST API."""
+    config = get_cli_config()
+    params: dict = {"output": config.output}
+
+    client = get_client()
     try:
-        conn = get_db_connection()
-        cur = conn.cursor()
-
-        cur.execute("SELECT COUNT(*) as total FROM beliefs")
-        total = cur.fetchone()["total"]
-
-        cur.execute("SELECT COUNT(*) as active FROM beliefs WHERE status = 'active' AND superseded_by_id IS NULL")
-        active = cur.fetchone()["active"]
-
-        cur.execute("SELECT COUNT(*) as with_emb FROM beliefs WHERE embedding IS NOT NULL")
-        with_embedding = cur.fetchone()["with_emb"]
-
-        cur.execute("SELECT COUNT(*) as tensions FROM tensions WHERE status = 'detected'")
-        tensions = cur.fetchone()["tensions"]
-
-        try:
-            cur.execute("SELECT COUNT(DISTINCT d) as count FROM beliefs, LATERAL unnest(domain_path) as d")
-            domains = cur.fetchone()["count"]
-        except (Exception,) as e:
-            logger.debug(f"Could not count domains (column may not exist): {e}")
-            domains = 0
-
-        # Count federated beliefs
-        try:
-            cur.execute("SELECT COUNT(*) as federated FROM beliefs WHERE is_local = FALSE")
-            federated = cur.fetchone()["federated"]
-        except (Exception,) as e:
-            logger.debug(f"Could not count federated beliefs (column may not exist): {e}")
-            federated = 0
-
-        print("📊 Valence Statistics")
-        print("─" * 30)
-        print(f"  Total beliefs:      {total}")
-        print(f"  Active beliefs:     {active}")
-        print(f"  Local beliefs:      {active - federated}")
-        print(f"  Federated beliefs:  {federated}")
-        print(f"  With embeddings:    {with_embedding}")
-        print(f"  Unique domains:     {domains}")
-        print(f"  Unresolved tensions:{tensions}")
-
+        result = client.get("/stats", params=params)
+        output_result(result)
         return 0
-
-    except Exception as e:
-        print(f"❌ Stats failed: {e}")
+    except ValenceConnectionError as e:
+        output_error(str(e))
         return 1
-    finally:
-        if cur:
-            cur.close()
-        if conn:
-            conn.close()
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1

--- a/src/valence/cli/config.py
+++ b/src/valence/cli/config.py
@@ -1,0 +1,103 @@
+"""CLI configuration — server URL, auth token, output format.
+
+Loads from ~/.valence/cli.toml with environment variable and flag overrides.
+Precedence: CLI flags > env vars > config file > defaults.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+_DEFAULT_CONFIG_PATH = Path.home() / ".valence" / "cli.toml"
+_DEFAULT_SERVER_URL = "http://127.0.0.1:8420"
+_DEFAULT_OUTPUT = "text"
+_DEFAULT_TIMEOUT = 30.0
+_ADMIN_TIMEOUT = 300.0
+
+
+@dataclass
+class CLIConfig:
+    """CLI configuration loaded from file, env, and flags."""
+
+    server_url: str = _DEFAULT_SERVER_URL
+    token: str = ""
+    output: str = _DEFAULT_OUTPUT
+    timeout: float = _DEFAULT_TIMEOUT
+
+    @classmethod
+    def load(
+        cls,
+        config_path: Path | None = None,
+        server_url: str | None = None,
+        token: str | None = None,
+        output: str | None = None,
+        timeout: float | None = None,
+    ) -> CLIConfig:
+        """Load config with precedence: flags > env > file > defaults."""
+        config = cls()
+
+        # 1. Load from file
+        path = config_path or _DEFAULT_CONFIG_PATH
+        if path.exists():
+            config._load_from_file(path)
+
+        # 2. Override from env
+        if url := os.environ.get("VALENCE_SERVER_URL"):
+            config.server_url = url
+        if tok := os.environ.get("VALENCE_TOKEN"):
+            config.token = tok
+        if out := os.environ.get("VALENCE_OUTPUT"):
+            if out in ("json", "text", "table"):
+                config.output = out
+
+        # 3. Override from flags (highest precedence)
+        if server_url is not None:
+            config.server_url = server_url
+        if token is not None:
+            config.token = token
+        if output is not None:
+            config.output = output
+        if timeout is not None:
+            config.timeout = timeout
+
+        return config
+
+    def _load_from_file(self, path: Path) -> None:
+        """Parse TOML config file."""
+        import tomllib
+
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+        if "server_url" in data:
+            self.server_url = str(data["server_url"])
+        if "token" in data:
+            self.token = str(data["token"])
+        if "output" in data and data["output"] in ("json", "text", "table"):
+            self.output = str(data["output"])
+        if "timeout" in data:
+            self.timeout = float(data["timeout"])
+
+
+_config: CLIConfig | None = None
+
+
+def get_cli_config() -> CLIConfig:
+    """Get the current CLI config singleton."""
+    global _config
+    if _config is None:
+        _config = CLIConfig.load()
+    return _config
+
+
+def set_cli_config(config: CLIConfig) -> None:
+    """Set the CLI config singleton (called from main after parsing args)."""
+    global _config
+    _config = config
+
+
+def reset_cli_config() -> None:
+    """Reset the config singleton (for testing)."""
+    global _config
+    _config = None

--- a/src/valence/cli/http_client.py
+++ b/src/valence/cli/http_client.py
@@ -1,0 +1,112 @@
+"""HTTP client for the Valence REST API.
+
+All CLI commands use this module to communicate with the server.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from .config import get_cli_config
+
+
+class ValenceAPIError(Exception):
+    """Raised when the API returns an error response."""
+
+    def __init__(self, status_code: int, code: str, message: str):
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        super().__init__(f"[{status_code}] {code}: {message}")
+
+
+class ValenceConnectionError(Exception):
+    """Raised when unable to connect to the server."""
+
+    def __init__(self, server_url: str, detail: str = ""):
+        self.server_url = server_url
+        msg = f"Cannot connect to Valence server at {server_url}"
+        if detail:
+            msg += f": {detail}"
+        msg += "\n\nIs the server running? Start with: valence-server"
+        super().__init__(msg)
+
+
+class ValenceClient:
+    """Thin HTTP client for the Valence REST API."""
+
+    def __init__(self, server_url: str | None = None, token: str | None = None, timeout: float | None = None):
+        config = get_cli_config()
+        self.base_url = (server_url if server_url is not None else config.server_url).rstrip("/")
+        self.token = token if token is not None else config.token
+        self.timeout = timeout if timeout is not None else config.timeout
+
+    def _headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}/api/v1{path}"
+
+    def _handle_response(self, resp: httpx.Response) -> dict[str, Any]:
+        """Parse response, raise ValenceAPIError on failure."""
+        if resp.status_code >= 400:
+            try:
+                body = resp.json()
+                error = body.get("error", {})
+                raise ValenceAPIError(
+                    status_code=resp.status_code,
+                    code=error.get("code", "UNKNOWN"),
+                    message=error.get("message", resp.text),
+                )
+            except (json.JSONDecodeError, KeyError):
+                raise ValenceAPIError(resp.status_code, "UNKNOWN", resp.text)
+
+        # For text/table output modes, server may return plain text
+        content_type = resp.headers.get("content-type", "")
+        if "text/plain" in content_type:
+            return {"formatted": resp.text}
+
+        try:
+            return resp.json()
+        except json.JSONDecodeError:
+            return {"formatted": resp.text}
+
+    def _request(self, method: str, path: str, params: dict[str, Any] | None = None, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Execute an HTTP request with connection error handling."""
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                resp = client.request(
+                    method,
+                    self._url(path),
+                    headers=self._headers(),
+                    params=params,
+                    json=body if method in ("POST", "PUT", "PATCH", "DELETE") and body is not None else None,
+                )
+            return self._handle_response(resp)
+        except httpx.ConnectError:
+            raise ValenceConnectionError(self.base_url)
+        except httpx.TimeoutException:
+            raise ValenceConnectionError(self.base_url, "request timed out")
+
+    def get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """HTTP GET request."""
+        return self._request("GET", path, params=params)
+
+    def post(self, path: str, body: dict[str, Any] | None = None, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """HTTP POST request."""
+        return self._request("POST", path, params=params, body=body)
+
+    def delete(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """HTTP DELETE request."""
+        return self._request("DELETE", path, params=params)
+
+
+def get_client() -> ValenceClient:
+    """Get a configured ValenceClient instance."""
+    return ValenceClient()

--- a/src/valence/cli/output.py
+++ b/src/valence/cli/output.py
@@ -1,0 +1,35 @@
+"""Output formatting for CLI commands.
+
+Handles JSON vs server-formatted text output based on CLI config.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from .config import get_cli_config
+
+
+def output_result(data: dict[str, Any], output_format: str | None = None) -> None:
+    """Print API response in the configured output format.
+
+    If output is "json", pretty-print the full JSON response.
+    If the response has a "formatted" key (server-side formatting), print that directly.
+    Otherwise fall back to JSON.
+    """
+    fmt = output_format or get_cli_config().output
+
+    if fmt == "json":
+        print(json.dumps(data, indent=2, default=str))
+    elif "formatted" in data:
+        print(data["formatted"])
+    else:
+        # Fallback: dump as JSON even in text mode if server didn't format
+        print(json.dumps(data, indent=2, default=str))
+
+
+def output_error(message: str) -> None:
+    """Print error message to stderr."""
+    print(f"Error: {message}", file=sys.stderr)

--- a/src/valence/server/admin_endpoints.py
+++ b/src/valence/server/admin_endpoints.py
@@ -1,0 +1,428 @@
+"""Admin REST endpoints for database management operations.
+
+All endpoints require admin:write scope (bearer tokens get full access automatically).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from .auth_helpers import authenticate, require_scope
+from .endpoint_utils import format_response, parse_output_format
+from .errors import internal_error, invalid_json_error, missing_field_error
+from .formatters import format_embeddings_status_text, format_maintenance_text, format_migration_status_text
+
+logger = logging.getLogger(__name__)
+
+ADMIN_SCOPE = "admin:write"
+
+
+# =============================================================================
+# MIGRATIONS
+# =============================================================================
+
+
+async def admin_migrate_status(request: Request) -> JSONResponse:
+    """GET /api/v1/admin/migrate/status — Show migration status."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, ADMIN_SCOPE):
+        return err
+
+    output_format = parse_output_format(request)
+
+    try:
+        from our_db import get_cursor
+
+        with get_cursor() as cur:
+            cur.execute("""
+                SELECT name, applied_at
+                FROM schema_migrations
+                ORDER BY applied_at
+            """)
+            applied = cur.fetchall()
+
+        migrations = [{"name": m["name"], "status": "applied", "applied_at": str(m["applied_at"])} for m in applied]
+
+        result = {"success": True, "migrations": migrations, "count": len(migrations)}
+        return format_response(result, output_format, text_formatter=format_migration_status_text)
+    except Exception:
+        logger.exception("Error getting migration status")
+        return internal_error()
+
+
+async def admin_migrate_up(request: Request) -> JSONResponse:
+    """POST /api/v1/admin/migrate/up — Apply pending migrations."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, ADMIN_SCOPE):
+        return err
+
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        body = {}
+
+    dry_run = body.get("dry_run", False)
+
+    try:
+        from ..core.migrations import MigrationRunner
+
+        runner = MigrationRunner()
+        applied = runner.up(dry_run=dry_run)
+
+        return JSONResponse({
+            "success": True,
+            "applied": applied,
+            "dry_run": dry_run,
+        })
+    except Exception:
+        logger.exception("Migration up failed")
+        return internal_error()
+
+
+async def admin_migrate_down(request: Request) -> JSONResponse:
+    """POST /api/v1/admin/migrate/down — Rollback the last migration."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, ADMIN_SCOPE):
+        return err
+
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        body = {}
+
+    dry_run = body.get("dry_run", False)
+
+    try:
+        from ..core.migrations import MigrationRunner
+
+        runner = MigrationRunner()
+        rolled_back = runner.down(dry_run=dry_run)
+
+        return JSONResponse({
+            "success": True,
+            "rolled_back": rolled_back,
+            "dry_run": dry_run,
+        })
+    except Exception:
+        logger.exception("Migration down failed")
+        return internal_error()
+
+
+# =============================================================================
+# MAINTENANCE
+# =============================================================================
+
+
+async def admin_maintenance(request: Request) -> JSONResponse:
+    """POST /api/v1/admin/maintenance — Run maintenance operations.
+
+    JSON body fields (all optional booleans):
+        retention, archive, tombstones, compact, views, vacuum, all, dry_run
+    """
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, ADMIN_SCOPE):
+        return err
+
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return invalid_json_error()
+
+    output_format = parse_output_format(request)
+    dry_run = body.get("dry_run", False)
+    run_all = body.get("all", False)
+
+    ops_requested = any(body.get(op) for op in ("retention", "archive", "tombstones", "compact", "views", "vacuum"))
+    if not run_all and not ops_requested:
+        return missing_field_error("at least one operation (retention, archive, tombstones, compact, views, vacuum, all)")
+
+    try:
+        from ..cli.utils import get_db_connection
+        from ..core.maintenance import (
+            MaintenanceResult,
+            apply_retention,
+            archive_beliefs,
+            cleanup_tombstones,
+            compact_exchanges,
+            refresh_views,
+            run_full_maintenance,
+            vacuum_analyze,
+        )
+
+        conn = get_db_connection()
+        results: list[MaintenanceResult] = []
+
+        try:
+            if run_all:
+                if not dry_run:
+                    conn.autocommit = True
+                cur = conn.cursor()
+                results = run_full_maintenance(cur, dry_run=dry_run)
+            else:
+                cur = conn.cursor()
+
+                if body.get("retention"):
+                    results.extend(apply_retention(cur, dry_run=dry_run))
+                if body.get("archive"):
+                    results.append(archive_beliefs(cur, dry_run=dry_run))
+                if body.get("tombstones"):
+                    results.append(cleanup_tombstones(cur, dry_run=dry_run))
+                if body.get("compact"):
+                    results.append(compact_exchanges(cur, dry_run=dry_run))
+                if body.get("views") and not dry_run:
+                    results.append(refresh_views(cur))
+                elif body.get("views"):
+                    results.append(MaintenanceResult(operation="refresh_views", details={"note": "skipped in dry-run"}, dry_run=True))
+                if body.get("vacuum") and not dry_run:
+                    conn.autocommit = True
+                    results.append(vacuum_analyze(cur))
+                elif body.get("vacuum"):
+                    results.append(MaintenanceResult(operation="vacuum_analyze", details={"note": "skipped in dry-run"}, dry_run=True))
+
+                if not conn.autocommit:
+                    conn.commit()
+        finally:
+            cur.close()
+            conn.close()
+
+        result_dicts = [{"operation": r.operation, "dry_run": r.dry_run, **r.details} for r in results]
+
+        result = {
+            "success": True,
+            "results": result_dicts,
+            "count": len(result_dicts),
+            "dry_run": dry_run,
+        }
+        return format_response(result, output_format, text_formatter=format_maintenance_text)
+    except Exception:
+        logger.exception("Maintenance failed")
+        return internal_error()
+
+
+# =============================================================================
+# EMBEDDINGS
+# =============================================================================
+
+
+async def admin_embeddings_status(request: Request) -> JSONResponse:
+    """GET /api/v1/admin/embeddings/status — Embedding coverage status."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, ADMIN_SCOPE):
+        return err
+
+    output_format = parse_output_format(request)
+
+    try:
+        from our_db import get_cursor
+
+        with get_cursor() as cur:
+            cur.execute("SELECT COUNT(*) as total FROM beliefs")
+            total = cur.fetchone()["total"]
+            cur.execute("SELECT COUNT(*) as embedded FROM beliefs WHERE embedding IS NOT NULL")
+            embedded = cur.fetchone()["embedded"]
+            cur.execute("SELECT COUNT(*) as missing FROM beliefs WHERE embedding IS NULL")
+            missing = cur.fetchone()["missing"]
+
+        coverage = f"{embedded / total:.1%}" if total > 0 else "N/A"
+        result = {
+            "success": True,
+            "stats": {
+                "total_beliefs": total,
+                "with_embeddings": embedded,
+                "missing_embeddings": missing,
+                "coverage": coverage,
+            },
+        }
+        return format_response(result, output_format, text_formatter=format_embeddings_status_text)
+    except Exception:
+        logger.exception("Error getting embedding status")
+        return internal_error()
+
+
+async def admin_embeddings_backfill(request: Request) -> JSONResponse:
+    """POST /api/v1/admin/embeddings/backfill — Backfill missing embeddings."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, ADMIN_SCOPE):
+        return err
+
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        body = {}
+
+    batch_size = body.get("batch_size", 50)
+    dry_run = body.get("dry_run", False)
+
+    try:
+        from our_db import get_cursor
+        from our_embeddings.service import generate_embedding
+
+        with get_cursor() as cur:
+            cur.execute(
+                "SELECT id, content FROM beliefs WHERE embedding IS NULL AND status = 'active' LIMIT %s",
+                (batch_size,),
+            )
+            rows = cur.fetchall()
+
+        if dry_run:
+            return JSONResponse({
+                "success": True,
+                "would_process": len(rows),
+                "dry_run": True,
+            })
+
+        processed = 0
+        errors = 0
+        for row in rows:
+            try:
+                embedding = generate_embedding(row["content"])
+                if embedding:
+                    with get_cursor() as cur:
+                        cur.execute("UPDATE beliefs SET embedding = %s WHERE id = %s", (embedding, row["id"]))
+                    processed += 1
+            except Exception:
+                errors += 1
+
+        return JSONResponse({
+            "success": True,
+            "processed": processed,
+            "errors": errors,
+            "remaining": len(rows) - processed - errors,
+        })
+    except Exception:
+        logger.exception("Embedding backfill failed")
+        return internal_error()
+
+
+async def admin_embeddings_migrate(request: Request) -> JSONResponse:
+    """POST /api/v1/admin/embeddings/migrate — Migrate embedding model/dimensions."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, ADMIN_SCOPE):
+        return err
+
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return invalid_json_error()
+
+    model = body.get("model")
+    dims = body.get("dims")
+    if not model and not dims:
+        return missing_field_error("model or dims")
+
+    dry_run = body.get("dry_run", False)
+
+    try:
+        from our_db import get_cursor
+
+        if dry_run:
+            with get_cursor() as cur:
+                cur.execute("SELECT COUNT(*) as count FROM beliefs WHERE embedding IS NOT NULL")
+                count = cur.fetchone()["count"]
+            return JSONResponse({
+                "success": True,
+                "would_affect": count,
+                "model": model,
+                "dims": dims,
+                "dry_run": True,
+            })
+
+        with get_cursor() as cur:
+            # NULL out all embeddings (they need regeneration with new model)
+            cur.execute("UPDATE beliefs SET embedding = NULL WHERE embedding IS NOT NULL")
+            affected = cur.rowcount
+
+        return JSONResponse({
+            "success": True,
+            "cleared_embeddings": affected,
+            "model": model,
+            "dims": dims,
+            "note": "Run /admin/embeddings/backfill to regenerate with new model",
+        })
+    except Exception:
+        logger.exception("Embedding migration failed")
+        return internal_error()
+
+
+# =============================================================================
+# CHAIN VERIFICATION
+# =============================================================================
+
+
+async def admin_verify_chains(request: Request) -> JSONResponse:
+    """GET /api/v1/admin/verify-chains — Verify supersession chain integrity."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, ADMIN_SCOPE):
+        return err
+
+    try:
+        from our_db import get_cursor
+
+        issues = []
+        with get_cursor() as cur:
+            # Check for broken supersession chains (pointing to non-existent beliefs)
+            cur.execute("""
+                SELECT b.id, b.superseded_by_id
+                FROM beliefs b
+                WHERE b.superseded_by_id IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM beliefs b2 WHERE b2.id = b.superseded_by_id)
+            """)
+            broken = cur.fetchall()
+            for row in broken:
+                issues.append({
+                    "type": "broken_chain",
+                    "belief_id": str(row["id"]),
+                    "points_to": str(row["superseded_by_id"]),
+                    "description": "Superseded belief points to non-existent belief",
+                })
+
+            # Check for cycles
+            cur.execute("""
+                WITH RECURSIVE chain AS (
+                    SELECT id, superseded_by_id, 1 as depth, ARRAY[id] as path
+                    FROM beliefs WHERE superseded_by_id IS NOT NULL
+                    UNION ALL
+                    SELECT b.id, b.superseded_by_id, c.depth + 1, c.path || b.id
+                    FROM beliefs b JOIN chain c ON b.id = c.superseded_by_id
+                    WHERE c.depth < 100 AND NOT (b.id = ANY(c.path))
+                )
+                SELECT id, depth FROM chain WHERE depth >= 50
+            """)
+            deep = cur.fetchall()
+            for row in deep:
+                issues.append({
+                    "type": "deep_chain",
+                    "belief_id": str(row["id"]),
+                    "depth": row["depth"],
+                    "description": "Supersession chain is unusually deep",
+                })
+
+        return JSONResponse({
+            "success": True,
+            "issues": issues,
+            "count": len(issues),
+            "status": "healthy" if not issues else "issues_found",
+        })
+    except Exception:
+        logger.exception("Chain verification failed")
+        return internal_error()

--- a/src/valence/server/app.py
+++ b/src/valence/server/app.py
@@ -26,6 +26,16 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, Response
 from starlette.routing import Route
 
+from .admin_endpoints import (
+    admin_embeddings_backfill,
+    admin_embeddings_migrate,
+    admin_embeddings_status,
+    admin_maintenance,
+    admin_migrate_down,
+    admin_migrate_status,
+    admin_migrate_up,
+    admin_verify_chains,
+)
 from .auth import get_token_store, verify_token
 from .auth_helpers import AuthenticatedClient  # noqa: F401 — re-exported for backwards compat
 from .compliance_endpoints import (
@@ -76,8 +86,10 @@ from .substrate_endpoints import (
     beliefs_list_endpoint,
     beliefs_search_endpoint,
     beliefs_supersede_endpoint,
+    conflicts_endpoint,
     entities_get_endpoint,
     entities_list_endpoint,
+    stats_endpoint,
     tensions_list_endpoint,
     tensions_resolve_endpoint,
     trust_check_endpoint,
@@ -943,6 +955,7 @@ def create_app() -> Starlette:
         Route(f"{API_V1}/beliefs", beliefs_list_endpoint, methods=["GET"]),
         Route(f"{API_V1}/beliefs", beliefs_create_endpoint, methods=["POST"]),
         Route(f"{API_V1}/beliefs/search", beliefs_search_endpoint, methods=["GET"]),
+        Route(f"{API_V1}/beliefs/conflicts", conflicts_endpoint, methods=["GET"]),
         Route(f"{API_V1}/beliefs/{{belief_id}}", beliefs_get_endpoint, methods=["GET"]),
         Route(f"{API_V1}/beliefs/{{belief_id}}/supersede", beliefs_supersede_endpoint, methods=["POST"]),
         Route(f"{API_V1}/beliefs/{{belief_id}}/confidence", beliefs_confidence_endpoint, methods=["GET"]),
@@ -951,6 +964,17 @@ def create_app() -> Starlette:
         Route(f"{API_V1}/tensions", tensions_list_endpoint, methods=["GET"]),
         Route(f"{API_V1}/tensions/{{id}}/resolve", tensions_resolve_endpoint, methods=["POST"]),
         Route(f"{API_V1}/trust", trust_check_endpoint, methods=["GET"]),
+        # Stats (Issue #396)
+        Route(f"{API_V1}/stats", stats_endpoint, methods=["GET"]),
+        # Admin endpoints (Issue #396)
+        Route(f"{API_V1}/admin/migrate/status", admin_migrate_status, methods=["GET"]),
+        Route(f"{API_V1}/admin/migrate/up", admin_migrate_up, methods=["POST"]),
+        Route(f"{API_V1}/admin/migrate/down", admin_migrate_down, methods=["POST"]),
+        Route(f"{API_V1}/admin/maintenance", admin_maintenance, methods=["POST"]),
+        Route(f"{API_V1}/admin/embeddings/status", admin_embeddings_status, methods=["GET"]),
+        Route(f"{API_V1}/admin/embeddings/backfill", admin_embeddings_backfill, methods=["POST"]),
+        Route(f"{API_V1}/admin/embeddings/migrate", admin_embeddings_migrate, methods=["POST"]),
+        Route(f"{API_V1}/admin/verify-chains", admin_verify_chains, methods=["GET"]),
         # VKB REST endpoints (Issue #380)
         Route(f"{API_V1}/sessions", sessions_create_endpoint, methods=["POST"]),
         Route(f"{API_V1}/sessions", sessions_list_endpoint, methods=["GET"]),

--- a/src/valence/server/endpoint_utils.py
+++ b/src/valence/server/endpoint_utils.py
@@ -1,9 +1,15 @@
-"""Shared utility functions for REST endpoint parameter parsing.
+"""Shared utility functions for REST endpoint parameter parsing and output formatting.
 
 Extracted from substrate_endpoints.py and vkb_endpoints.py to avoid duplication.
 """
 
 from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse, Response
 
 
 def _parse_bool(value: str | None, default: bool = False) -> bool:
@@ -31,3 +37,40 @@ def _parse_float(value: str | None, default: float | None = None) -> float | Non
         return float(value)
     except ValueError:
         return default
+
+
+# =============================================================================
+# OUTPUT FORMATTING
+# =============================================================================
+
+
+def parse_output_format(request: Request) -> str:
+    """Parse ?output= query parameter. Default: json."""
+    fmt = request.query_params.get("output", "json")
+    if fmt not in ("json", "text", "table"):
+        return "json"
+    return fmt
+
+
+def format_response(
+    data: dict[str, Any],
+    output_format: str,
+    text_formatter: Callable[[dict[str, Any]], str] | None = None,
+    table_formatter: Callable[[dict[str, Any]], str] | None = None,
+    status_code: int = 200,
+) -> Response:
+    """Return response in the requested output format.
+
+    For JSON mode (default), returns JSONResponse.
+    For text/table mode, uses the provided formatter to produce plain text.
+    If no formatter is available, falls back to JSON.
+    """
+    if output_format == "json":
+        return JSONResponse(data, status_code=status_code)
+
+    formatter = table_formatter if output_format == "table" and table_formatter else text_formatter
+    if formatter:
+        formatted_text = formatter(data)
+        return PlainTextResponse(formatted_text, status_code=status_code)
+
+    return JSONResponse(data, status_code=status_code)

--- a/src/valence/server/formatters.py
+++ b/src/valence/server/formatters.py
@@ -1,0 +1,165 @@
+"""Server-side text/table formatters for REST responses.
+
+Each formatter takes a response data dict and returns a human-readable string.
+Used by endpoints when ?output=text or ?output=table is requested.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def format_stats_text(data: dict[str, Any]) -> str:
+    """Format stats response as human-readable text."""
+    stats = data.get("stats", {})
+    lines = ["Valence Statistics", "-" * 30]
+    for key, value in stats.items():
+        label = key.replace("_", " ").title()
+        lines.append(f"  {label}: {value}")
+    return "\n".join(lines)
+
+
+def format_beliefs_list_text(data: dict[str, Any]) -> str:
+    """Format beliefs query/list result as human-readable text."""
+    beliefs = data.get("beliefs", [])
+    if not beliefs:
+        return "No beliefs found."
+
+    lines = [f"Found {len(beliefs)} belief(s)", ""]
+    for i, b in enumerate(beliefs, 1):
+        conf = b.get("confidence", {})
+        overall = conf.get("overall", "?") if isinstance(conf, dict) else conf
+        if isinstance(overall, float):
+            overall = f"{overall:.0%}"
+        content = str(b.get("content", ""))[:80]
+        lines.append(f"[{i}] {content}")
+        bid = str(b.get("id", ""))[:8]
+        lines.append(f"    ID: {bid}  Confidence: {overall}")
+        domains = b.get("domain_path")
+        if domains:
+            lines.append(f"    Domains: {', '.join(domains)}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def format_entities_list_text(data: dict[str, Any]) -> str:
+    """Format entity search results as text."""
+    entities = data.get("entities", [])
+    if not entities:
+        return "No entities found."
+
+    lines = [f"Found {len(entities)} entity/entities", ""]
+    for e in entities:
+        etype = e.get("type", "unknown")
+        lines.append(f"  [{etype}] {e.get('name', '?')} ({str(e.get('id', ''))[:8]})")
+    return "\n".join(lines)
+
+
+def format_tensions_list_text(data: dict[str, Any]) -> str:
+    """Format tensions list as text."""
+    tensions = data.get("tensions", [])
+    if not tensions:
+        return "No tensions found."
+
+    lines = [f"Found {len(tensions)} tension(s)", ""]
+    for t in tensions:
+        tid = str(t.get("id", ""))[:8]
+        severity = t.get("severity", "?")
+        status = t.get("status", "?")
+        desc = str(t.get("description", ""))[:60]
+        lines.append(f"  [{tid}] ({severity}/{status}) {desc}")
+    return "\n".join(lines)
+
+
+def format_conflicts_text(data: dict[str, Any]) -> str:
+    """Format conflict detection results as text."""
+    conflicts = data.get("conflicts", [])
+    if not conflicts:
+        return "No potential conflicts detected."
+
+    lines = [f"Found {len(conflicts)} potential conflict(s)", ""]
+    for i, c in enumerate(conflicts[:10], 1):
+        lines.append("=" * 60)
+        sim = c.get("similarity", 0)
+        score = c.get("conflict_score", 0)
+        lines.append(f"Conflict #{i} (similarity: {sim:.1%}, signal: {score:.2f})")
+        lines.append(f"Reason: {c.get('reason', '?')}")
+        lines.append(f"  A [{str(c.get('id_a', ''))[:8]}] {str(c.get('content_a', ''))[:70]}")
+        lines.append(f"  B [{str(c.get('id_b', ''))[:8]}] {str(c.get('content_b', ''))[:70]}")
+        lines.append("")
+    lines.append("=" * 60)
+    return "\n".join(lines)
+
+
+def format_maintenance_text(data: dict[str, Any]) -> str:
+    """Format maintenance results as text."""
+    results = data.get("results", [])
+    dry_run = data.get("dry_run", False)
+    dry_label = " (dry run)" if dry_run else ""
+
+    lines = [f"Maintenance Report{dry_label}", "=" * 50]
+    for r in results:
+        op = r.get("operation", "?")
+        details = {k: v for k, v in r.items() if k not in ("operation", "dry_run")}
+        detail_str = ", ".join(f"{k}={v}" for k, v in details.items()) if details else ""
+        lines.append(f"  {op}: {detail_str}")
+    lines.append("=" * 50)
+    lines.append(f"  {len(results)} operation(s) completed")
+    return "\n".join(lines)
+
+
+def format_sessions_list_text(data: dict[str, Any]) -> str:
+    """Format sessions list as text."""
+    sessions = data.get("sessions", [])
+    if not sessions:
+        return "No sessions found."
+
+    lines = [f"Found {len(sessions)} session(s)", ""]
+    for s in sessions:
+        sid = str(s.get("id", ""))[:8]
+        status = s.get("status", "?")
+        platform = s.get("platform", "?")
+        lines.append(f"  [{sid}] ({status}) platform={platform}")
+    return "\n".join(lines)
+
+
+def format_patterns_list_text(data: dict[str, Any]) -> str:
+    """Format patterns list as text."""
+    patterns = data.get("patterns", [])
+    if not patterns:
+        return "No patterns found."
+
+    lines = [f"Found {len(patterns)} pattern(s)", ""]
+    for p in patterns:
+        pid = str(p.get("id", ""))[:8]
+        ptype = p.get("type", "?")
+        desc = str(p.get("description", ""))[:60]
+        conf = p.get("confidence", "?")
+        if isinstance(conf, float):
+            conf = f"{conf:.0%}"
+        lines.append(f"  [{pid}] ({ptype}, {conf}) {desc}")
+    return "\n".join(lines)
+
+
+def format_migration_status_text(data: dict[str, Any]) -> str:
+    """Format migration status as text."""
+    migrations = data.get("migrations", [])
+    if not migrations:
+        return "No migrations found."
+
+    lines = ["Migration Status", "-" * 40]
+    for m in migrations:
+        name = m.get("name", "?")
+        status = m.get("status", "?")
+        lines.append(f"  [{status}] {name}")
+    return "\n".join(lines)
+
+
+def format_embeddings_status_text(data: dict[str, Any]) -> str:
+    """Format embeddings status as text."""
+    stats = data.get("stats", {})
+    lines = ["Embedding Status", "-" * 30]
+    for key, value in stats.items():
+        label = key.replace("_", " ").title()
+        lines.append(f"  {label}: {value}")
+    return "\n".join(lines)

--- a/src/valence/server/substrate_endpoints.py
+++ b/src/valence/server/substrate_endpoints.py
@@ -13,8 +13,9 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from .auth_helpers import authenticate, require_scope
-from .endpoint_utils import _parse_bool, _parse_float, _parse_int
+from .endpoint_utils import _parse_bool, _parse_float, _parse_int, format_response, parse_output_format
 from .errors import internal_error, invalid_json_error, missing_field_error, validation_error
+from .formatters import format_beliefs_list_text, format_conflicts_text, format_stats_text
 
 logger = logging.getLogger(__name__)
 
@@ -401,4 +402,195 @@ async def trust_check_endpoint(request: Request) -> JSONResponse:
         return JSONResponse(result)
     except Exception:
         logger.exception("Error checking trust")
+        return internal_error()
+
+
+# =============================================================================
+# STATS
+# =============================================================================
+
+
+async def stats_endpoint(request: Request) -> JSONResponse:
+    """GET /api/v1/stats — Aggregate database statistics."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, "substrate:read"):
+        return err
+
+    output_format = parse_output_format(request)
+
+    try:
+        from our_db import get_cursor
+
+        with get_cursor() as cur:
+            cur.execute("SELECT COUNT(*) as total FROM beliefs")
+            total = cur.fetchone()["total"]
+
+            cur.execute("SELECT COUNT(*) as active FROM beliefs WHERE status = 'active' AND superseded_by_id IS NULL")
+            active = cur.fetchone()["active"]
+
+            cur.execute("SELECT COUNT(*) as with_emb FROM beliefs WHERE embedding IS NOT NULL")
+            with_embedding = cur.fetchone()["with_emb"]
+
+            cur.execute("SELECT COUNT(*) as tensions FROM tensions WHERE status = 'detected'")
+            tensions = cur.fetchone()["tensions"]
+
+            try:
+                cur.execute("SELECT COUNT(DISTINCT d) as count FROM beliefs, LATERAL unnest(domain_path) as d")
+                domains = cur.fetchone()["count"]
+            except Exception:
+                domains = 0
+
+            try:
+                cur.execute("SELECT COUNT(*) as federated FROM beliefs WHERE is_local = FALSE")
+                federated = cur.fetchone()["federated"]
+            except Exception:
+                federated = 0
+
+        result = {
+            "success": True,
+            "stats": {
+                "total_beliefs": total,
+                "active_beliefs": active,
+                "local_beliefs": active - federated,
+                "federated_beliefs": federated,
+                "with_embeddings": with_embedding,
+                "unique_domains": domains,
+                "unresolved_tensions": tensions,
+            },
+        }
+        return format_response(result, output_format, text_formatter=format_stats_text)
+    except Exception:
+        logger.exception("Error getting stats")
+        return internal_error()
+
+
+# =============================================================================
+# CONFLICT DETECTION
+# =============================================================================
+
+
+async def conflicts_endpoint(request: Request) -> JSONResponse:
+    """GET /api/v1/beliefs/conflicts — Detect potential contradictions."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, "substrate:read"):
+        return err
+
+    threshold = _parse_float(request.query_params.get("threshold"), 0.85) or 0.85
+    auto_record = _parse_bool(request.query_params.get("auto_record"))
+    output_format = parse_output_format(request)
+
+    try:
+        from our_db import get_cursor
+
+        with get_cursor() as cur:
+            cur.execute(
+                """
+                WITH belief_pairs AS (
+                    SELECT
+                        b1.id as id_a, b1.content as content_a, b1.confidence as confidence_a,
+                        b2.id as id_b, b2.content as content_b, b2.confidence as confidence_b,
+                        1 - (b1.embedding <=> b2.embedding) as similarity
+                    FROM beliefs b1
+                    CROSS JOIN beliefs b2
+                    WHERE b1.id < b2.id
+                      AND b1.embedding IS NOT NULL AND b2.embedding IS NOT NULL
+                      AND b1.status = 'active' AND b2.status = 'active'
+                      AND b1.superseded_by_id IS NULL AND b2.superseded_by_id IS NULL
+                      AND 1 - (b1.embedding <=> b2.embedding) > %s
+                    ORDER BY similarity DESC
+                    LIMIT 50
+                )
+                SELECT * FROM belief_pairs
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM tensions t
+                    WHERE (t.belief_a_id = belief_pairs.id_a AND t.belief_b_id = belief_pairs.id_b)
+                       OR (t.belief_a_id = belief_pairs.id_b AND t.belief_b_id = belief_pairs.id_a)
+                )
+                """,
+                (threshold,),
+            )
+            pairs = cur.fetchall()
+
+            negation_words = {
+                "not", "never", "no", "n't", "cannot", "without", "neither", "none",
+                "nobody", "nothing", "nowhere", "false", "incorrect", "wrong", "fail",
+                "reject", "deny", "refuse", "avoid",
+            }
+            opposites = [
+                ("good", "bad"), ("right", "wrong"), ("true", "false"),
+                ("should", "should not"), ("always", "never"), ("prefer", "avoid"),
+                ("like", "dislike"), ("works", "fails"), ("correct", "incorrect"),
+            ]
+
+            conflicts = []
+            for pair in pairs:
+                content_a = pair["content_a"].lower()
+                content_b = pair["content_b"].lower()
+                words_a = set(content_a.split())
+                words_b = set(content_b.split())
+
+                neg_a = bool(words_a & negation_words)
+                neg_b = bool(words_b & negation_words)
+
+                conflict_signal = 0.0
+                reason = []
+
+                if neg_a != neg_b:
+                    conflict_signal += 0.4
+                    reason.append("negation asymmetry")
+
+                for pos, neg in opposites:
+                    if (pos in content_a and neg in content_b) or (neg in content_a and pos in content_b):
+                        conflict_signal += 0.3
+                        reason.append(f"opposite: {pos}/{neg}")
+                        break
+
+                if conflict_signal > 0.2 or pair["similarity"] > 0.92:
+                    conflicts.append({
+                        "id_a": str(pair["id_a"]),
+                        "content_a": pair["content_a"],
+                        "id_b": str(pair["id_b"]),
+                        "content_b": pair["content_b"],
+                        "similarity": float(pair["similarity"]),
+                        "conflict_score": conflict_signal + (float(pair["similarity"]) - threshold) * 0.5,
+                        "reason": ", ".join(reason) if reason else "high similarity",
+                    })
+
+            conflicts.sort(key=lambda x: x["conflict_score"], reverse=True)
+
+            recorded = []
+            if auto_record and conflicts:
+                for c in conflicts:
+                    cur.execute(
+                        """
+                        INSERT INTO tensions (belief_a_id, belief_b_id, type, description, severity)
+                        VALUES (%s, %s, 'contradiction', %s, %s)
+                        ON CONFLICT DO NOTHING
+                        RETURNING id
+                        """,
+                        (
+                            c["id_a"],
+                            c["id_b"],
+                            f"Auto-detected: {c['reason']}",
+                            "high" if c["conflict_score"] > 0.5 else "medium",
+                        ),
+                    )
+                    row = cur.fetchone()
+                    if row:
+                        recorded.append(str(row["id"]))
+
+        result = {
+            "success": True,
+            "conflicts": conflicts,
+            "count": len(conflicts),
+            "threshold": threshold,
+            "recorded_tensions": recorded,
+        }
+        return format_response(result, output_format, text_formatter=format_conflicts_text)
+    except Exception:
+        logger.exception("Error detecting conflicts")
         return internal_error()

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,0 +1,120 @@
+"""Tests for CLI config loading with precedence: flags > env > file > defaults."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from valence.cli.config import CLIConfig, get_cli_config, reset_cli_config, set_cli_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset config singleton between tests."""
+    reset_cli_config()
+    yield
+    reset_cli_config()
+
+
+class TestCLIConfigDefaults:
+    def test_defaults(self):
+        config = CLIConfig()
+        assert config.server_url == "http://127.0.0.1:8420"
+        assert config.token == ""
+        assert config.output == "text"
+        assert config.timeout == 30.0
+
+    def test_load_defaults_when_no_file(self, tmp_path):
+        config = CLIConfig.load(config_path=tmp_path / "nonexistent.toml")
+        assert config.server_url == "http://127.0.0.1:8420"
+        assert config.token == ""
+        assert config.output == "text"
+
+
+class TestCLIConfigFile:
+    def test_load_from_toml(self, tmp_path):
+        config_file = tmp_path / "cli.toml"
+        config_file.write_text(
+            'server_url = "http://remote:9000"\n'
+            'token = "vt_file_token"\n'
+            'output = "json"\n'
+            "timeout = 60.0\n"
+        )
+        config = CLIConfig.load(config_path=config_file)
+        assert config.server_url == "http://remote:9000"
+        assert config.token == "vt_file_token"
+        assert config.output == "json"
+        assert config.timeout == 60.0
+
+    def test_partial_toml(self, tmp_path):
+        config_file = tmp_path / "cli.toml"
+        config_file.write_text('token = "vt_partial"\n')
+        config = CLIConfig.load(config_path=config_file)
+        assert config.server_url == "http://127.0.0.1:8420"  # default
+        assert config.token == "vt_partial"
+
+    def test_invalid_output_in_toml_ignored(self, tmp_path):
+        config_file = tmp_path / "cli.toml"
+        config_file.write_text('output = "csv"\n')
+        config = CLIConfig.load(config_path=config_file)
+        assert config.output == "text"  # default, csv is not valid
+
+
+class TestCLIConfigEnv:
+    def test_env_overrides_file(self, tmp_path):
+        config_file = tmp_path / "cli.toml"
+        config_file.write_text('server_url = "http://file:1111"\ntoken = "vt_file"\n')
+
+        env = {
+            "VALENCE_SERVER_URL": "http://env:2222",
+            "VALENCE_TOKEN": "vt_env",
+            "VALENCE_OUTPUT": "table",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            config = CLIConfig.load(config_path=config_file)
+        assert config.server_url == "http://env:2222"
+        assert config.token == "vt_env"
+        assert config.output == "table"
+
+    def test_env_invalid_output_ignored(self):
+        with patch.dict(os.environ, {"VALENCE_OUTPUT": "xml"}, clear=False):
+            config = CLIConfig.load(config_path=Path("/nonexistent"))
+        assert config.output == "text"
+
+
+class TestCLIConfigFlags:
+    def test_flags_override_env(self):
+        env = {"VALENCE_SERVER_URL": "http://env:2222", "VALENCE_TOKEN": "vt_env"}
+        with patch.dict(os.environ, env, clear=False):
+            config = CLIConfig.load(
+                config_path=Path("/nonexistent"),
+                server_url="http://flag:3333",
+                token="vt_flag",
+                output="json",
+                timeout=120.0,
+            )
+        assert config.server_url == "http://flag:3333"
+        assert config.token == "vt_flag"
+        assert config.output == "json"
+        assert config.timeout == 120.0
+
+    def test_partial_flags_keep_env(self):
+        with patch.dict(os.environ, {"VALENCE_TOKEN": "vt_env"}, clear=False):
+            config = CLIConfig.load(config_path=Path("/nonexistent"), server_url="http://flag:3333")
+        assert config.server_url == "http://flag:3333"
+        assert config.token == "vt_env"
+
+
+class TestCLIConfigSingleton:
+    def test_get_set_singleton(self):
+        config = CLIConfig(server_url="http://test:9999", token="vt_test")
+        set_cli_config(config)
+        assert get_cli_config().server_url == "http://test:9999"
+        assert get_cli_config().token == "vt_test"
+
+    def test_get_creates_default_if_unset(self):
+        config = get_cli_config()
+        assert config.server_url == "http://127.0.0.1:8420"

--- a/tests/cli/test_embeddings_cli.py
+++ b/tests/cli/test_embeddings_cli.py
@@ -2,21 +2,27 @@
 
 Tests cover:
 1. Argument parsing for `valence embeddings backfill`
-2. Dry-run mode (no mutations, shows counts)
-3. Content-type filtering
-4. Force mode (re-embed all)
-5. Normal backfill (delegates to service)
-6. Error handling
+2. REST client calls to server
+3. Error handling
 """
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
-from uuid import uuid4
 
 import pytest
 
 from valence.cli.main import app, cmd_embeddings
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset CLI config singleton for each test."""
+    from valence.cli.config import reset_cli_config
+    reset_cli_config()
+    yield
+    reset_cli_config()
+
 
 # ============================================================================
 # Argument Parsing
@@ -32,16 +38,14 @@ class TestEmbeddingsArgParsing:
         args = parser.parse_args(["embeddings", "backfill"])
         assert args.command == "embeddings"
         assert args.embeddings_command == "backfill"
-        assert args.batch_size == 100
+        assert args.batch_size == 50
         assert args.dry_run is False
-        assert args.content_type is None
-        assert args.force is False
 
     def test_embeddings_backfill_batch_size(self):
         """Parse --batch-size flag."""
         parser = app()
-        args = parser.parse_args(["embeddings", "backfill", "--batch-size", "50"])
-        assert args.batch_size == 50
+        args = parser.parse_args(["embeddings", "backfill", "--batch-size", "100"])
+        assert args.batch_size == 100
 
     def test_embeddings_backfill_batch_size_short(self):
         """Parse -b short flag."""
@@ -55,345 +59,11 @@ class TestEmbeddingsArgParsing:
         args = parser.parse_args(["embeddings", "backfill", "--dry-run"])
         assert args.dry_run is True
 
-    def test_embeddings_backfill_content_type(self):
-        """Parse --content-type flag."""
-        parser = app()
-        for ct in ("belief", "exchange", "pattern"):
-            args = parser.parse_args(["embeddings", "backfill", "--content-type", ct])
-            assert args.content_type == ct
-
-    def test_embeddings_backfill_content_type_short(self):
-        """Parse -t short flag."""
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill", "-t", "belief"])
-        assert args.content_type == "belief"
-
-    def test_embeddings_backfill_content_type_invalid(self):
-        """Invalid content type raises error."""
-        parser = app()
-        with pytest.raises(SystemExit):
-            parser.parse_args(["embeddings", "backfill", "--content-type", "invalid"])
-
-    def test_embeddings_backfill_force(self):
-        """Parse --force flag."""
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill", "--force"])
-        assert args.force is True
-
-    def test_embeddings_backfill_force_short(self):
-        """Parse -f short flag."""
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill", "-f"])
-        assert args.force is True
-
-    def test_embeddings_backfill_all_flags(self):
-        """Parse all flags together."""
-        parser = app()
-        args = parser.parse_args(
-            [
-                "embeddings",
-                "backfill",
-                "--batch-size",
-                "25",
-                "--dry-run",
-                "--content-type",
-                "belief",
-                "--force",
-            ]
-        )
-        assert args.batch_size == 25
-        assert args.dry_run is True
-        assert args.content_type == "belief"
-        assert args.force is True
-
     def test_embeddings_requires_subcommand(self):
         """embeddings without subcommand raises error."""
         parser = app()
         with pytest.raises(SystemExit):
             parser.parse_args(["embeddings"])
-
-
-# ============================================================================
-# Mock Database Fixture
-# ============================================================================
-
-
-@pytest.fixture
-def mock_db():
-    """Create a mock database connection and cursor."""
-    mock_conn = MagicMock()
-    mock_cur = MagicMock()
-    mock_conn.cursor.return_value = mock_cur
-    return mock_conn, mock_cur
-
-
-# ============================================================================
-# Dry Run Tests
-# ============================================================================
-
-
-class TestBackfillDryRun:
-    """Test dry-run mode shows counts without mutating."""
-
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_dry_run_shows_counts(self, mock_get_conn, mock_db, capsys):
-        """Dry run shows missing counts per type."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-
-        # Return counts for belief, exchange, pattern
-        mock_cur.fetchone.side_effect = [
-            {"count": 10},  # beliefs missing
-            {"count": 5},  # exchanges missing
-            {"count": 3},  # patterns missing
-        ]
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill", "--dry-run"])
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        captured = capsys.readouterr()
-        assert "Dry run" in captured.out
-        assert "10" in captured.out
-        assert "5" in captured.out
-        assert "3" in captured.out
-        assert "18" in captured.out  # total
-
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_dry_run_single_type(self, mock_get_conn, mock_db, capsys):
-        """Dry run with --content-type shows only that type."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-
-        mock_cur.fetchone.side_effect = [
-            {"count": 15},  # beliefs missing
-        ]
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill", "--dry-run", "-t", "belief"])
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        captured = capsys.readouterr()
-        assert "Dry run" in captured.out
-        assert "15" in captured.out
-
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_dry_run_nothing_to_backfill(self, mock_get_conn, mock_db, capsys):
-        """Dry run when nothing needs backfilling."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-
-        mock_cur.fetchone.side_effect = [
-            {"count": 0},
-            {"count": 0},
-            {"count": 0},
-        ]
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill", "--dry-run"])
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        captured = capsys.readouterr()
-        assert "Nothing to backfill" in captured.out
-
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_dry_run_force_counts_all(self, mock_get_conn, mock_db, capsys):
-        """Dry run with --force counts all records, not just missing."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-
-        # Force mode counts all active records
-        mock_cur.fetchone.side_effect = [
-            {"count": 100},  # all beliefs
-            {"count": 50},  # all exchanges
-            {"count": 25},  # all patterns
-        ]
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill", "--dry-run", "--force"])
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        captured = capsys.readouterr()
-        assert "Dry run" in captured.out
-        assert "Force mode" in captured.out
-        assert "175" in captured.out  # total
-
-
-# ============================================================================
-# Normal Backfill Tests
-# ============================================================================
-
-
-class TestBackfillNormal:
-    """Test normal backfill delegates to service layer."""
-
-    @patch("our_embeddings.service.backfill_embeddings", return_value=5)
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_backfill_calls_service(self, mock_get_conn, mock_backfill, mock_db, capsys):
-        """Backfill delegates to backfill_embeddings service."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-
-        # Counts
-        mock_cur.fetchone.side_effect = [
-            {"count": 5},  # beliefs missing
-        ]
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill", "-t", "belief"])
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        mock_backfill.assert_called_once_with("belief", batch_size=100)
-
-    @patch("our_embeddings.service.backfill_embeddings", side_effect=[3, 2, 1])
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_backfill_all_types(self, mock_get_conn, mock_backfill, mock_db, capsys):
-        """Backfill processes all types when no filter."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-
-        mock_cur.fetchone.side_effect = [
-            {"count": 3},
-            {"count": 2},
-            {"count": 1},
-        ]
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill"])
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        assert mock_backfill.call_count == 3
-        captured = capsys.readouterr()
-        assert "complete" in captured.out.lower()
-
-    @patch("our_embeddings.service.backfill_embeddings", return_value=10)
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_backfill_custom_batch_size(self, mock_get_conn, mock_backfill, mock_db, capsys):
-        """Batch size is passed through to service."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-
-        mock_cur.fetchone.side_effect = [{"count": 10}]
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill", "-t", "belief", "-b", "25"])
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        mock_backfill.assert_called_once_with("belief", batch_size=25)
-
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_backfill_nothing_to_do(self, mock_get_conn, mock_db, capsys):
-        """Backfill exits cleanly when nothing needs embedding."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-
-        mock_cur.fetchone.side_effect = [
-            {"count": 0},
-            {"count": 0},
-            {"count": 0},
-        ]
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill"])
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        captured = capsys.readouterr()
-        assert "Nothing to backfill" in captured.out
-
-
-# ============================================================================
-# Force Mode Tests
-# ============================================================================
-
-
-class TestBackfillForce:
-    """Test --force mode re-embeds existing records."""
-
-    @patch("our_embeddings.service.embed_content", return_value={})
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_force_reembeds_all(self, mock_get_conn, mock_embed, mock_db, capsys):
-        """Force mode fetches and re-embeds all records."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-
-        belief_id = uuid4()
-
-        # Count query returns total active beliefs
-        mock_cur.fetchone.side_effect = [{"count": 1}]
-        # Fetch records for force re-embed
-        mock_cur.fetchall.return_value = [
-            {"id": belief_id, "content": "Test belief"},
-        ]
-
-        parser = app()
-        args = parser.parse_args(
-            [
-                "embeddings",
-                "backfill",
-                "--force",
-                "-t",
-                "belief",
-            ]
-        )
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        mock_embed.assert_called_once_with("belief", str(belief_id), "Test belief")
-        captured = capsys.readouterr()
-        assert "Force mode" in captured.out
-
-
-# ============================================================================
-# Error Handling Tests
-# ============================================================================
-
-
-class TestBackfillErrors:
-    """Test error handling in backfill."""
-
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_db_error_returns_nonzero(self, mock_get_conn, capsys):
-        """Database connection failure returns non-zero exit code."""
-        mock_get_conn.side_effect = Exception("Connection refused")
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill"])
-        result = cmd_embeddings(args)
-
-        assert result == 1
-        captured = capsys.readouterr()
-        assert "failed" in captured.err.lower()
-
-
-# ============================================================================
-# Command Routing
-# ============================================================================
-
-
-class TestEmbeddingsRouting:
-    """Test embeddings command routing."""
-
-    def test_main_dispatches_to_embeddings(self):
-        """main() dispatches 'embeddings' to cmd_embeddings via args.func."""
-        parser = app()
-        args = parser.parse_args(["embeddings", "backfill", "--dry-run"])
-
-        # With modular registration, args.func is set by set_defaults()
-        assert hasattr(args, "func")
-        assert args.func is cmd_embeddings
-
-
-# ============================================================================
-# Migrate Argument Parsing (#364)
-# ============================================================================
 
 
 class TestMigrateArgParsing:
@@ -406,11 +76,11 @@ class TestMigrateArgParsing:
             parser.parse_args(["embeddings", "migrate"])
 
     def test_migrate_known_model(self):
-        """Parse known model with defaults auto-resolved."""
+        """Parse known model."""
         parser = app()
         args = parser.parse_args(["embeddings", "migrate", "--model", "text-embedding-3-small"])
         assert args.model == "text-embedding-3-small"
-        assert args.dims is None  # resolved at runtime
+        assert args.dims is None
         assert args.dry_run is False
 
     def test_migrate_custom_model_with_dims(self):
@@ -426,126 +96,6 @@ class TestMigrateArgParsing:
         args = parser.parse_args(["embeddings", "migrate", "--model", "text-embedding-3-small", "--dry-run"])
         assert args.dry_run is True
 
-    def test_migrate_all_flags(self):
-        """Parse all migrate flags together."""
-        parser = app()
-        args = parser.parse_args([
-            "embeddings", "migrate",
-            "--model", "custom/model",
-            "--dims", "512",
-            "--provider", "custom_provider",
-            "--type-id", "custom_512",
-            "--dry-run",
-        ])
-        assert args.model == "custom/model"
-        assert args.dims == 512
-        assert args.provider == "custom_provider"
-        assert args.type_id == "custom_512"
-        assert args.dry_run is True
-
-
-# ============================================================================
-# Migrate Command Tests (#364)
-# ============================================================================
-
-
-class TestMigrateCommand:
-    """Test embeddings migrate command logic."""
-
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_migrate_dry_run_known_model(self, mock_get_conn, capsys):
-        """Dry run shows migration plan without making changes."""
-        parser = app()
-        args = parser.parse_args(["embeddings", "migrate", "--model", "text-embedding-3-small", "--dry-run"])
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        captured = capsys.readouterr()
-        assert "Dry run" in captured.out
-        assert "1536" in captured.out
-        assert "text-embedding-3-small" in captured.out
-        mock_get_conn.assert_not_called()
-
-    def test_migrate_custom_model_missing_dims(self, capsys):
-        """Custom model without --dims returns error."""
-        parser = app()
-        args = parser.parse_args(["embeddings", "migrate", "--model", "unknown-model"])
-        result = cmd_embeddings(args)
-
-        assert result == 1
-        captured = capsys.readouterr()
-        assert "Unknown model" in captured.err
-        assert "--dims" in captured.err
-
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_migrate_already_configured(self, mock_get_conn, mock_db, capsys):
-        """Skip migration if already on the target model."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-
-        mock_cur.fetchone.return_value = {
-            "id": "local_bge_small",
-            "dimensions": 384,
-            "is_default": True,
-        }
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "migrate", "--model", "BAAI/bge-small-en-v1.5"])
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        captured = capsys.readouterr()
-        assert "Already configured" in captured.out
-
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_migrate_executes_steps(self, mock_get_conn, mock_db, capsys):
-        """Migration executes all steps via migrate_embedding_dimensions function."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-        mock_conn.autocommit = True  # will be set to False
-
-        # First fetchone: current embedding type
-        # Second fetchall: migration steps
-        mock_cur.fetchone.return_value = {
-            "id": "local_bge_small",
-            "dimensions": 384,
-            "is_default": True,
-        }
-        mock_cur.fetchall.return_value = [
-            {"step": "register_type", "detail": "Registered openai_text3_small"},
-            {"step": "complete", "detail": "Migration complete"},
-        ]
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "migrate", "--model", "text-embedding-3-small"])
-        result = cmd_embeddings(args)
-
-        assert result == 0
-        captured = capsys.readouterr()
-        assert "Migration to" in captured.out
-        assert "1536" in captured.out
-        mock_conn.commit.assert_called_once()
-
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_migrate_error_rolls_back(self, mock_get_conn, mock_db, capsys):
-        """Migration error triggers rollback."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
-
-        mock_cur.fetchone.side_effect = Exception("DB error")
-
-        parser = app()
-        args = parser.parse_args(["embeddings", "migrate", "--model", "text-embedding-3-small"])
-        result = cmd_embeddings(args)
-
-        assert result == 1
-        mock_conn.rollback.assert_called_once()
-
-
-# ============================================================================
-# Status Argument Parsing (#364)
-# ============================================================================
-
 
 class TestStatusArgParsing:
     """Test CLI argument parsing for embeddings status command."""
@@ -558,49 +108,183 @@ class TestStatusArgParsing:
 
 
 # ============================================================================
-# Status Command Tests (#364)
+# REST Client Command Tests
 # ============================================================================
 
 
-class TestStatusCommand:
-    """Test embeddings status command logic."""
+class TestBackfillREST:
+    """Test embeddings backfill via REST client."""
 
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_status_shows_info(self, mock_get_conn, mock_db, capsys):
-        """Status shows embedding types, columns, and coverage."""
-        mock_conn, mock_cur = mock_db
-        mock_get_conn.return_value = mock_conn
+    @patch("valence.cli.commands.embeddings.get_client")
+    def test_backfill_happy_path(self, mock_get_client):
+        """Backfill calls POST /admin/embeddings/backfill."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"success": True, "processed": 10, "errors": 0}
+        mock_get_client.return_value = mock_client
 
-        # Calls: embedding_types, vector columns, coverage, total beliefs, embedded beliefs
-        mock_cur.fetchall.side_effect = [
-            [{"id": "local_bge_small", "provider": "local", "model": "BAAI/bge-small-en-v1.5", "dimensions": 384, "is_default": True, "status": "active"}],
-            [{"table_name": "beliefs", "column_name": "embedding", "udt_name": "vector", "dims": 384}],
-            [{"embedding_type_id": "local_bge_small", "content_type": "belief", "count": 42}],
-        ]
-        mock_cur.fetchone.side_effect = [
-            {"count": 100},  # total beliefs
-            {"count": 42},   # embedded beliefs
-        ]
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        call_body = mock_client.post.call_args[1]["body"]
+        assert call_body["batch_size"] == 50
+        assert call_body["dry_run"] is False
+
+    @patch("valence.cli.commands.embeddings.get_client")
+    def test_backfill_dry_run(self, mock_get_client):
+        """Dry run passes dry_run=True."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"success": True, "would_process": 5, "dry_run": True}
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "--dry-run"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        call_body = mock_client.post.call_args[1]["body"]
+        assert call_body["dry_run"] is True
+
+    @patch("valence.cli.commands.embeddings.get_client")
+    def test_backfill_custom_batch_size(self, mock_get_client):
+        """Custom batch size passed through."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"success": True, "processed": 25}
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "-b", "25"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        call_body = mock_client.post.call_args[1]["body"]
+        assert call_body["batch_size"] == 25
+
+    @patch("valence.cli.commands.embeddings.get_client")
+    def test_backfill_connection_error(self, mock_get_client):
+        """Handles connection error."""
+        from valence.cli.http_client import ValenceConnectionError
+        mock_client = MagicMock()
+        mock_client.post.side_effect = ValenceConnectionError("http://127.0.0.1:8420")
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill"])
+        result = cmd_embeddings(args)
+
+        assert result == 1
+
+
+class TestMigrateREST:
+    """Test embeddings migrate via REST client."""
+
+    @patch("valence.cli.commands.embeddings.get_client")
+    def test_migrate_happy_path(self, mock_get_client):
+        """Migrate calls POST /admin/embeddings/migrate."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"success": True, "cleared_embeddings": 50}
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "migrate", "--model", "text-embedding-3-small"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        call_body = mock_client.post.call_args[1]["body"]
+        assert call_body["model"] == "text-embedding-3-small"
+
+    @patch("valence.cli.commands.embeddings.get_client")
+    def test_migrate_with_dims(self, mock_get_client):
+        """Migrate passes dims."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"success": True, "cleared_embeddings": 50}
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "migrate", "--model", "custom", "--dims", "768"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        call_body = mock_client.post.call_args[1]["body"]
+        assert call_body["model"] == "custom"
+        assert call_body["dims"] == 768
+
+    @patch("valence.cli.commands.embeddings.get_client")
+    def test_migrate_dry_run(self, mock_get_client):
+        """Migrate dry run."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"success": True, "would_affect": 50, "dry_run": True}
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "migrate", "--model", "text-embedding-3-small", "--dry-run"])
+        result = cmd_embeddings(args)
+
+        assert result == 0
+        call_body = mock_client.post.call_args[1]["body"]
+        assert call_body["dry_run"] is True
+
+    @patch("valence.cli.commands.embeddings.get_client")
+    def test_migrate_api_error(self, mock_get_client):
+        """Handles API error."""
+        from valence.cli.http_client import ValenceAPIError
+        mock_client = MagicMock()
+        mock_client.post.side_effect = ValenceAPIError(400, "MISSING_FIELD", "model or dims required")
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["embeddings", "migrate", "--model", "x"])
+        result = cmd_embeddings(args)
+
+        assert result == 1
+
+
+class TestStatusREST:
+    """Test embeddings status via REST client."""
+
+    @patch("valence.cli.commands.embeddings.get_client")
+    def test_status_happy_path(self, mock_get_client):
+        """Status calls GET /admin/embeddings/status."""
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"success": True, "stats": {"total_beliefs": 100, "with_embeddings": 80}}
+        mock_get_client.return_value = mock_client
 
         parser = app()
         args = parser.parse_args(["embeddings", "status"])
         result = cmd_embeddings(args)
 
         assert result == 0
-        captured = capsys.readouterr()
-        assert "local_bge_small" in captured.out
-        assert "384" in captured.out
-        assert "42/100" in captured.out
+        mock_client.get.assert_called_once()
+        assert "/admin/embeddings/status" in mock_client.get.call_args[0][0]
 
-    @patch("valence.cli.commands.embeddings.get_db_connection")
-    def test_status_error_handling(self, mock_get_conn, capsys):
-        """Status handles connection errors gracefully."""
-        mock_get_conn.side_effect = Exception("Cannot connect")
+    @patch("valence.cli.commands.embeddings.get_client")
+    def test_status_connection_error(self, mock_get_client):
+        """Handles connection error."""
+        from valence.cli.http_client import ValenceConnectionError
+        mock_client = MagicMock()
+        mock_client.get.side_effect = ValenceConnectionError("http://127.0.0.1:8420")
+        mock_get_client.return_value = mock_client
 
         parser = app()
         args = parser.parse_args(["embeddings", "status"])
         result = cmd_embeddings(args)
 
         assert result == 1
-        captured = capsys.readouterr()
-        assert "failed" in captured.err.lower()
+
+
+# ============================================================================
+# Command Routing
+# ============================================================================
+
+
+class TestEmbeddingsRouting:
+    """Test embeddings command routing."""
+
+    def test_main_dispatches_to_embeddings(self):
+        """main() dispatches 'embeddings' to cmd_embeddings via args.func."""
+        parser = app()
+        args = parser.parse_args(["embeddings", "backfill", "--dry-run"])
+
+        assert hasattr(args, "func")
+        assert args.func is cmd_embeddings

--- a/tests/cli/test_http_client.py
+++ b/tests/cli/test_http_client.py
@@ -1,0 +1,172 @@
+"""Tests for the Valence HTTP client."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from valence.cli.config import CLIConfig, reset_cli_config, set_cli_config
+from valence.cli.http_client import ValenceAPIError, ValenceClient, ValenceConnectionError, get_client
+
+
+@pytest.fixture(autouse=True)
+def _setup_config():
+    """Set up a test config."""
+    set_cli_config(CLIConfig(server_url="http://test:8420", token="vt_test123", timeout=5.0))
+    yield
+    reset_cli_config()
+
+
+class TestValenceClient:
+    def test_url_construction(self):
+        client = ValenceClient()
+        assert client._url("/beliefs") == "http://test:8420/api/v1/beliefs"
+        assert client._url("/admin/migrate/up") == "http://test:8420/api/v1/admin/migrate/up"
+
+    def test_url_strips_trailing_slash(self):
+        client = ValenceClient(server_url="http://test:8420/")
+        assert client._url("/beliefs") == "http://test:8420/api/v1/beliefs"
+
+    def test_headers_with_token(self):
+        client = ValenceClient()
+        headers = client._headers()
+        assert headers["Authorization"] == "Bearer vt_test123"
+
+    def test_headers_without_token(self):
+        client = ValenceClient(token="")
+        headers = client._headers()
+        assert "Authorization" not in headers
+
+    def test_constructor_overrides_config(self):
+        client = ValenceClient(server_url="http://override:9999", token="vt_override", timeout=99.0)
+        assert client.base_url == "http://override:9999"
+        assert client.token == "vt_override"
+        assert client.timeout == 99.0
+
+
+class TestHandleResponse:
+    def test_success_json(self):
+        client = ValenceClient()
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.headers = {"content-type": "application/json"}
+        resp.json.return_value = {"success": True, "beliefs": []}
+        result = client._handle_response(resp)
+        assert result == {"success": True, "beliefs": []}
+
+    def test_success_plain_text(self):
+        client = ValenceClient()
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.headers = {"content-type": "text/plain; charset=utf-8"}
+        resp.text = "Valence Statistics\n---------\nBeliefs: 42"
+        result = client._handle_response(resp)
+        assert result == {"formatted": "Valence Statistics\n---------\nBeliefs: 42"}
+
+    def test_error_response_raises(self):
+        client = ValenceClient()
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 404
+        resp.json.return_value = {"success": False, "error": {"code": "NOT_FOUND_BELIEF", "message": "Belief not found"}}
+        with pytest.raises(ValenceAPIError) as exc_info:
+            client._handle_response(resp)
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.code == "NOT_FOUND_BELIEF"
+        assert exc_info.value.message == "Belief not found"
+
+    def test_error_response_non_json(self):
+        client = ValenceClient()
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 500
+        resp.json.side_effect = json.JSONDecodeError("", "", 0)
+        resp.text = "Internal Server Error"
+        with pytest.raises(ValenceAPIError) as exc_info:
+            client._handle_response(resp)
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.message == "Internal Server Error"
+
+    def test_auth_error(self):
+        client = ValenceClient()
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 401
+        resp.json.return_value = {"success": False, "error": {"code": "AUTH_MISSING_TOKEN", "message": "Missing or invalid authentication token"}}
+        with pytest.raises(ValenceAPIError) as exc_info:
+            client._handle_response(resp)
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.code == "AUTH_MISSING_TOKEN"
+
+
+class TestClientRequests:
+    @patch("valence.cli.http_client.httpx.Client")
+    def test_get(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "application/json"}
+        mock_resp.json.return_value = {"success": True, "data": "test"}
+        mock_client.request.return_value = mock_resp
+
+        client = ValenceClient()
+        result = client.get("/beliefs", params={"query": "test"})
+        assert result == {"success": True, "data": "test"}
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "http://test:8420/api/v1/beliefs",
+            headers={"Authorization": "Bearer vt_test123"},
+            params={"query": "test"},
+            json=None,
+        )
+
+    @patch("valence.cli.http_client.httpx.Client")
+    def test_post(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 201
+        mock_resp.headers = {"content-type": "application/json"}
+        mock_resp.json.return_value = {"success": True, "id": "abc123"}
+        mock_client.request.return_value = mock_resp
+
+        client = ValenceClient()
+        result = client.post("/beliefs", body={"content": "test belief"})
+        assert result == {"success": True, "id": "abc123"}
+
+    @patch("valence.cli.http_client.httpx.Client")
+    def test_connection_error(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.request.side_effect = httpx.ConnectError("Connection refused")
+
+        client = ValenceClient()
+        with pytest.raises(ValenceConnectionError) as exc_info:
+            client.get("/health")
+        assert "http://test:8420" in str(exc_info.value)
+        assert "valence-server" in str(exc_info.value)
+
+    @patch("valence.cli.http_client.httpx.Client")
+    def test_timeout_error(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.request.side_effect = httpx.TimeoutException("timed out")
+
+        client = ValenceClient()
+        with pytest.raises(ValenceConnectionError) as exc_info:
+            client.get("/health")
+        assert "timed out" in str(exc_info.value)
+
+
+class TestGetClient:
+    def test_get_client_uses_config(self):
+        client = get_client()
+        assert client.base_url == "http://test:8420"
+        assert client.token == "vt_test123"

--- a/tests/cli/test_migration_cli.py
+++ b/tests/cli/test_migration_cli.py
@@ -1,0 +1,200 @@
+"""Tests for migration CLI commands.
+
+Tests cover:
+1. Argument parsing for migrate up/down/status/create
+2. REST client calls for migrate up/down/status
+3. Local-only migrate create
+4. Error handling
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from valence.cli.main import app
+from valence.cli.commands.migration import cmd_migrate
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    """Reset CLI config singleton for each test."""
+    from valence.cli.config import reset_cli_config
+    reset_cli_config()
+    yield
+    reset_cli_config()
+
+
+# ============================================================================
+# Argument Parsing
+# ============================================================================
+
+
+class TestMigrateArgParsing:
+    """Test CLI argument parsing for migrate commands."""
+
+    def test_migrate_up_defaults(self):
+        """Parse migrate up with defaults."""
+        parser = app()
+        args = parser.parse_args(["migrate", "up"])
+        assert args.command == "migrate"
+        assert args.migrate_command == "up"
+        assert args.dry_run is False
+
+    def test_migrate_up_dry_run(self):
+        """Parse migrate up --dry-run."""
+        parser = app()
+        args = parser.parse_args(["migrate", "up", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_migrate_down_defaults(self):
+        """Parse migrate down with defaults."""
+        parser = app()
+        args = parser.parse_args(["migrate", "down"])
+        assert args.migrate_command == "down"
+        assert args.dry_run is False
+
+    def test_migrate_down_dry_run(self):
+        """Parse migrate down --dry-run."""
+        parser = app()
+        args = parser.parse_args(["migrate", "down", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_migrate_status(self):
+        """Parse migrate status."""
+        parser = app()
+        args = parser.parse_args(["migrate", "status"])
+        assert args.migrate_command == "status"
+
+    def test_migrate_create(self):
+        """Parse migrate create."""
+        parser = app()
+        args = parser.parse_args(["migrate", "create", "add_users_table"])
+        assert args.migrate_command == "create"
+        assert args.name == "add_users_table"
+
+    def test_migrate_requires_subcommand(self):
+        """migrate without subcommand raises error."""
+        parser = app()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["migrate"])
+
+
+# ============================================================================
+# REST Client Command Tests
+# ============================================================================
+
+
+class TestMigrateUpREST:
+    """Test migrate up via REST client."""
+
+    @patch("valence.cli.commands.migration.get_client")
+    def test_up_happy_path(self, mock_get_client):
+        """Migrate up calls POST /admin/migrate/up."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"success": True, "applied": ["001_init"], "dry_run": False}
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["migrate", "up"])
+        result = cmd_migrate(args)
+
+        assert result == 0
+        mock_client.post.assert_called_once_with("/admin/migrate/up", body={"dry_run": False})
+
+    @patch("valence.cli.commands.migration.get_client")
+    def test_up_dry_run(self, mock_get_client):
+        """Migrate up dry run passes dry_run=True."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"success": True, "applied": ["001_init"], "dry_run": True}
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["migrate", "up", "--dry-run"])
+        result = cmd_migrate(args)
+
+        assert result == 0
+        call_body = mock_client.post.call_args[1]["body"]
+        assert call_body["dry_run"] is True
+
+    @patch("valence.cli.commands.migration.get_client")
+    def test_up_connection_error(self, mock_get_client):
+        """Handles connection error."""
+        from valence.cli.http_client import ValenceConnectionError
+        mock_client = MagicMock()
+        mock_client.post.side_effect = ValenceConnectionError("http://127.0.0.1:8420")
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["migrate", "up"])
+        result = cmd_migrate(args)
+
+        assert result == 1
+
+
+class TestMigrateDownREST:
+    """Test migrate down via REST client."""
+
+    @patch("valence.cli.commands.migration.get_client")
+    def test_down_happy_path(self, mock_get_client):
+        """Migrate down calls POST /admin/migrate/down."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"success": True, "rolled_back": "001_init", "dry_run": False}
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["migrate", "down"])
+        result = cmd_migrate(args)
+
+        assert result == 0
+        mock_client.post.assert_called_once_with("/admin/migrate/down", body={"dry_run": False})
+
+
+class TestMigrateStatusREST:
+    """Test migrate status via REST client."""
+
+    @patch("valence.cli.commands.migration.get_client")
+    def test_status_happy_path(self, mock_get_client):
+        """Migrate status calls GET /admin/migrate/status."""
+        mock_client = MagicMock()
+        mock_client.get.return_value = {"success": True, "migrations": [], "count": 0}
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["migrate", "status"])
+        result = cmd_migrate(args)
+
+        assert result == 0
+        mock_client.get.assert_called_once()
+        assert "/admin/migrate/status" in mock_client.get.call_args[0][0]
+
+    @patch("valence.cli.commands.migration.get_client")
+    def test_status_api_error(self, mock_get_client):
+        """Handles API error."""
+        from valence.cli.http_client import ValenceAPIError
+        mock_client = MagicMock()
+        mock_client.get.side_effect = ValenceAPIError(403, "FORBIDDEN", "Insufficient scope")
+        mock_get_client.return_value = mock_client
+
+        parser = app()
+        args = parser.parse_args(["migrate", "status"])
+        result = cmd_migrate(args)
+
+        assert result == 1
+
+
+# ============================================================================
+# Command Routing
+# ============================================================================
+
+
+class TestMigrateRouting:
+    """Test migrate command routing."""
+
+    def test_dispatches_to_migrate(self):
+        """main() dispatches 'migrate' to cmd_migrate via args.func."""
+        parser = app()
+        args = parser.parse_args(["migrate", "up"])
+        assert hasattr(args, "func")
+        assert args.func is cmd_migrate

--- a/tests/core/test_exchange_compaction.py
+++ b/tests/core/test_exchange_compaction.py
@@ -272,20 +272,20 @@ class TestCompactExchanges:
 class TestCmdMaintenanceCompact:
     """Test --compact CLI flag."""
 
-    @patch("valence.cli.commands.maintenance.get_db_connection")
-    def test_compact_flag(self, mock_conn_fn):
+    @patch("valence.cli.commands.maintenance.get_client")
+    def test_compact_flag(self, mock_get_client):
         from valence.cli.commands.maintenance import cmd_maintenance
 
-        mock_conn = MagicMock()
-        mock_conn_fn.return_value = mock_conn
-        mock_cur = MagicMock()
-        mock_conn.cursor.return_value = mock_cur
-        mock_cur.fetchall.return_value = []  # No candidates
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"success": True, "results": [], "count": 0, "dry_run": False}
+        mock_get_client.return_value = mock_client
 
         args = argparse.Namespace(
             run_all=False, retention=False, archive=False,
             tombstones=False, compact=True, views=False, vacuum=False,
-            dry_run=False, output_json=False,
+            dry_run=False,
         )
         result = cmd_maintenance(args)
         assert result == 0
+        call_body = mock_client.post.call_args[1]["body"]
+        assert call_body["compact"] is True

--- a/tests/server/test_admin_endpoints.py
+++ b/tests/server/test_admin_endpoints.py
@@ -1,0 +1,287 @@
+"""Tests for admin REST endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from valence.server.admin_endpoints import (
+    admin_embeddings_backfill,
+    admin_embeddings_migrate,
+    admin_embeddings_status,
+    admin_maintenance,
+    admin_migrate_down,
+    admin_migrate_status,
+    admin_migrate_up,
+    admin_verify_chains,
+)
+from valence.server.auth_helpers import AuthenticatedClient
+
+MOCK_CLIENT = AuthenticatedClient(client_id="test", auth_method="bearer")
+
+
+@pytest.fixture
+def app():
+    routes = [
+        Route("/api/v1/admin/migrate/status", admin_migrate_status, methods=["GET"]),
+        Route("/api/v1/admin/migrate/up", admin_migrate_up, methods=["POST"]),
+        Route("/api/v1/admin/migrate/down", admin_migrate_down, methods=["POST"]),
+        Route("/api/v1/admin/maintenance", admin_maintenance, methods=["POST"]),
+        Route("/api/v1/admin/embeddings/status", admin_embeddings_status, methods=["GET"]),
+        Route("/api/v1/admin/embeddings/backfill", admin_embeddings_backfill, methods=["POST"]),
+        Route("/api/v1/admin/embeddings/migrate", admin_embeddings_migrate, methods=["POST"]),
+        Route("/api/v1/admin/verify-chains", admin_verify_chains, methods=["GET"]),
+    ]
+    return Starlette(routes=routes)
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    with patch("valence.server.admin_endpoints.authenticate", return_value=MOCK_CLIENT):
+        yield
+
+
+def _mock_cursor():
+    """Create a mock cursor context manager."""
+    mock_cur = MagicMock()
+    mock_cm = MagicMock()
+    mock_cm.__enter__ = MagicMock(return_value=mock_cur)
+    mock_cm.__exit__ = MagicMock(return_value=False)
+    return mock_cm, mock_cur
+
+
+# =============================================================================
+# AUTH
+# =============================================================================
+
+
+class TestAdminAuth:
+    def test_unauthenticated_returns_401(self, client):
+        with patch(
+            "valence.server.admin_endpoints.authenticate",
+            return_value=JSONResponse({"error": "unauthorized"}, status_code=401),
+        ):
+            resp = client.get("/api/v1/admin/migrate/status")
+            assert resp.status_code == 401
+
+    def test_wrong_scope_returns_403(self, client):
+        oauth_client = AuthenticatedClient(client_id="test", auth_method="oauth", scope="substrate:read")
+        with patch("valence.server.admin_endpoints.authenticate", return_value=oauth_client):
+            resp = client.get("/api/v1/admin/migrate/status")
+            assert resp.status_code == 403
+
+
+# =============================================================================
+# MIGRATION ENDPOINTS
+# =============================================================================
+
+
+class TestMigrateStatus:
+    @patch("our_db.get_cursor")
+    def test_happy_path(self, mock_gc, client):
+        mock_cm, mock_cur = _mock_cursor()
+        mock_gc.return_value = mock_cm
+        mock_cur.fetchall.return_value = [
+            {"name": "001_init", "applied_at": "2024-01-01 00:00:00"},
+            {"name": "002_add_embeddings", "applied_at": "2024-01-02 00:00:00"},
+        ]
+
+        resp = client.get("/api/v1/admin/migrate/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["count"] == 2
+
+    @patch("our_db.get_cursor")
+    def test_text_output(self, mock_gc, client):
+        mock_cm, mock_cur = _mock_cursor()
+        mock_gc.return_value = mock_cm
+        mock_cur.fetchall.return_value = [{"name": "001_init", "applied_at": "2024-01-01"}]
+
+        resp = client.get("/api/v1/admin/migrate/status", params={"output": "text"})
+        assert resp.status_code == 200
+        assert "Migration Status" in resp.text
+
+
+class TestMigrateUp:
+    @patch("valence.core.migrations.MigrationRunner")
+    def test_happy_path(self, mock_runner_cls, client):
+        mock_runner = MagicMock()
+        mock_runner.up.return_value = ["001_init", "002_embeddings"]
+        mock_runner_cls.return_value = mock_runner
+
+        resp = client.post("/api/v1/admin/migrate/up", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert len(data["applied"]) == 2
+
+    @patch("valence.core.migrations.MigrationRunner")
+    def test_dry_run(self, mock_runner_cls, client):
+        mock_runner = MagicMock()
+        mock_runner.up.return_value = ["001_init"]
+        mock_runner_cls.return_value = mock_runner
+
+        resp = client.post("/api/v1/admin/migrate/up", json={"dry_run": True})
+        assert resp.status_code == 200
+        assert resp.json()["dry_run"] is True
+
+
+# =============================================================================
+# MAINTENANCE
+# =============================================================================
+
+
+class TestMaintenance:
+    def test_no_operation_returns_error(self, client):
+        resp = client.post("/api/v1/admin/maintenance", json={})
+        assert resp.status_code == 400
+
+    @patch("valence.cli.utils.get_db_connection")
+    @patch("valence.core.maintenance.apply_retention")
+    def test_retention(self, mock_retention, mock_conn, client):
+        from valence.core.maintenance import MaintenanceResult
+
+        mock_retention.return_value = [MaintenanceResult(operation="apply_retention", details={"deleted": 5})]
+        conn = MagicMock()
+        conn.autocommit = False
+        conn.cursor.return_value = MagicMock()
+        mock_conn.return_value = conn
+
+        resp = client.post("/api/v1/admin/maintenance", json={"retention": True})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["count"] == 1
+
+    @patch("valence.cli.utils.get_db_connection")
+    @patch("valence.core.maintenance.run_full_maintenance")
+    def test_run_all(self, mock_full, mock_conn, client):
+        from valence.core.maintenance import MaintenanceResult
+
+        mock_full.return_value = [
+            MaintenanceResult(operation="retention", details={}),
+            MaintenanceResult(operation="archive", details={}),
+        ]
+        conn = MagicMock()
+        conn.autocommit = False
+        conn.cursor.return_value = MagicMock()
+        mock_conn.return_value = conn
+
+        resp = client.post("/api/v1/admin/maintenance", json={"all": True})
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 2
+
+    @patch("valence.cli.utils.get_db_connection")
+    @patch("valence.core.maintenance.apply_retention")
+    def test_dry_run(self, mock_retention, mock_conn, client):
+        from valence.core.maintenance import MaintenanceResult
+
+        mock_retention.return_value = [MaintenanceResult(operation="retention", details={"would_delete": 5}, dry_run=True)]
+        conn = MagicMock()
+        conn.autocommit = False
+        conn.cursor.return_value = MagicMock()
+        mock_conn.return_value = conn
+
+        resp = client.post("/api/v1/admin/maintenance", json={"retention": True, "dry_run": True})
+        assert resp.status_code == 200
+        assert resp.json()["dry_run"] is True
+
+
+# =============================================================================
+# EMBEDDINGS
+# =============================================================================
+
+
+class TestEmbeddingsStatus:
+    @patch("our_db.get_cursor")
+    def test_happy_path(self, mock_gc, client):
+        mock_cm, mock_cur = _mock_cursor()
+        mock_gc.return_value = mock_cm
+        mock_cur.fetchone.side_effect = [
+            {"total": 100},
+            {"embedded": 80},
+            {"missing": 20},
+        ]
+
+        resp = client.get("/api/v1/admin/embeddings/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["stats"]["total_beliefs"] == 100
+        assert data["stats"]["with_embeddings"] == 80
+
+
+class TestEmbeddingsBackfill:
+    @patch("our_embeddings.service.generate_embedding")
+    @patch("our_db.get_cursor")
+    def test_dry_run(self, mock_gc, mock_embed, client):
+        mock_cm, mock_cur = _mock_cursor()
+        mock_gc.return_value = mock_cm
+        mock_cur.fetchall.return_value = [{"id": "1", "content": "test"}]
+
+        resp = client.post("/api/v1/admin/embeddings/backfill", json={"dry_run": True})
+        assert resp.status_code == 200
+        assert resp.json()["dry_run"] is True
+        assert resp.json()["would_process"] == 1
+
+
+class TestEmbeddingsMigrate:
+    def test_missing_params(self, client):
+        resp = client.post("/api/v1/admin/embeddings/migrate", json={})
+        assert resp.status_code == 400
+
+    @patch("our_db.get_cursor")
+    def test_dry_run(self, mock_gc, client):
+        mock_cm, mock_cur = _mock_cursor()
+        mock_gc.return_value = mock_cm
+        mock_cur.fetchone.return_value = {"count": 50}
+
+        resp = client.post("/api/v1/admin/embeddings/migrate", json={"model": "text-embedding-3-small", "dry_run": True})
+        assert resp.status_code == 200
+        assert resp.json()["would_affect"] == 50
+
+
+# =============================================================================
+# CHAIN VERIFICATION
+# =============================================================================
+
+
+class TestVerifyChains:
+    @patch("our_db.get_cursor")
+    def test_healthy(self, mock_gc, client):
+        mock_cm, mock_cur = _mock_cursor()
+        mock_gc.return_value = mock_cm
+        mock_cur.fetchall.side_effect = [[], []]
+
+        resp = client.get("/api/v1/admin/verify-chains")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["status"] == "healthy"
+        assert data["count"] == 0
+
+    @patch("our_db.get_cursor")
+    def test_issues_found(self, mock_gc, client):
+        mock_cm, mock_cur = _mock_cursor()
+        mock_gc.return_value = mock_cm
+        mock_cur.fetchall.side_effect = [
+            [{"id": "abc", "superseded_by_id": "xyz"}],
+            [],
+        ]
+
+        resp = client.get("/api/v1/admin/verify-chains")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "issues_found"
+        assert data["count"] == 1


### PR DESCRIPTION
## Summary

Refactors the Valence CLI from a direct-DB client (psycopg2 + embeddings) into a pure REST client that talks exclusively to the Valence HTTP server. This decouples the CLI from heavy dependencies (ML models, Postgres drivers), makes it usable from any machine with a token, and centralizes all logic server-side.

- **New infrastructure**: `CLIConfig` (TOML + env + flags), `ValenceClient` (httpx-based HTTP client), `output` module
- **8 new admin endpoints**: migrate up/down/status, maintenance, embeddings backfill/migrate/status, verify-chains
- **2 new query endpoints**: `GET /stats`, `GET /beliefs/conflicts`
- **Server-side output formatting**: `?output=json|text|table` on all endpoints
- **6 CLI command modules rewritten** as thin REST clients: beliefs, stats, conflicts, migration, maintenance, embeddings
- **26 files changed**: 2,669 insertions, 2,526 deletions (net +143 lines while adding significant new capability)

## What Changed

### Phase 1: Infrastructure
- `src/valence/cli/config.py` — CLI config with precedence: flags > env > TOML file > defaults
- `src/valence/cli/http_client.py` — `ValenceClient` with get/post/delete, Bearer auth, structured error handling
- `src/valence/cli/output.py` — Unified output formatting
- Global `--server`, `--token`, `--output`, `--json`, `--timeout` flags on CLI

### Phase 2: Server Endpoints
- `src/valence/server/admin_endpoints.py` — 8 admin endpoints (all require `admin:write` scope)
- `src/valence/server/formatters.py` — Text/table formatters per resource type
- Stats and conflicts endpoints on `substrate_endpoints.py`
- `?output=` format support across all endpoints

### Phase 3: CLI Command Rewrites
Each command module went from direct DB queries to ~3-line REST calls:
- `beliefs.py`: 687 → ~170 lines (init, add, query, list, verify-chains)
- `stats.py`: 74 → ~35 lines
- `conflicts.py`: 220 → ~50 lines
- `migration.py`: 263 → ~120 lines (create stays local)
- `maintenance.py`: 132 → ~75 lines
- `embeddings.py`: 430 → ~120 lines

### Phase 4: Cleanup
- Removed `cmd_migrate_visibility` (legacy)
- Removed `get_db_connection`/`get_embedding` from CLI re-exports
- Lint fixes via ruff

## Test plan

- [x] `pytest tests/cli/ -v` — all CLI tests pass (new + rewritten)
- [x] `pytest tests/server/ -v` — all server tests pass (new + existing)
- [x] `pytest tests/ --timeout=60 -q` — full suite: 2770 passed, 6 pre-existing failures (config port mismatches), 124 skipped
- [x] `ruff check` — clean
- [ ] Manual: `valence --server http://127.0.0.1:8420 --token vt_xxx query "test"`
- [ ] Manual: `valence --json stats` returns JSON
- [ ] Manual: `valence stats` returns human-readable text

## Deferred (future PRs)

- Trust mutation commands (set/show/watch/unwatch/distrust/ignore) — need new server endpoints
- Peers, IO, federation commands — need admin CRUD endpoints
- Attestations, resources commands — need new endpoints
- Schema, QoS, discovery — local-only, no DB deps

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)