### PR TITLE
feat: epistemic article types — episodic, semantic, procedural (#501)

### DIFF
--- a/migrations/006_epistemic_types.sql
+++ b/migrations/006_epistemic_types.sql
@@ -1,0 +1,13 @@
+-- Add epistemic_type to articles for different lifecycle rules
+-- Types: episodic (decays), semantic (persists), procedural (pinned)
+
+DO $$ BEGIN
+    CREATE TYPE epistemic_type AS ENUM ('episodic', 'semantic', 'procedural');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE articles
+    ADD COLUMN IF NOT EXISTS epistemic_type epistemic_type NOT NULL DEFAULT 'semantic';
+
+-- Index for filtering by type in decay/eviction queries
+CREATE INDEX IF NOT EXISTS idx_articles_epistemic_type ON articles (epistemic_type) WHERE status = 'active';

--- a/schema.sql
+++ b/schema.sql
@@ -67,6 +67,7 @@ CREATE TABLE public.articles (
     title text,
     author_type text DEFAULT 'system'::text NOT NULL,
     pinned boolean DEFAULT false NOT NULL,
+    epistemic_type text DEFAULT 'semantic' NOT NULL,
     size_tokens integer,
     compiled_at timestamp with time zone,
     usage_score numeric(8,4) DEFAULT 0 NOT NULL,

--- a/src/valence/core/inference.py
+++ b/src/valence/core/inference.py
@@ -69,6 +69,7 @@ TASK_OUTPUT_SCHEMAS: dict[str, str] = {
     {
       "title": "<descriptive article title>",
       "content": "<article content>",
+      "epistemic_type": "episodic|semantic|procedural",
       "source_relationships": [
         {"source_id": "<source_id>", "relationship": "originates|confirms|supersedes|contradicts|contends"}
       ]


### PR DESCRIPTION
## Summary

Adds `epistemic_type` classification to articles, enabling different lifecycle rules per knowledge type.

### Types

| Type | Description | Lifecycle |
|------|-------------|-----------|
| **episodic** | Temporal/event-based (session logs, meeting notes) | Decays over time |
| **semantic** | Factual/persistent (config, architecture decisions) | Persists until superseded |
| **procedural** | Instructional (runbooks, guides) | Pinned, explicit updates only |

### Changes

- **Migration 006**: adds `epistemic_type` column (default: `'semantic'`)
- **Compilation prompt**: instructs LLM to classify each article by type
- **compile_article/recompile_article**: stores `epistemic_type` from LLM response
- **schema.sql**: updated
- Defaults to `'semantic'` for backward compat

### Follow-up (not in this PR)

- Decay rules: episodic articles decay based on freshness, semantic don't
- Eviction eligibility: only episodic articles eligible for archival
- Retrieval weighting: adjust ranking formula by type
- Query intent detection: prefer semantic for factual queries, episodic for 'what happened' queries

Closes #501