### PR TITLE
feat: REST parity — knowledge_search, article_compile, admin_forget

### DIFF
--- a/src/valence/server/app.py
+++ b/src/valence/server/app.py
@@ -60,6 +60,11 @@ from .endpoints.contentions import (
     list_contentions_endpoint,
     resolve_contention_endpoint,
 )
+from .endpoints.parity import (
+    admin_forget_endpoint,
+    compile_article_endpoint,
+    knowledge_search_endpoint,
+)
 from .endpoints.sources import (
     sources_create_endpoint,
     sources_delete_endpoint,
@@ -1238,9 +1243,11 @@ def create_app() -> Starlette:
         # -----------------------------------------------------------------------
         # v2 Articles endpoints (C2, C3, C5)
         # -----------------------------------------------------------------------
+        Route(f"{API_V1}/search", knowledge_search_endpoint, methods=["GET"]),
         Route(f"{API_V1}/articles", search_articles_endpoint, methods=["GET"]),
         Route(f"{API_V1}/articles", create_article_endpoint, methods=["POST"]),
         Route(f"{API_V1}/articles/search", search_articles_endpoint, methods=["POST"]),
+        Route(f"{API_V1}/articles/compile", compile_article_endpoint, methods=["POST"]),
         Route(f"{API_V1}/articles/merge", merge_articles_endpoint, methods=["POST"]),
         Route(f"{API_V1}/articles/{{article_id}}", get_article_endpoint, methods=["GET"]),
         Route(f"{API_V1}/articles/{{article_id}}", update_article_endpoint, methods=["PUT"]),
@@ -1282,6 +1289,7 @@ def create_app() -> Starlette:
         Route(f"{API_V1}/config/inference", config_inference_endpoint, methods=["PUT"]),
         # Admin endpoints (Issue #396)
         Route(f"{API_V1}/admin/maintenance", admin_maintenance, methods=["POST"]),
+        Route(f"{API_V1}/admin/forget/{{target_type}}/{{target_id}}", admin_forget_endpoint, methods=["DELETE"]),
         Route(f"{API_V1}/admin/embeddings/status", admin_embeddings_status, methods=["GET"]),
         Route(f"{API_V1}/admin/embeddings/backfill", admin_embeddings_backfill, methods=["POST"]),
         Route(f"{API_V1}/admin/embeddings/migrate", admin_embeddings_migrate, methods=["POST"]),

--- a/src/valence/server/endpoints/parity.py
+++ b/src/valence/server/endpoints/parity.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Ourochronos Contributors
+
+"""REST endpoints for knowledge search, article compilation, and admin forget.
+
+Routes:
+    GET    /api/v1/search                          — knowledge_search_endpoint
+    POST   /api/v1/articles/compile                — compile_article_endpoint
+    DELETE /api/v1/admin/forget/:target_type/:id   — admin_forget_endpoint
+"""
+
+from __future__ import annotations
+
+import logging
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from ..auth_helpers import authenticate, require_scope
+from ..endpoint_utils import _parse_bool, _parse_int
+from ..errors import internal_error, missing_field_error
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Knowledge Search
+# ---------------------------------------------------------------------------
+
+
+async def knowledge_search_endpoint(request: Request) -> JSONResponse:
+    """GET /api/v1/search — Unified knowledge retrieval."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, "substrate:read"):
+        return err
+
+    query = request.query_params.get("query", "").strip()
+    if not query:
+        return missing_field_error("query")
+
+    limit = _parse_int(request.query_params.get("limit"), 10)
+    include_sources = _parse_bool(request.query_params.get("include_sources"))
+    session_id = request.query_params.get("session_id")
+
+    try:
+        from valence.mcp.handlers.articles import knowledge_search
+
+        result = knowledge_search(
+            query=query,
+            limit=limit,
+            include_sources=include_sources,
+            session_id=session_id,
+        )
+        status = 200 if result.get("success") else 400
+        return JSONResponse(result, status_code=status)
+    except Exception:
+        logger.exception("knowledge_search_endpoint failed")
+        return internal_error()
+
+
+# ---------------------------------------------------------------------------
+# Article Compile
+# ---------------------------------------------------------------------------
+
+
+async def compile_article_endpoint(request: Request) -> JSONResponse:
+    """POST /api/v1/articles/compile — Compile sources into an article via LLM."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, "substrate:write"):
+        return err
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            {"success": False, "error": {"code": "invalid_json", "message": "Invalid JSON body"}},
+            status_code=400,
+        )
+
+    source_ids = body.get("source_ids")
+    if not source_ids or not isinstance(source_ids, list):
+        return missing_field_error("source_ids")
+
+    title_hint = body.get("title_hint")
+
+    try:
+        from valence.mcp.handlers.articles import article_compile
+
+        result = article_compile(source_ids=source_ids, title_hint=title_hint)
+        status = 200 if result.get("success") else 400
+        return JSONResponse(result, status_code=status)
+    except Exception:
+        logger.exception("compile_article_endpoint failed")
+        return internal_error()
+
+
+# ---------------------------------------------------------------------------
+# Admin Forget
+# ---------------------------------------------------------------------------
+
+
+async def admin_forget_endpoint(request: Request) -> JSONResponse:
+    """DELETE /api/v1/admin/forget/:target_type/:target_id — Permanently remove a source or article."""
+    client = authenticate(request)
+    if isinstance(client, JSONResponse):
+        return client
+    if err := require_scope(client, "substrate:write"):
+        return err
+
+    target_type = request.path_params.get("target_type", "")
+    target_id = request.path_params.get("target_id", "")
+
+    if target_type not in ("source", "article"):
+        return JSONResponse(
+            {"success": False, "error": {"code": "validation_error", "message": "target_type must be 'source' or 'article'"}},
+            status_code=400,
+        )
+
+    if not target_id:
+        return missing_field_error("target_id")
+
+    try:
+        from valence.mcp.handlers.admin import admin_forget
+
+        result = admin_forget(target_type=target_type, target_id=target_id)
+        status = 200 if result.get("success") else 400
+        return JSONResponse(result, status_code=status)
+    except Exception:
+        logger.exception("admin_forget_endpoint failed")
+        return internal_error()

--- a/tests/server/test_parity_endpoints.py
+++ b/tests/server/test_parity_endpoints.py
@@ -1,0 +1,160 @@
+"""Tests for parity endpoints (knowledge_search, article_compile, admin_forget)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    import valence.server.config as config_module
+
+    config_module._settings = None
+    yield
+    config_module._settings = None
+
+
+@pytest.fixture
+def app_env(monkeypatch, tmp_path):
+    token_file = tmp_path / "tokens.json"
+    token_file.write_text('{"tokens": []}')
+    monkeypatch.setenv("VALENCE_TOKEN_FILE", str(token_file))
+    monkeypatch.setenv("VALENCE_RATE_LIMIT_RPM", "60")
+    return {"token_file": token_file}
+
+
+@pytest.fixture
+def client(app_env) -> TestClient:
+    from valence.server.app import create_app
+
+    app = create_app()
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def auth_token(app_env) -> str:
+    from valence.server.auth import get_token_store
+
+    store = get_token_store(app_env["token_file"])
+    return store.create(client_id="test-client")
+
+
+API_V1 = "/api/v1"
+
+
+class TestKnowledgeSearchEndpoint:
+    """Tests for GET /api/v1/search."""
+
+    def test_requires_auth(self, client):
+        response = client.get(f"{API_V1}/search?query=test")
+        assert response.status_code == 401
+
+    def test_missing_query(self, client, auth_token):
+        response = client.get(f"{API_V1}/search", headers={"Authorization": f"Bearer {auth_token}"})
+        assert response.status_code == 400
+
+    @patch("valence.mcp.handlers.articles.knowledge_search")
+    def test_search_success(self, mock_search, client, auth_token):
+        mock_search.return_value = {"success": True, "results": [{"title": "test"}], "count": 1}
+
+        response = client.get(
+            f"{API_V1}/search?query=python",
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        mock_search.assert_called_once_with(query="python", limit=10, include_sources=False, session_id=None)
+
+    @patch("valence.mcp.handlers.articles.knowledge_search")
+    def test_search_with_params(self, mock_search, client, auth_token):
+        mock_search.return_value = {"success": True, "results": [], "count": 0}
+
+        response = client.get(
+            f"{API_V1}/search?query=test&limit=5&include_sources=true&session_id=abc",
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+
+        assert response.status_code == 200
+        mock_search.assert_called_once_with(query="test", limit=5, include_sources=True, session_id="abc")
+
+
+class TestCompileArticleEndpoint:
+    """Tests for POST /api/v1/articles/compile."""
+
+    def test_requires_auth(self, client):
+        response = client.post(f"{API_V1}/articles/compile", json={"source_ids": ["abc"]})
+        assert response.status_code == 401
+
+    def test_missing_source_ids(self, client, auth_token):
+        response = client.post(
+            f"{API_V1}/articles/compile",
+            json={},
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+        assert response.status_code == 400
+
+    def test_invalid_json(self, client, auth_token):
+        response = client.post(
+            f"{API_V1}/articles/compile",
+            content=b"not json",
+            headers={"Authorization": f"Bearer {auth_token}", "Content-Type": "application/json"},
+        )
+        assert response.status_code == 400
+
+    @patch("valence.mcp.handlers.articles.article_compile")
+    def test_compile_success(self, mock_compile, client, auth_token):
+        mock_compile.return_value = {"success": True, "article": {"id": "art-1"}}
+
+        response = client.post(
+            f"{API_V1}/articles/compile",
+            json={"source_ids": ["src-1", "src-2"], "title_hint": "My Article"},
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+
+        assert response.status_code == 200
+        mock_compile.assert_called_once_with(source_ids=["src-1", "src-2"], title_hint="My Article")
+
+
+class TestAdminForgetEndpoint:
+    """Tests for DELETE /api/v1/admin/forget/:target_type/:target_id."""
+
+    def test_requires_auth(self, client):
+        response = client.delete(f"{API_V1}/admin/forget/source/abc")
+        assert response.status_code == 401
+
+    def test_invalid_target_type(self, client, auth_token):
+        response = client.delete(
+            f"{API_V1}/admin/forget/invalid/abc",
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+        assert response.status_code == 400
+        assert "target_type" in response.json()["error"]["message"]
+
+    @patch("valence.mcp.handlers.admin.admin_forget")
+    def test_forget_source(self, mock_forget, client, auth_token):
+        mock_forget.return_value = {"success": True, "deleted": "source", "id": "src-1"}
+
+        response = client.delete(
+            f"{API_V1}/admin/forget/source/src-1",
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+
+        assert response.status_code == 200
+        mock_forget.assert_called_once_with(target_type="source", target_id="src-1")
+
+    @patch("valence.mcp.handlers.admin.admin_forget")
+    def test_forget_article(self, mock_forget, client, auth_token):
+        mock_forget.return_value = {"success": True, "deleted": "article", "id": "art-1"}
+
+        response = client.delete(
+            f"{API_V1}/admin/forget/article/art-1",
+            headers={"Authorization": f"Bearer {auth_token}"},
+        )
+
+        assert response.status_code == 200
+        mock_forget.assert_called_once_with(target_type="article", target_id="art-1")


### PR DESCRIPTION
Closes #543

## New REST endpoints
- `GET /api/v1/search?query=...&limit=&include_sources=&session_id=` — unified knowledge retrieval
- `POST /api/v1/articles/compile` — compile sources into article via LLM  
- `DELETE /api/v1/admin/forget/{target_type}/{target_id}` — permanent deletion

All delegate to existing MCP handler functions. 12 new tests. 1635 total passing.