### PR TITLE
feat(#530, #531): server management CLI + write tracking

### DIFF
--- a/src/valence/cli/commands/server.py
+++ b/src/valence/cli/commands/server.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Ourochronos Contributors
+
+"""Server management commands — restart, status, logs.
+
+Commands:
+    valence server status     Show server PID, uptime, version, code freshness
+    valence server restart    Restart via LaunchAgent (unload + load)
+    valence server logs       Tail server logs
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import time
+from pathlib import Path
+
+from ..output import output_error, output_result
+
+LAUNCHD_LABEL = "com.ourochronos.valence-server"
+PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+HEALTH_URL = "http://127.0.0.1:8420/health"
+LOG_DIR = Path.home() / ".valence" / "logs"
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register server subcommands."""
+    server_p = subparsers.add_parser("server", help="Server management")
+    server_sub = server_p.add_subparsers(dest="server_command", required=True)
+
+    # status
+    status_p = server_sub.add_parser("status", help="Show server status")
+    status_p.set_defaults(func=cmd_server_status)
+
+    # restart
+    restart_p = server_sub.add_parser("restart", help="Restart the server")
+    restart_p.add_argument("--timeout", type=int, default=15, help="Seconds to wait for health check")
+    restart_p.set_defaults(func=cmd_server_restart)
+
+    # logs
+    logs_p = server_sub.add_parser("logs", help="Tail server logs")
+    logs_p.add_argument("-n", "--lines", type=int, default=50, help="Number of lines to show")
+    logs_p.add_argument("-f", "--follow", action="store_true", help="Follow log output")
+    logs_p.add_argument("--err", action="store_true", help="Show error log instead of stdout")
+    logs_p.set_defaults(func=cmd_server_logs)
+
+
+def _get_server_pid() -> int | None:
+    """Get the PID of the running Valence server."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "uvicorn.*valence"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            pids = result.stdout.strip().split("\n")
+            # Return the first (main) PID
+            return int(pids[0]) if pids[0] else None
+    except Exception:
+        pass
+    return None
+
+
+def _check_health(timeout: float = 5.0) -> dict | None:
+    """Hit the health endpoint and return response, or None on failure."""
+    try:
+        import httpx
+
+        resp = httpx.get(HEALTH_URL, timeout=timeout)
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception:
+        pass
+    return None
+
+
+def _get_git_head() -> str | None:
+    """Get current git HEAD commit (short hash)."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=Path.home() / "projects" / "valence",
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def _launchd_loaded() -> bool:
+    """Check if the LaunchAgent is loaded."""
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", LAUNCHD_LABEL],
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def cmd_server_status(args: argparse.Namespace) -> int:
+    """Show server status."""
+    pid = _get_server_pid()
+    health = _check_health()
+    loaded = _launchd_loaded()
+    git_head = _get_git_head()
+
+    status: dict = {
+        "running": pid is not None,
+        "pid": pid,
+        "launchd_loaded": loaded,
+        "launchd_label": LAUNCHD_LABEL,
+    }
+
+    if health:
+        status["health"] = health.get("status", "unknown")
+        status["version"] = health.get("version", "unknown")
+        status["database"] = health.get("database", "unknown")
+        if "started_at" in health:
+            status["started_at"] = health["started_at"]
+        if "last_write_at" in health:
+            status["last_write_at"] = health["last_write_at"]
+        if "git_commit" in health:
+            status["server_commit"] = health["git_commit"]
+    else:
+        status["health"] = "unreachable"
+
+    if git_head:
+        status["repo_head"] = git_head
+        server_commit = status.get("server_commit")
+        if server_commit and server_commit != git_head:
+            status["code_stale"] = True
+            status["warning"] = f"Server running {server_commit}, repo at {git_head} — restart needed"
+
+    output_result(status)
+    return 0
+
+
+def cmd_server_restart(args: argparse.Namespace) -> int:
+    """Restart the server via LaunchAgent."""
+    timeout = args.timeout
+
+    if not PLIST_PATH.exists():
+        output_error(f"LaunchAgent plist not found: {PLIST_PATH}")
+        return 1
+
+    old_pid = _get_server_pid()
+    print(f"Restarting Valence server (PID {old_pid or 'unknown'})...")
+
+    # Try launchctl kickstart -k first (cleanest restart)
+    try:
+        result = subprocess.run(
+            [
+                "launchctl",
+                "kickstart",
+                "-k",
+                f"gui/{os.getuid()}/{LAUNCHD_LABEL}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return _wait_for_health(timeout, old_pid)
+    except Exception:
+        pass
+
+    # Fallback: unload + load
+    print("  Using unload/load fallback...")
+    subprocess.run(
+        ["launchctl", "unload", str(PLIST_PATH)],
+        capture_output=True,
+    )
+    time.sleep(2)
+
+    subprocess.run(
+        ["launchctl", "load", str(PLIST_PATH)],
+        capture_output=True,
+    )
+
+    return _wait_for_health(timeout, old_pid)
+
+
+def _wait_for_health(timeout: int, old_pid: int | None) -> int:
+    """Wait for the server to come up healthy with a new PID."""
+    print("  Waiting for health check...", end="", flush=True)
+
+    start = time.time()
+    while time.time() - start < timeout:
+        time.sleep(1)
+        print(".", end="", flush=True)
+
+        new_pid = _get_server_pid()
+        if new_pid and new_pid != old_pid:
+            health = _check_health(timeout=3.0)
+            if health and health.get("status") == "healthy":
+                print()
+                print(f"  ✅ Server restarted (PID {new_pid})")
+                if health.get("database") != "connected":
+                    print(f"  ⚠️  Database: {health.get('database', 'unknown')}")
+                return 0
+
+    print()
+    # Check if it came up at all
+    new_pid = _get_server_pid()
+    if new_pid:
+        health = _check_health(timeout=3.0)
+        if health:
+            print(f"  ✅ Server running (PID {new_pid}) but took longer than expected")
+            return 0
+        else:
+            print(f"  ⚠️  Server process exists (PID {new_pid}) but health check fails")
+            print("     Check logs: valence server logs --err")
+            return 1
+    else:
+        output_error("Server failed to start. Check: valence server logs --err")
+        return 1
+
+
+def cmd_server_logs(args: argparse.Namespace) -> int:
+    """Tail server logs."""
+    log_file = LOG_DIR / ("server.err.log" if args.err else "server.log")
+
+    if not log_file.exists():
+        # Check old location
+        alt = Path.home() / "projects" / "valence" / "nohup.out"
+        if alt.exists():
+            log_file = alt
+        else:
+            output_error(f"Log file not found: {log_file}")
+            return 1
+
+    if args.follow:
+        try:
+            os.execvp("tail", ["tail", "-f", "-n", str(args.lines), str(log_file)])
+        except Exception as e:
+            output_error(f"Failed to tail: {e}")
+            return 1
+    else:
+        try:
+            result = subprocess.run(
+                ["tail", "-n", str(args.lines), str(log_file)],
+                capture_output=True,
+                text=True,
+            )
+            print(result.stdout, end="")
+            return 0
+        except Exception as e:
+            output_error(f"Failed to read log: {e}")
+            return 1

--- a/src/valence/server/endpoints/articles.py
+++ b/src/valence/server/endpoints/articles.py
@@ -104,6 +104,10 @@ async def create_article_endpoint(request: Request) -> JSONResponse:
             domain_path=body.get("domain_path"),
         )
         status = 201 if result.to_dict().get("success") else 400
+        if status == 201:
+            from ...server.app import record_write
+
+            record_write()
         return JSONResponse(result.to_dict(), status_code=status)
     except Exception:
         logger.exception("Error creating article")

--- a/src/valence/server/endpoints/sources.py
+++ b/src/valence/server/endpoints/sources.py
@@ -97,6 +97,9 @@ async def sources_create_endpoint(request: Request) -> JSONResponse:
         )
         if not result.success:
             return _json_response({"success": False, "error": result.error}, status_code=400)
+        from ...server.app import record_write
+
+        record_write()
         return _json_response({"success": True, "source": result.data}, status_code=201)
 
     except ConflictError as e:

--- a/tests/server/test_server_cli.py
+++ b/tests/server/test_server_cli.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MIT
+"""Tests for server management CLI and health metadata."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestServerStatus:
+    """Test valence server status command."""
+
+    @patch("valence.cli.commands.server._check_health")
+    @patch("valence.cli.commands.server._launchd_loaded")
+    @patch("valence.cli.commands.server._get_server_pid")
+    @patch("valence.cli.commands.server._get_git_head")
+    def test_status_healthy(self, mock_git, mock_pid, mock_loaded, mock_health, capsys):
+        from valence.cli.commands.server import cmd_server_status
+
+        mock_pid.return_value = 12345
+        mock_loaded.return_value = True
+        mock_git.return_value = "abc1234"
+        mock_health.return_value = {
+            "status": "healthy",
+            "version": "2.0.0",
+            "database": "connected",
+            "started_at": "2026-02-26T12:00:00Z",
+            "git_commit": "abc1234",
+            "last_write_at": "2026-02-26T16:00:00Z",
+        }
+
+        args = MagicMock()
+        result = cmd_server_status(args)
+        assert result == 0
+
+    @patch("valence.cli.commands.server._check_health")
+    @patch("valence.cli.commands.server._launchd_loaded")
+    @patch("valence.cli.commands.server._get_server_pid")
+    @patch("valence.cli.commands.server._get_git_head")
+    def test_status_stale_code(self, mock_git, mock_pid, mock_loaded, mock_health, capsys):
+        from valence.cli.commands.server import cmd_server_status
+
+        mock_pid.return_value = 12345
+        mock_loaded.return_value = True
+        mock_git.return_value = "def5678"
+        mock_health.return_value = {
+            "status": "healthy",
+            "version": "2.0.0",
+            "database": "connected",
+            "git_commit": "abc1234",
+        }
+
+        args = MagicMock()
+        result = cmd_server_status(args)
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "restart needed" in captured.out.lower() or "stale" in captured.out.lower() or "code_stale" in captured.out
+
+    @patch("valence.cli.commands.server._check_health")
+    @patch("valence.cli.commands.server._launchd_loaded")
+    @patch("valence.cli.commands.server._get_server_pid")
+    @patch("valence.cli.commands.server._get_git_head")
+    def test_status_server_down(self, mock_git, mock_pid, mock_loaded, mock_health, capsys):
+        from valence.cli.commands.server import cmd_server_status
+
+        mock_pid.return_value = None
+        mock_loaded.return_value = False
+        mock_git.return_value = "abc1234"
+        mock_health.return_value = None
+
+        args = MagicMock()
+        result = cmd_server_status(args)
+        assert result == 0  # status always returns 0 (it's informational)
+        captured = capsys.readouterr()
+        assert "unreachable" in captured.out
+
+
+class TestHealthMetadata:
+    """Test server health endpoint metadata."""
+
+    def test_record_write_updates_timestamp(self):
+        from valence.server import app as app_mod
+
+        app_mod._last_write_at = None
+        app_mod.record_write()
+        assert app_mod._last_write_at is not None
+        assert "T" in app_mod._last_write_at  # ISO format
+
+    def test_record_write_updates_on_each_call(self):
+        import time
+
+        from valence.server import app as app_mod
+
+        app_mod.record_write()
+        first = app_mod._last_write_at
+        time.sleep(0.01)
+        app_mod.record_write()
+        second = app_mod._last_write_at
+        # Timestamps should differ (or at least both be set)
+        assert first is not None
+        assert second is not None
+
+
+class TestFlattenTree:
+    """Test _flatten_tree in section_embeddings (ensure it's accessible)."""
+
+    def test_import(self):
+        from valence.core.section_embeddings import _flatten_tree
+
+        assert callable(_flatten_tree)


### PR DESCRIPTION
## #530 — Server Management CLI

New `valence server` subcommands:

**`valence server status`**
- Server PID, health, version, database connectivity
- LaunchAgent loaded state
- Code staleness detection: compares server's startup git commit against current repo HEAD
- Last successful write timestamp

**`valence server restart`**
- Uses `launchctl kickstart -k` (cleanest restart)
- Falls back to `unload` + `load` if kickstart unavailable
- Waits for health check with configurable timeout (`--timeout`)
- Reports new PID on success, directs to error logs on failure

**`valence server logs`**
- Tail stdout or stderr (`--err`) logs
- Follow mode (`-f`)
- Configurable line count (`-n`)

## #531 — Write Failure Visibility

**Health endpoint enrichment:**
```json
{
  "status": "healthy",
  "started_at": "2026-02-26T16:00:00+00:00",
  "git_commit": "ec1865f",
  "last_write_at": "2026-02-26T17:30:00+00:00",
  "database": "connected"
}
```

- `started_at` + `git_commit` captured at startup
- `last_write_at` updated on every successful source ingest or article create
- Clients can detect stale connections (no recent writes = possible silent failures)
- `valence server status` surfaces all of this

## Tests
6 new tests. 1709 total passing.

Closes #530, closes #531.