### PR TITLE
fix(#529): compute confidence from source reliability, track corroboration, inline usage updates

### DIFF
--- a/src/valence/server/admin_endpoints.py
+++ b/src/valence/server/admin_endpoints.py
@@ -56,12 +56,14 @@ async def admin_maintenance(request: Request) -> Response:
     run_all = body.get("all", False)
 
     # v2 knowledge operations
-    v2_ops = any(body.get(op) for op in ("recompute_scores", "process_queue", "evict_if_over_capacity"))
+    v2_ops = any(body.get(op) for op in ("recompute_scores", "process_queue", "evict_if_over_capacity", "backfill_confidence"))
     # Legacy DB operations
     legacy_ops = any(body.get(op) for op in ("views", "vacuum"))
 
     if not run_all and not v2_ops and not legacy_ops:
-        return missing_field_error("at least one operation (all, views, vacuum, recompute_scores, process_queue, evict_if_over_capacity)")
+        return missing_field_error(
+            "at least one operation (all, views, vacuum, recompute_scores, process_queue, evict_if_over_capacity, backfill_confidence)"
+        )
 
     try:
         from ..core.maintenance import MaintenanceResult
@@ -112,6 +114,22 @@ async def admin_maintenance(request: Request) -> Response:
                 results.append(
                     {
                         "operation": "evict_if_over_capacity",
+                        "dry_run": False,
+                        "success": res.success,
+                        **(res.data if isinstance(res.data, dict) and res.success else {"result": res.data} if res.success else {"error": res.error}),
+                    }
+                )
+
+        if run_all or body.get("backfill_confidence"):
+            if dry_run:
+                results.append({"operation": "backfill_confidence", "dry_run": True, "note": "skipped in dry-run"})
+            else:
+                from ..core.usage import backfill_confidence_scores
+
+                res = await backfill_confidence_scores()
+                results.append(
+                    {
+                        "operation": "backfill_confidence",
                         "dry_run": False,
                         "success": res.success,
                         **(res.data if isinstance(res.data, dict) and res.success else {"result": res.data} if res.success else {"error": res.error}),


### PR DESCRIPTION
## Problem
All knowledge quality signals were flat and undifferentiated:
- Confidence: hardcoded 0.7 for every article
- Corroboration: always 0
- Usage scores: only updated during batch maintenance (which was broken until #526)

## Fix

### 1. Confidence from source reliability
```
initial_confidence = min(0.95, avg(source.reliability) + source_bonus)
source_bonus = min(0.15, ln(1 + source_count - 1) × 0.1)  # multi-source boost
```
Applied in both `compile_article()` and `recompile_article()`.

### 2. Corroboration tracking
- `corroboration_count` = number of linked sources (set at compile time)
- `confidence_source` = avg source reliability

### 3. Inline usage score updates
Each `knowledge_search` hit immediately increments `usage_score += 1.0`. Batch recompute (`compute_usage_scores`) still runs for decay-corrected accuracy.

### 4. Backfill maintenance operation
New `backfill_confidence` op recomputes confidence and corroboration for all existing articles from their linked sources. Included in `{"all": true}` maintenance runs.

## Results (live DB, 85 active articles)
| Metric | Before | After |
|--------|--------|-------|
| Usage scores | all 0 | 0.3 — 5.3 |
| Confidence | all 0.7 | 0.4 — 0.51 |
| Corroboration | all 0 | 1 — 3 |

## Files changed
- `compilation.py`: confidence computed from sources at compile + recompile
- `retrieval.py`: inline usage_score bump on retrieval
- `usage.py`: new `backfill_confidence_scores()`
- `admin_endpoints.py`: wired backfill op
- `test_admin_endpoints.py`: updated for new op

1695 tests passing.

Closes #529.