### PR TITLE
fix: source ingest serialization + maintenance v2 ops via REST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ coverage.json
 
 repomix-output.xml
 tokens.json
+nohup.out

--- a/src/valence/server/endpoints/sources.py
+++ b/src/valence/server/endpoints/sources.py
@@ -88,14 +88,16 @@ async def sources_create_endpoint(request: Request) -> JSONResponse:
         from ...core.exceptions import ConflictError, ValidationException
         from ...core.sources import ingest_source
 
-        source = await ingest_source(
+        result = await ingest_source(
             content=content,
             source_type=source_type,
             title=body.get("title"),
             url=body.get("url"),
             metadata=body.get("metadata"),
         )
-        return _json_response({"success": True, "source": source}, status_code=201)
+        if not result.success:
+            return _json_response({"success": False, "error": result.error}, status_code=400)
+        return _json_response({"success": True, "source": result.data}, status_code=201)
 
     except ConflictError as e:
         return conflict_error(e.message)
@@ -129,8 +131,8 @@ async def sources_get_endpoint(request: Request) -> JSONResponse:
         from ...core.exceptions import NotFoundError
         from ...core.sources import get_source
 
-        source = await get_source(source_id)
-        return _json_response({"success": True, "source": source})
+        result = await get_source(source_id)
+        return _json_response({"success": True, "source": result.data})
 
     except NotFoundError:
         return not_found_error(f"source {source_id}")


### PR DESCRIPTION
## Problem
- Source ingest endpoint (POST /sources) crashed with `TypeError: Object of type ValenceResponse is not JSON serializable` — all writes via REST were broken, including memory_store via OpenClaw plugin
- Admin maintenance endpoint only supported legacy DB ops (views/vacuum), not v2 knowledge ops (recompute_scores, process_queue, evict_if_over_capacity) — all maintenance calls from plugin failed

## Fix
- **sources.py**: Unwrap `ValenceResponse` before JSON serialization (`result.data` instead of raw `result`)
- **admin_endpoints.py**: Add v2 maintenance operations (recompute_scores, process_queue, evict_if_over_capacity) alongside legacy ops
- Fix async: use `await` instead of `run_until_complete` (already in async context)
- Fix DB connection: use raw psycopg2 for legacy ops needing autocommit

## Testing
- curl POST /sources → 201 ✅
- curl POST /admin/maintenance {recompute_scores: true} → 200 ✅
- curl POST /admin/maintenance {all: true} → 200 (scores + queue + views + vacuum) ✅
- memory_store via OpenClaw plugin → ✅
- admin_maintenance via OpenClaw plugin → ✅

Also fixes LaunchAgent: removed stale VALENCE_TOKEN_FILE env var pointing to wrong path.