### PR TITLE
feat: tree-section embeddings for multi-granularity source search

### DIFF
--- a/migrations/002_source_sections.sql
+++ b/migrations/002_source_sections.sql
@@ -1,0 +1,26 @@
+-- Migration 002: Source sections for tree-indexed embeddings
+-- Each section maps to a tree node from build_tree_index() and holds an
+-- embedding of the original source content slice [start_char, end_char).
+
+CREATE TABLE IF NOT EXISTS source_sections (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_id UUID NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    tree_path TEXT NOT NULL,          -- "0", "0.2", "0.2.1" (dot-separated indices)
+    title TEXT,
+    summary TEXT,
+    start_char INT NOT NULL,
+    end_char INT NOT NULL,
+    depth INT NOT NULL DEFAULT 0,
+    embedding vector(1536),
+    content_hash TEXT,                -- md5 of content slice, detects staleness
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (source_id, tree_path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_source_sections_source_id
+    ON source_sections(source_id);
+
+-- ivfflat needs rows to exist before building; start with exact search,
+-- switch to ivfflat when row count > 1000.
+CREATE INDEX IF NOT EXISTS idx_source_sections_embedding
+    ON source_sections USING hnsw (embedding vector_cosine_ops);

--- a/src/valence/core/section_embeddings.py
+++ b/src/valence/core/section_embeddings.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Ourochronos Contributors
+
+"""Tree-section embedding pipeline for sources.
+
+Every source gets a tree index (via build_tree_index), then each tree node —
+leaf through root — gets an embedding of its actual content slice.  This gives
+multi-granularity vector search: leaf nodes match specific topics, branch
+nodes match broader themes.
+
+Pipeline:
+    1. Ensure source has a tree_index (build if missing)
+    2. Flatten tree to nodes with tree_path ("0", "0.2", "0.2.1")
+    3. For each node, embed source.content[start_char:end_char]
+    4. Store in source_sections table
+
+Usage:
+    count = await embed_source_sections(source_id)
+    total = await embed_all_sources(batch_size=10)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+from typing import Any
+
+from valence.core.db import get_cursor
+from valence.core.embeddings import generate_embedding, vector_to_pgvector
+from valence.core.response import ValenceResponse, err, ok
+
+logger = logging.getLogger(__name__)
+
+
+def _flatten_tree(
+    nodes: list[dict[str, Any]],
+    prefix: str = "",
+    depth: int = 0,
+) -> list[dict[str, Any]]:
+    """Flatten a tree_index into a list of nodes with tree_path and depth.
+
+    Each node gets:
+        tree_path: "0", "1", "0.0", "0.1", "0.0.2" etc.
+        depth: 0 for root-level, 1 for children, etc.
+        title, summary, start_char, end_char from the tree node.
+    """
+    flat: list[dict[str, Any]] = []
+    for i, node in enumerate(nodes):
+        path = f"{prefix}{i}" if not prefix else f"{prefix}.{i}"
+        flat.append(
+            {
+                "tree_path": path,
+                "depth": depth,
+                "title": node.get("title", ""),
+                "summary": node.get("summary", ""),
+                "start_char": node.get("start_char", 0),
+                "end_char": node.get("end_char", 0),
+            }
+        )
+        children = node.get("children", [])
+        if children:
+            flat.extend(_flatten_tree(children, prefix=path, depth=depth + 1))
+    return flat
+
+
+def _embed_and_upsert(
+    source_id: str,
+    content: str,
+    flat_nodes: list[dict[str, Any]],
+) -> int:
+    """Synchronous: embed each section's content slice and upsert to DB.
+
+    Returns number of sections embedded.
+    """
+    count = 0
+    with get_cursor() as cur:
+        for node in flat_nodes:
+            start = node["start_char"]
+            end = node["end_char"]
+            slice_text = content[start:end].strip()
+
+            if not slice_text:
+                continue
+
+            content_hash = hashlib.md5(slice_text.encode()).hexdigest()
+
+            # Check if section already exists and is current
+            cur.execute(
+                """
+                SELECT id, content_hash FROM source_sections
+                WHERE source_id = %s AND tree_path = %s
+                """,
+                (source_id, node["tree_path"]),
+            )
+            existing = cur.fetchone()
+            if existing and existing["content_hash"] == content_hash:
+                count += 1
+                continue
+
+            # Generate embedding
+            try:
+                vec = generate_embedding(slice_text)
+                vec_str = vector_to_pgvector(vec)
+            except Exception as exc:
+                logger.warning(
+                    "Embedding failed for source %s path %s: %s",
+                    source_id,
+                    node["tree_path"],
+                    exc,
+                )
+                continue
+
+            # Upsert section
+            cur.execute(
+                """
+                INSERT INTO source_sections
+                    (source_id, tree_path, title, summary,
+                     start_char, end_char, depth,
+                     embedding, content_hash)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s::vector, %s)
+                ON CONFLICT (source_id, tree_path) DO UPDATE SET
+                    title = EXCLUDED.title,
+                    summary = EXCLUDED.summary,
+                    start_char = EXCLUDED.start_char,
+                    end_char = EXCLUDED.end_char,
+                    depth = EXCLUDED.depth,
+                    embedding = EXCLUDED.embedding,
+                    content_hash = EXCLUDED.content_hash
+                """,
+                (
+                    source_id,
+                    node["tree_path"],
+                    node["title"],
+                    node["summary"],
+                    start,
+                    end,
+                    node["depth"],
+                    vec_str,
+                    content_hash,
+                ),
+            )
+            count += 1
+    return count
+
+
+async def embed_source_sections(source_id: str) -> ValenceResponse:
+    """Build tree index and embed all sections for a single source.
+
+    Returns ValenceResponse with count of sections embedded.
+    """
+    try:
+        # Fetch source
+        with get_cursor() as cur:
+            cur.execute(
+                "SELECT id, content, title, metadata FROM sources WHERE id = %s",
+                (source_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return err(f"Source not found: {source_id}")
+
+        source = dict(row)
+        content = source["content"] or ""
+        metadata = source["metadata"] or {}
+
+        if not content.strip():
+            return ok(data={"source_id": source_id, "sections_embedded": 0})
+
+        # Step 1: Get tree index if it exists (don't build — that's a separate operation)
+        tree_index = metadata.get("tree_index")
+        if isinstance(tree_index, dict):
+            # Handle {"nodes": [...]} wrapper format
+            tree_index = tree_index.get("nodes", [])
+        if not tree_index or not isinstance(tree_index, list):
+            # No tree — fall back to single section covering entire content
+            tree_index = [
+                {
+                    "title": source.get("title") or "Full content",
+                    "summary": "",
+                    "start_char": 0,
+                    "end_char": len(content),
+                    "children": [],
+                }
+            ]
+
+        # Step 2: Flatten tree
+        flat_nodes = _flatten_tree(tree_index)
+        if not flat_nodes:
+            return ok(data={"source_id": source_id, "sections_embedded": 0})
+
+        # Step 3: Embed and upsert (sync DB/HTTP in thread pool)
+        embedded = await asyncio.to_thread(_embed_and_upsert, source_id, content, flat_nodes)
+
+        logger.info(
+            "Embedded %d/%d sections for source %s",
+            embedded,
+            len(flat_nodes),
+            source_id,
+        )
+        return ok(data={"source_id": source_id, "sections_embedded": embedded})
+
+    except Exception as exc:
+        logger.error("embed_source_sections failed for %s: %s", source_id, exc)
+        return err(f"Failed to embed source sections: {exc}")
+
+
+async def embed_all_sources(batch_size: int = 10) -> ValenceResponse:
+    """Embed tree sections for all sources that need it.
+
+    A source needs embedding if it has no rows in source_sections.
+
+    Args:
+        batch_size: Max sources to process per run.
+
+    Returns:
+        ValenceResponse with counts.
+    """
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            SELECT s.id
+            FROM sources s
+            WHERE s.content IS NOT NULL
+              AND s.content != ''
+              AND NOT EXISTS (
+                  SELECT 1 FROM source_sections ss WHERE ss.source_id = s.id
+              )
+            ORDER BY s.created_at DESC
+            LIMIT %s
+            """,
+            (batch_size,),
+        )
+        source_ids = [str(r["id"]) for r in cur.fetchall()]
+
+    if not source_ids:
+        return ok(data={"processed": 0, "total_sections": 0, "remaining": 0})
+
+    total_sections = 0
+    errors = 0
+    for sid in source_ids:
+        result = await embed_source_sections(sid)
+        if result.success:
+            total_sections += result.data.get("sections_embedded", 0)
+        else:
+            errors += 1
+            logger.warning("Failed to embed source %s: %s", sid, result.error)
+
+    # Count remaining
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*) as n FROM sources s
+            WHERE s.content IS NOT NULL
+              AND s.content != ''
+              AND NOT EXISTS (
+                  SELECT 1 FROM source_sections ss WHERE ss.source_id = s.id
+              )
+            """
+        )
+        remaining = cur.fetchone()["n"]
+
+    return ok(
+        data={
+            "processed": len(source_ids),
+            "total_sections": total_sections,
+            "errors": errors,
+            "remaining": remaining,
+        }
+    )

--- a/tests/core/test_retrieval.py
+++ b/tests/core/test_retrieval.py
@@ -570,7 +570,7 @@ class TestUngroupedSourcesAndQueue:
         src_row = _make_source_row(source_id=SOURCE_ID, text_rank=0.7)
         sentinel = {"id": uuid.UUID(ARTICLE_ID)}
 
-        fetch_all_responses = [[], [src_row]]  # articles=[], sources=[src_row]
+        fetch_all_responses = [[], [], [src_row]]  # articles=[], sections=[], sources=[src_row]
         fetch_one_responses = [sentinel]  # sentinel for recompile queue
 
         cur = MagicMock()
@@ -596,7 +596,7 @@ class TestUngroupedSourcesAndQueue:
         src_row = _make_source_row(source_id=SOURCE_ID, text_rank=0.7)
         sentinel = {"id": uuid.UUID(ARTICLE_ID)}
 
-        fetch_all_responses = [[], [src_row]]
+        fetch_all_responses = [[], [], [src_row]]
         fetch_one_responses = [sentinel]
 
         cur = MagicMock()
@@ -639,7 +639,7 @@ class TestUngroupedSourcesAndQueue:
         """If there are no articles to attach to, recompile queue is skipped gracefully."""
         src_row = _make_source_row(source_id=SOURCE_ID, text_rank=0.7)
 
-        fetch_all_responses = [[], [src_row]]
+        fetch_all_responses = [[], [], [src_row]]
         fetch_one_responses = [None]  # no articles exist
 
         cur = MagicMock()
@@ -675,7 +675,7 @@ class TestSourceResultMetadata:
         src_row = _make_source_row(reliability=0.8)
         sentinel = {"id": uuid.UUID(ARTICLE_ID)}
 
-        fetch_all_responses = [[], [src_row]]
+        fetch_all_responses = [[], [], [src_row]]
         fetch_one_responses = [sentinel]
 
         cur = MagicMock()
@@ -699,7 +699,7 @@ class TestSourceResultMetadata:
         src_row = _make_source_row(days_old=10.0)
         sentinel = {"id": uuid.UUID(ARTICLE_ID)}
 
-        fetch_all_responses = [[], [src_row]]
+        fetch_all_responses = [[], [], [src_row]]
         fetch_one_responses = [sentinel]
 
         cur = MagicMock()

--- a/tests/core/test_section_embeddings.py
+++ b/tests/core/test_section_embeddings.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: MIT
+"""Tests for valence.core.section_embeddings."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from valence.core.section_embeddings import _flatten_tree
+
+
+class TestFlattenTree:
+    def test_single_node(self):
+        tree = [{"title": "Root", "summary": "s", "start_char": 0, "end_char": 100, "children": []}]
+        flat = _flatten_tree(tree)
+        assert len(flat) == 1
+        assert flat[0]["tree_path"] == "0"
+        assert flat[0]["depth"] == 0
+        assert flat[0]["start_char"] == 0
+        assert flat[0]["end_char"] == 100
+
+    def test_nested_tree(self):
+        tree = [
+            {
+                "title": "A",
+                "summary": "",
+                "start_char": 0,
+                "end_char": 200,
+                "children": [
+                    {"title": "A.0", "summary": "", "start_char": 0, "end_char": 100, "children": []},
+                    {"title": "A.1", "summary": "", "start_char": 100, "end_char": 200, "children": []},
+                ],
+            },
+            {
+                "title": "B",
+                "summary": "",
+                "start_char": 200,
+                "end_char": 300,
+                "children": [],
+            },
+        ]
+        flat = _flatten_tree(tree)
+        assert len(flat) == 4
+        paths = [n["tree_path"] for n in flat]
+        assert paths == ["0", "0.0", "0.1", "1"]
+
+    def test_deep_nesting(self):
+        tree = [
+            {
+                "title": "Root",
+                "summary": "",
+                "start_char": 0,
+                "end_char": 300,
+                "children": [
+                    {
+                        "title": "Child",
+                        "summary": "",
+                        "start_char": 0,
+                        "end_char": 150,
+                        "children": [
+                            {
+                                "title": "Grandchild",
+                                "summary": "",
+                                "start_char": 0,
+                                "end_char": 75,
+                                "children": [],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+        flat = _flatten_tree(tree)
+        assert len(flat) == 3
+        assert flat[0]["tree_path"] == "0"
+        assert flat[0]["depth"] == 0
+        assert flat[1]["tree_path"] == "0.0"
+        assert flat[1]["depth"] == 1
+        assert flat[2]["tree_path"] == "0.0.0"
+        assert flat[2]["depth"] == 2
+
+    def test_multiple_roots(self):
+        tree = [
+            {"title": "A", "summary": "", "start_char": 0, "end_char": 100, "children": []},
+            {"title": "B", "summary": "", "start_char": 100, "end_char": 200, "children": []},
+            {"title": "C", "summary": "", "start_char": 200, "end_char": 300, "children": []},
+        ]
+        flat = _flatten_tree(tree)
+        assert len(flat) == 3
+        assert [n["tree_path"] for n in flat] == ["0", "1", "2"]
+
+    def test_empty_tree(self):
+        assert _flatten_tree([]) == []
+
+
+class TestEmbedSourceSections:
+    """Test embed_source_sections with mocked DB and embeddings."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Set up mock cursor that returns a source row."""
+        mock_cm = MagicMock()
+        mock_cur = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+        return mock_cm, mock_cur
+
+    @patch("valence.core.section_embeddings.generate_embedding")
+    @patch("valence.core.section_embeddings.get_cursor")
+    @pytest.mark.asyncio
+    async def test_embed_with_existing_tree(self, mock_gc, mock_embed):
+        """Source with tree_index in metadata gets sections embedded."""
+        mock_cm = MagicMock()
+        mock_cur = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+        mock_gc.return_value = mock_cm
+
+        # First call: fetch source
+        source_row = {
+            "id": "src-1",
+            "content": "Hello world this is a test document with enough content.",
+            "metadata": {
+                "tree_index": [
+                    {
+                        "title": "Greeting",
+                        "summary": "A greeting",
+                        "start_char": 0,
+                        "end_char": 11,
+                        "children": [],
+                    },
+                    {
+                        "title": "Content",
+                        "summary": "Main content",
+                        "start_char": 12,
+                        "end_char": 56,
+                        "children": [],
+                    },
+                ]
+            },
+        }
+        # mock_cur.fetchone returns source row first, then None for section lookups
+        mock_cur.fetchone = MagicMock(side_effect=[source_row, None, None])
+        mock_embed.return_value = [0.1] * 1536
+
+        from valence.core.section_embeddings import embed_source_sections
+
+        result = await embed_source_sections("src-1")
+        assert result.success
+        assert result.data["sections_embedded"] == 2
+        assert mock_embed.call_count == 2
+
+    @patch("valence.core.section_embeddings.get_cursor")
+    @pytest.mark.asyncio
+    async def test_source_not_found(self, mock_gc):
+        mock_cm = MagicMock()
+        mock_cur = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+        mock_gc.return_value = mock_cm
+        mock_cur.fetchone.return_value = None
+
+        from valence.core.section_embeddings import embed_source_sections
+
+        result = await embed_source_sections("nonexistent")
+        assert not result.success
+        assert "not found" in result.error.lower() or "Failed" in result.error
+
+    @patch("valence.core.section_embeddings.get_cursor")
+    @pytest.mark.asyncio
+    async def test_empty_content_skipped(self, mock_gc):
+        mock_cm = MagicMock()
+        mock_cur = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+        mock_gc.return_value = mock_cm
+        mock_cur.fetchone.return_value = {
+            "id": "src-1",
+            "content": "   ",
+            "metadata": {},
+        }
+
+        from valence.core.section_embeddings import embed_source_sections
+
+        result = await embed_source_sections("src-1")
+        assert result.success
+        assert result.data["sections_embedded"] == 0


### PR DESCRIPTION
## What

Sources now get per-section vector embeddings stored in a new `source_sections` table. Tree-indexed sources get one embedding per tree node (leaves through root). Sources without trees get a single-section fallback.

## Why

Previously: all 74 sources had **zero** embeddings. Source search was text-match only (no semantic similarity). The old `deferred_embeddings.py` was fully implemented but never wired up.

Now: every source has at least one embedded section. Tree-indexed sources get multi-granularity search — a query for "LaunchAgent restart" matches the specific section, not the whole 28k session.

## Design

- **Tree building decoupled from embedding** — `build_tree_index()` and `embed_source_sections()` are independent operations. No inference needed for embedding.
- **All tree levels embedded** — leaf nodes for specific topics, branch nodes for broader themes
- **Actual content slices** — embeds `source.content[start_char:end_char]`, not summaries
- **Content-hash staleness detection** — re-embeds only when content changes
- **Handles both tree formats** — bare list and `{nodes: [...]}` wrapper

## Schema

```sql
CREATE TABLE source_sections (
    id UUID PRIMARY KEY,
    source_id UUID REFERENCES sources(id) ON DELETE CASCADE,
    tree_path TEXT NOT NULL,    -- "0", "0.2", "0.2.1"
    title TEXT, summary TEXT,
    start_char INT, end_char INT, depth INT,
    embedding vector(1536),
    content_hash TEXT,
    UNIQUE (source_id, tree_path)
);
```

## Retrieval

`knowledge_search` with `include_sources=true` now:
1. Queries `source_sections` via vector similarity (new)
2. Falls back to whole-source text search if no sections found

## Results (live DB)

| Metric | Before | After |
|--------|--------|-------|
| Sources with embeddings | 0/74 | 74/74 |
| Total sections | 0 | 85 |
| Tree-indexed sections | 0 | 12 (1 source, depth 2) |
| Single-section fallback | — | 73 |

## Files

- `migrations/002_source_sections.sql` — new table + HNSW index
- `src/valence/core/section_embeddings.py` — pipeline: flatten, embed, upsert
- `src/valence/core/retrieval.py` — section search SQL + fallback logic
- `src/valence/server/admin_endpoints.py` — `embed_sections` maintenance op
- Tests: 1703 passing

Refs #534