### PR TITLE
fix: Decimal serialization + circular reference in compile response

### DIFF
--- a/src/valence/core/compilation.py
+++ b/src/valence/core/compilation.py
@@ -587,7 +587,7 @@ async def compile_article(
 
     first_article = created_articles[0]
     if len(created_articles) > 1:
-        first_article["_all_articles"] = created_articles
+        first_article["_all_articles"] = created_articles[1:]
         logger.info("Compiled %d articles from %d sources", len(created_articles), len(sources))
 
     return ok(data=first_article, degraded=is_degraded)

--- a/src/valence/core/db.py
+++ b/src/valence/core/db.py
@@ -313,6 +313,7 @@ def serialize_row(row: dict[str, Any], *, strip_internal: bool = True) -> dict[s
     import json as _json
     import uuid as _uuid
     from datetime import datetime as _dt
+    from decimal import Decimal as _Decimal
 
     d = dict(row)
     for key, val in list(d.items()):
@@ -320,6 +321,8 @@ def serialize_row(row: dict[str, Any], *, strip_internal: bool = True) -> dict[s
             d[key] = val.isoformat()
         elif isinstance(val, _uuid.UUID):
             d[key] = str(val)
+        elif isinstance(val, _Decimal):
+            d[key] = float(val)
         elif key in ("confidence", "metadata") and isinstance(val, str):
             try:
                 d[key] = _json.loads(val)

--- a/src/valence/server/endpoints/parity.py
+++ b/src/valence/server/endpoints/parity.py
@@ -91,8 +91,12 @@ async def compile_article_endpoint(request: Request) -> JSONResponse:
         from valence.mcp.handlers.articles import article_compile
 
         result = article_compile(source_ids=source_ids, title_hint=title_hint)
-        status = 200 if result.get("success") else 400
-        return JSONResponse(result, status_code=status)
+        # Ensure all nested dicts are JSON-safe (Decimal, UUID, datetime)
+        import json as _json
+
+        safe_result = _json.loads(_json.dumps(result, default=str))
+        status = 200 if safe_result.get("success") else 400
+        return JSONResponse(safe_result, status_code=status)
     except Exception:
         logger.exception("compile_article_endpoint failed")
         return internal_error()


### PR DESCRIPTION
## Bugs fixed

Two bugs that only manifested when compilation actually succeeded via inference:

1. **Decimal serialization in `db.serialize_row()`**: PostgreSQL `numeric` columns return `Decimal` objects which aren't JSON-serializable. Added `Decimal → float` conversion.

2. **Circular reference in `_all_articles`**: When LLM produces multiple articles, `first_article["_all_articles"] = created_articles` creates a circular ref (list contains the dict which contains the list). Fixed: `_all_articles` now contains only the extra articles, excluding the parent.

3. **Safety net in compile endpoint**: Added `json.dumps(default=str)` to catch any remaining non-serializable types.

## Verified
- Compilation via callback → OpenClaw gateway → Anthropic: ✅
- Tree building via same path: ✅
- 1635 tests passing