### PR TITLE
refactor(#534): unify row serialization into db.serialize_row

### DIFF
--- a/src/valence/mcp/handlers/sources.py
+++ b/src/valence/mcp/handlers/sources.py
@@ -9,12 +9,11 @@ import json
 import logging
 from typing import Any
 
-from valence.core.db import get_cursor
+from valence.core.db import get_cursor, serialize_row
 from valence.core.sources import (
     RELIABILITY_DEFAULTS,
     VALID_SOURCE_TYPES,
     _compute_fingerprint,
-    _row_to_dict,
 )
 
 logger = logging.getLogger(__name__)
@@ -83,7 +82,7 @@ def source_ingest(
         )
         row = cur.fetchone()
 
-    source = _row_to_dict(row)
+    source = serialize_row(row)
     return {"success": True, "source": source}
 
 
@@ -104,7 +103,7 @@ def source_get(source_id: str) -> dict[str, Any]:
     if not row:
         return {"success": False, "error": f"Source not found: {source_id}"}
 
-    source = _row_to_dict(row)
+    source = serialize_row(row)
     return {"success": True, "source": source}
 
 
@@ -130,7 +129,7 @@ def source_search(query: str, limit: int = 20) -> dict[str, Any]:
         )
         rows = cur.fetchall()
 
-    sources = [_row_to_dict(row) for row in rows]
+    sources = [serialize_row(row) for row in rows]
     return {"success": True, "sources": sources, "total_count": len(sources)}
 
 

--- a/tests/core/test_sources.py
+++ b/tests/core/test_sources.py
@@ -20,11 +20,11 @@ from uuid import uuid4
 
 import pytest
 
+from valence.core.db import serialize_row
 from valence.core.sources import (
     RELIABILITY_DEFAULTS,
     VALID_SOURCE_TYPES,
     _compute_fingerprint,
-    _row_to_dict,
     get_source,
     ingest_source,
     list_sources,
@@ -111,20 +111,20 @@ class TestRowToDict:
             "created_at": datetime(2026, 1, 1),
             "metadata": {},
         }
-        result = _row_to_dict(row)
+        result = serialize_row(row)
         assert "content_tsv" not in result
         assert "embedding" not in result
 
     def test_id_becomes_string(self):
         uid = uuid4()
         row = {"id": uid, "created_at": datetime(2026, 1, 1), "metadata": {}}
-        result = _row_to_dict(row)
+        result = serialize_row(row)
         assert result["id"] == str(uid)
 
     def test_created_at_becomes_isoformat(self):
         dt = datetime(2026, 2, 21, 12, 0, 0)
         row = {"id": uuid4(), "created_at": dt, "metadata": {}}
-        result = _row_to_dict(row)
+        result = serialize_row(row)
         assert result["created_at"] == dt.isoformat()
 
     def test_metadata_string_decoded(self):
@@ -133,7 +133,7 @@ class TestRowToDict:
             "created_at": datetime(2026, 1, 1),
             "metadata": '{"key": "val"}',
         }
-        result = _row_to_dict(row)
+        result = serialize_row(row)
         assert result["metadata"] == {"key": "val"}
 
 


### PR DESCRIPTION
## What

Replace 4 duplicate `_row_to_*` functions with a single enhanced `serialize_row` in `db.py`.

## Before: 4 functions doing the same thing

| Module | Function | Lines |
|--------|----------|-------|
| `sources.py` | `_row_to_dict` | 20 |
| `articles.py` | `_row_to_article` | 18 |
| `usage.py` | `_row_to_dict` | 8 |
| `sessions.py` | `_row_to_dict` | 14 |

## After: 1 function

`db.serialize_row(row, *, strip_internal=True)` now handles:
- UUID → str
- datetime → ISO string
- JSON string columns (`confidence`, `metadata`) → parsed dicts
- Strip `content_tsv` and `embedding` by default

## Impact
- Net: **-55 lines**
- Fixed MCP handler import (was importing private `_row_to_dict` cross-module)
- 1697 tests passing

Refs #534