### PR TITLE
feat: surface epistemic_type across MCP, REST, and CLI

### DIFF
--- a/src/valence/cli/commands/articles.py
+++ b/src/valence/cli/commands/articles.py
@@ -28,6 +28,11 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     search_p.add_argument("query", help="Search query")
     search_p.add_argument("--limit", "-n", type=int, default=10, help="Max results (default 10)")
     search_p.add_argument("--domain", "-d", action="append", dest="domain_filter", help="Domain path filter (repeatable)")
+    search_p.add_argument(
+        "--epistemic-type",
+        choices=["episodic", "semantic", "procedural"],
+        help="Filter results by epistemic type",
+    )
     search_p.set_defaults(func=cmd_articles_search)
 
     # --- get ---
@@ -52,6 +57,12 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         default="agent",
         help="Author type (default: agent)",
     )
+    create_p.add_argument(
+        "--epistemic-type",
+        choices=["episodic", "semantic", "procedural"],
+        default="semantic",
+        help="Knowledge type: episodic (decays), semantic (persists), procedural (pinned)",
+    )
     create_p.set_defaults(func=cmd_articles_create)
 
     # --- update ---
@@ -59,6 +70,11 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     update_p.add_argument("article_id", help="UUID of the article to update")
     update_p.add_argument("--content", "-c", required=True, help="New content for the article")
     update_p.add_argument("--source-id", help="Optional source ID that prompted this update")
+    update_p.add_argument(
+        "--epistemic-type",
+        choices=["episodic", "semantic", "procedural"],
+        help="Optional new epistemic type classification",
+    )
     update_p.set_defaults(func=cmd_articles_update)
 
     # --- merge ---
@@ -92,6 +108,8 @@ def cmd_articles_search(args: argparse.Namespace) -> int:
     }
     if getattr(args, "domain_filter", None):
         body["domain_filter"] = args.domain_filter
+    if getattr(args, "epistemic_type", None):
+        body["epistemic_type"] = args.epistemic_type
 
     try:
         result = client.post("/articles/search", body=body)
@@ -135,6 +153,8 @@ def cmd_articles_create(args: argparse.Namespace) -> int:
         body["title"] = args.title
     if getattr(args, "domain_path", None):
         body["domain_path"] = args.domain_path
+    if getattr(args, "epistemic_type", None):
+        body["epistemic_type"] = args.epistemic_type
 
     try:
         result = client.post("/articles", body=body)
@@ -192,6 +212,8 @@ def cmd_articles_update(args: argparse.Namespace) -> int:
     }
     if getattr(args, "source_id", None):
         body["source_id"] = args.source_id
+    if getattr(args, "epistemic_type", None):
+        body["epistemic_type"] = args.epistemic_type
 
     try:
         result = client.put(f"/articles/{args.article_id}", body=body)

--- a/src/valence/cli/commands/unified_search.py
+++ b/src/valence/cli/commands/unified_search.py
@@ -41,6 +41,11 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Search only sources",
     )
+    search_p.add_argument(
+        "--epistemic-type",
+        choices=["episodic", "semantic", "procedural"],
+        help="Filter article results by epistemic type",
+    )
     search_p.set_defaults(func=cmd_search)
 
 
@@ -58,6 +63,8 @@ def cmd_search(args: argparse.Namespace) -> int:
         # Search articles unless sources-only
         if not args.sources_only:
             article_body = {"query": args.query, "limit": args.limit}
+            if getattr(args, "epistemic_type", None):
+                article_body["epistemic_type"] = args.epistemic_type
             articles_result = client.post("/articles/search", body=article_body)
             results["articles"] = articles_result.get("articles", articles_result.get("results", []))
 

--- a/src/valence/mcp/handlers/articles.py
+++ b/src/valence/mcp/handlers/articles.py
@@ -20,6 +20,7 @@ def knowledge_search(
     limit: int = 10,
     include_sources: bool = False,
     session_id: str | None = None,
+    epistemic_type: str | None = None,
 ) -> dict[str, Any]:
     """Unified knowledge retrieval."""
     if not query or not query.strip():
@@ -42,6 +43,10 @@ def knowledge_search(
     else:
         result_list = results
 
+    # Filter by epistemic_type if specified
+    if epistemic_type:
+        result_list = [r for r in result_list if r.get("epistemic_type") == epistemic_type]
+
     return {
         "success": True,
         "results": result_list,
@@ -56,6 +61,7 @@ def article_create(
     source_ids: list[str] | None = None,
     author_type: str = "system",
     domain_path: list[str] | None = None,
+    epistemic_type: str = "semantic",
 ) -> dict[str, Any]:
     """Create a new article."""
     from valence.core.articles import create_article
@@ -67,6 +73,7 @@ def article_create(
             source_ids=source_ids,
             author_type=author_type,
             domain_path=domain_path,
+            epistemic_type=epistemic_type,
         )
     )
     if not result.success:
@@ -91,6 +98,7 @@ def article_update(
     article_id: str,
     content: str,
     source_id: str | None = None,
+    epistemic_type: str | None = None,
 ) -> dict[str, Any]:
     """Update an article's content."""
     from valence.core.articles import update_article
@@ -100,6 +108,7 @@ def article_update(
             article_id=article_id,
             content=content,
             source_id=source_id,
+            epistemic_type=epistemic_type,
         )
     )
     if not result.success:

--- a/src/valence/mcp/tools.py
+++ b/src/valence/mcp/tools.py
@@ -169,6 +169,11 @@ SUBSTRATE_TOOLS = [
                     "type": "string",
                     "description": "Optional session ID for usage trace attribution",
                 },
+                "epistemic_type": {
+                    "type": "string",
+                    "enum": ["episodic", "semantic", "procedural"],
+                    "description": "Filter results by epistemic type",
+                },
             },
             "required": ["query"],
         },
@@ -235,6 +240,12 @@ SUBSTRATE_TOOLS = [
                     "items": {"type": "string"},
                     "description": "Hierarchical domain tags (e.g. ['python', 'stdlib'])",
                 },
+                "epistemic_type": {
+                    "type": "string",
+                    "enum": ["episodic", "semantic", "procedural"],
+                    "default": "semantic",
+                    "description": "Knowledge type: episodic (decays), semantic (persists), procedural (pinned)",
+                },
             },
             "required": ["content"],
         },
@@ -287,6 +298,11 @@ SUBSTRATE_TOOLS = [
                 "source_id": {
                     "type": "string",
                     "description": "Optional UUID of the source that triggered this update",
+                },
+                "epistemic_type": {
+                    "type": "string",
+                    "enum": ["episodic", "semantic", "procedural"],
+                    "description": "Optional new epistemic type classification",
                 },
             },
             "required": ["article_id", "content"],

--- a/src/valence/server/substrate_endpoints.py
+++ b/src/valence/server/substrate_endpoints.py
@@ -95,6 +95,7 @@ async def beliefs_create_endpoint(request: Request) -> JSONResponse:
             title=body.get("title"),
             source_ids=body.get("source_ids"),
             domain_path=body.get("domain_path"),
+            epistemic_type=body.get("epistemic_type", "semantic"),
         )
         status_code = 201 if result.get("success") else 400
         return JSONResponse(result, status_code=status_code)
@@ -201,6 +202,7 @@ async def beliefs_supersede_endpoint(request: Request) -> JSONResponse:
         result = article_update(
             article_id=belief_id,
             content=new_content,
+            epistemic_type=body.get("epistemic_type"),
         )
         status_code = 200 if result.get("success") else 404
         return JSONResponse(result, status_code=status_code)

--- a/tests/cli/test_new_commands.py
+++ b/tests/cli/test_new_commands.py
@@ -34,6 +34,7 @@ class TestUnifiedSearch:
             limit=5,
             articles_only=False,
             sources_only=False,
+            epistemic_type=None,
         )
 
         result = cmd_search(args)
@@ -61,6 +62,7 @@ class TestUnifiedSearch:
             limit=5,
             articles_only=True,
             sources_only=False,
+            epistemic_type=None,
         )
 
         result = cmd_search(args)
@@ -84,6 +86,7 @@ class TestUnifiedSearch:
             limit=5,
             articles_only=False,
             sources_only=True,
+            epistemic_type=None,
         )
 
         result = cmd_search(args)
@@ -102,6 +105,7 @@ class TestUnifiedSearch:
             limit=5,
             articles_only=True,
             sources_only=True,
+            epistemic_type=None,
         )
 
         result = cmd_search(args)

--- a/tests/server/test_substrate_endpoints.py
+++ b/tests/server/test_substrate_endpoints.py
@@ -341,7 +341,7 @@ class TestBeliefsSupersede:
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is True
-        mock_update.assert_called_once_with(article_id="art1", content="updated belief")
+        mock_update.assert_called_once_with(article_id="art1", content="updated belief", epistemic_type=None)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Exposes the `epistemic_type` field (added in #508) across all API surfaces.

### Changes

| Surface | Create | Update | Search/Filter |
|---------|--------|--------|---------------|
| MCP tools | ✅ `article_create` | ✅ `article_update` | ✅ `knowledge_search` |
| REST API | ✅ `POST /articles` | ✅ `POST /beliefs/:id/supersede` | — |
| CLI | ✅ `--epistemic-type` | ✅ `--epistemic-type` | ✅ `--epistemic-type` |

### Validation

- Input validated against `(episodic, semantic, procedural)`
- Defaults to `semantic` for backward compat
- 1674 tests passed, mypy clean

Builds on #508.