### PR TITLE
fix: ruff linting violations in test suite (#451)

### DIFF
--- a/tests/core/test_rightsizing.py
+++ b/tests/core/test_rightsizing.py
@@ -395,7 +395,7 @@ class TestMutationQueueSplitIntegration:
             patch("valence.core.articles.split_article", mock_split),
             patch("valence.core.compilation._set_queue_item_status", mock_status),
         ):
-            count = await process_mutation_queue()
+            await process_mutation_queue()
 
         mock_split.assert_called_once_with(ARTICLE_ID)
 

--- a/tests/core/test_split.py
+++ b/tests/core/test_split.py
@@ -13,8 +13,6 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
-import pytest
-
 from valence.core.response import ValenceResponse
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #451

This PR fixes all ruff linting violations in the test suite:

- **tests/core/test_split.py**: Removed unused  import (F401)
- **tests/core/test_rightsizing.py**: Removed unused  variable assignment (F841)

All tests now pass All checks passed! with zero violations.