### PR TITLE
fix: register server CLI command + correct health URL

### DIFF
--- a/src/valence/cli/commands/__init__.py
+++ b/src/valence/cli/commands/__init__.py
@@ -18,6 +18,7 @@ from . import (
     memory,
     migration,
     provenance,
+    server,
     sessions,
     sources,
     stats,
@@ -56,6 +57,7 @@ COMMAND_MODULES = [
     embeddings,
     migration,
     maintenance,
+    server,
 ]
 
 __all__ = [

--- a/src/valence/cli/commands/server.py
+++ b/src/valence/cli/commands/server.py
@@ -21,7 +21,7 @@ from ..output import output_error, output_result
 
 LAUNCHD_LABEL = "com.ourochronos.valence-server"
 PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
-HEALTH_URL = "http://127.0.0.1:8420/health"
+HEALTH_URL = "http://127.0.0.1:8420/api/v1/health"
 LOG_DIR = Path.home() / ".valence" / "logs"
 
 


### PR DESCRIPTION
Follow-up to #536.

- Register `server` module in `COMMAND_MODULES` (without this, `valence server` wasn't recognized)
- Fix health URL: `/health` → `/api/v1/health` (was returning 404)

Tested locally: `valence server status` now works and returns full health metadata.