### PR TITLE
fix(#528): include diagnostic detail in error responses

### DIFF
--- a/tests/server/test_errors.py
+++ b/tests/server/test_errors.py
@@ -1,0 +1,71 @@
+"""Tests for error response helpers."""
+
+import os
+from unittest.mock import patch
+
+from valence.server.errors import internal_error
+
+
+class TestInternalError:
+    def test_includes_request_id(self):
+        resp = internal_error()
+        data = resp.body.decode()
+        import json
+
+        body = json.loads(data)
+        assert body["success"] is False
+        assert "request_id" in body["error"]
+        assert len(body["error"]["request_id"]) == 12
+
+    def test_debug_mode_includes_exception_detail(self):
+        with patch.dict(os.environ, {"VALENCE_DEBUG": "1"}):
+            # Reimport to pick up env change
+            import valence.server.errors as errors
+
+            old = errors._DEBUG
+            errors._DEBUG = True
+            try:
+                exc = ValueError("test value error")
+                resp = errors.internal_error(exc=exc)
+                import json
+
+                body = json.loads(resp.body.decode())
+                assert body["error"]["exception"] == "ValueError"
+                assert body["error"]["detail"] == "test value error"
+            finally:
+                errors._DEBUG = old
+
+    def test_production_mode_hides_exception_detail(self):
+        import valence.server.errors as errors
+
+        old = errors._DEBUG
+        errors._DEBUG = False
+        try:
+            exc = ValueError("secret internal detail")
+            resp = errors.internal_error(exc=exc)
+            import json
+
+            body = json.loads(resp.body.decode())
+            assert "exception" not in body["error"]
+            assert "detail" not in body["error"]
+            assert "request_id" in body["error"]
+        finally:
+            errors._DEBUG = old
+
+    def test_captures_current_exception(self):
+        import valence.server.errors as errors
+
+        old = errors._DEBUG
+        errors._DEBUG = True
+        try:
+            try:
+                raise TypeError("auto-captured")
+            except TypeError:
+                resp = errors.internal_error()
+            import json
+
+            body = json.loads(resp.body.decode())
+            assert body["error"]["exception"] == "TypeError"
+            assert body["error"]["detail"] == "auto-captured"
+        finally:
+            errors._DEBUG = old


### PR DESCRIPTION
## Problem
Every 500 error returned the identical generic message:
```json
{"success": false, "error": {"code": "INTERNAL_ERROR", "message": "Internal server error"}}
```
This made debugging impossible from the client side — three different bugs today (#526) all produced the same response.

## Fix
`internal_error()` now:
- **Auto-captures** the current exception via `sys.exc_info()` (no caller changes needed)
- **Always includes** a `request_id` (12-char hex) for log correlation
- **Debug mode** (`VALENCE_DEBUG=1`, default): includes `exception`, `detail`, and `traceback` in response
- **Production mode** (`VALENCE_DEBUG=0`): only `request_id` — no internal details leaked

### Before
```
Internal server error
```

### After (debug)
```json
{
  "code": "INTERNAL_ERROR",
  "message": "Internal server error",
  "request_id": "d8eed2999103",
  "exception": "TypeError",
  "detail": "Object of type ValenceResponse is not JSON serializable"
}
```

## Scope
- 2 files changed: `errors.py` (enhanced), `test_errors.py` (new, 4 tests)
- All 35 existing `internal_error()` call sites benefit automatically — zero caller changes
- 1695 tests passing

Closes #528.