### PR TITLE
ci: restore *.md to paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
+      - "*.md"
       - "docs/**"
       - "!pyproject.toml"
       - ".github/ISSUE_TEMPLATE/**"
   push:
     branches: [main]
     paths-ignore:
+      - "*.md"
       - "docs/**"
       - "!pyproject.toml"
       - ".github/ISSUE_TEMPLATE/**"


### PR DESCRIPTION
Restores *.md exclusion from CI paths-ignore after temporarily removing it for #431. Prevents unnecessary CI runs for docs-only changes.