### PR TITLE
fix: TASK_TREE task type, small source guard, CLI string error handling

### DIFF
--- a/memory/2026-02-26.md
+++ b/memory/2026-02-26.md
@@ -1,0 +1,48 @@
+
+---
+
+## 9:36 PM — Parity PRs + Inference Working End-to-End
+
+### PRs Merged (#545–#549)
+- **#545** (closes #544): Remove legacy v1 routes — beliefs/entities/tensions REST, entity MCP handlers, dead formatters. Moved `/beliefs/conflicts` → `/contentions/detect`. **-1,629 lines**
+- **#546** (closes #543): REST parity — `GET /search`, `POST /articles/compile`, `DELETE /admin/forget/{type}/{id}`. All delegate to existing MCP handlers. +12 tests.
+- **#547** (closes #542): MCP tool parity — added 5 missing Tool() definitions (source_list, article_search, provenance_get, provenance_link, contention_detect). 34 tools = 34 handlers, perfect 1:1.
+- **#548** (closes #541): OpenAPI spec rewrite — 11 stale paths → 44 v2 endpoints. Version bumped to 2.0.0. Note: `docs/**` is in CI paths-ignore, needed trivial code change to trigger checks.
+- **#549**: Fix Decimal serialization in `db.serialize_row()` + circular reference in `_all_articles`. Both only manifested when compilation actually succeeded via inference.
+
+### Inference Working End-to-End
+- **Callback pipeline confirmed**: Valence server → callback backend → OpenClaw gateway (port 18789) → Anthropic → structured JSON response
+- **Compilation works**: Compiled 2 articles from 2 sources, produced proper PageIndex article with title, content, provenance
+- **Tree building works**: Built 4-node tree with character offsets for source via same pipeline
+- Config stored in `system_config` table: `{"provider": "callback", "callback_url": "http://127.0.0.1:18789/valence/inference"}`
+- Server loads inference config from DB at startup (app.py lifespan)
+
+### Branch Cleanup Complete
+- Deleted 30 stale branches, only `main` remains
+- 14 stale `/tmp/valence-*` worktree dirs removed
+- Session ingestion content preserved at `/tmp/preserved-branch-content/`
+
+### Parity Achieved
+- **REST**: 44 endpoints documented in OpenAPI
+- **MCP**: 34 tools, 34 handlers, 1:1
+- **CLI**: 17 top-level commands
+
+### Bugs Found & Fixed
+- `db.serialize_row()` missing Decimal → float conversion
+- `compilation.py`: `_all_articles` circular reference (list contained parent dict which contained list)
+- CLI token was stale after server restart — created new token, stored in `~/.valence/cli.toml`
+- `contention_detect` MCP handler was legit (wraps `core.contention.detect_contention`), just missing Tool() definition
+- Entity MCP handlers were truly dead (reference `entities` table that doesn't exist in v2)
+
+### Current State
+- **main HEAD**: `25a455c`
+- **Server**: PID 24772, commit 25a455c
+- **Tests**: 1,635 passed, 10 skipped
+- **CLI token**: `vt_c70030d...` in `~/.valence/cli.toml`
+- **New articles from test compile**: `1bd83ddb` (PageIndex architecture), `dc946d29` (Valence tooling reference)
+
+### Next Steps
+1. Build trees for all ~73 untree'd sources (inference now works)
+2. Recompile all 85 existing articles (were compiled in degraded/concatenation mode)
+3. Test retrieval quality with real queries
+4. Audit + cleanup pass before release

--- a/src/valence/cli/http_client.py
+++ b/src/valence/cli/http_client.py
@@ -62,6 +62,12 @@ class ValenceClient:
             try:
                 body = resp.json()
                 error = body.get("error", {})
+                if isinstance(error, str):
+                    raise ValenceAPIError(
+                        status_code=resp.status_code,
+                        code="ERROR",
+                        message=error,
+                    )
                 raise ValenceAPIError(
                     status_code=resp.status_code,
                     code=error.get("code", "UNKNOWN"),

--- a/src/valence/core/inference.py
+++ b/src/valence/core/inference.py
@@ -31,8 +31,9 @@ TASK_UPDATE = "update"  # Incremental article update (medium)
 TASK_CLASSIFY = "classify"  # Relationship classification (low)
 TASK_CONTENTION = "contention"  # Contention detection (medium)
 TASK_SPLIT = "split"  # Intelligent split point (low)
+TASK_TREE = "tree"  # Tree index building (medium)
 
-_ALL_TASKS = {TASK_COMPILE, TASK_UPDATE, TASK_CLASSIFY, TASK_CONTENTION, TASK_SPLIT}
+_ALL_TASKS = {TASK_COMPILE, TASK_UPDATE, TASK_CLASSIFY, TASK_CONTENTION, TASK_SPLIT, TASK_TREE}
 
 # ---------------------------------------------------------------------------
 # Shared enum — DR-11
@@ -51,6 +52,7 @@ _TASK_REQUIRED_OUTPUT_FIELDS: dict[str, list[str]] = {
     TASK_CLASSIFY: ["relationship", "confidence", "reasoning"],
     TASK_CONTENTION: ["is_contention", "materiality", "explanation"],
     TASK_SPLIT: ["split_index", "part_a_title", "part_b_title", "reasoning"],
+    TASK_TREE: ["nodes"],
 }
 
 # Fields that contain relationship_enum values and must be validated
@@ -60,6 +62,7 @@ _TASK_RELATIONSHIP_FIELDS: dict[str, list[str]] = {
     TASK_CLASSIFY: ["relationship"],
     TASK_CONTENTION: [],
     TASK_SPLIT: [],
+    TASK_TREE: [],
 }
 
 # Output schema descriptions — used in prompt builders

--- a/tests/cli/test_http_client.py
+++ b/tests/cli/test_http_client.py
@@ -98,6 +98,18 @@ class TestHandleResponse:
         assert exc_info.value.status_code == 401
         assert exc_info.value.code == "AUTH_MISSING_TOKEN"
 
+    def test_error_response_string_error(self):
+        """Errors returned as plain strings should be handled gracefully."""
+        client = ValenceClient()
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 400
+        resp.json.return_value = {"success": False, "error": "Source already has tree_index."}
+        with pytest.raises(ValenceAPIError) as exc_info:
+            client._handle_response(resp)
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.code == "ERROR"
+        assert "tree_index" in exc_info.value.message
+
 
 class TestClientRequests:
     @patch("valence.cli.http_client.httpx.Client")

--- a/tests/core/test_confidence.py
+++ b/tests/core/test_confidence.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 
 import math
 
-import pytest
-
-from valence.core.confidence import ConfidenceResult, compute_confidence
+from valence.core.confidence import compute_confidence
 
 
 class TestComputeConfidence:

--- a/tests/core/test_tree_index.py
+++ b/tests/core/test_tree_index.py
@@ -116,6 +116,15 @@ class TestBuildTreeIndex:
         assert "already has tree_index" in result.error
 
     @pytest.mark.asyncio
+    async def test_too_small(self):
+        """Sources under 200 chars should be rejected gracefully."""
+        cur = _make_cursor(fetchone_seq=[{"id": "abc", "content": "tiny", "metadata": {}}])
+        with patch("valence.core.tree_index.get_cursor", return_value=cur):
+            result = await build_tree_index("abc")
+        assert not result.success
+        assert "too small" in result.error
+
+    @pytest.mark.asyncio
     async def test_single_window_success(self):
         source_content = "Hello world " * 100
         tree_response = json.dumps({"nodes": [{"title": "Test", "summary": "A test", "start_char": 0, "end_char": len(source_content)}]})

--- a/tests/server/test_parity_endpoints.py
+++ b/tests/server/test_parity_endpoints.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from starlette.testclient import TestClient

--- a/tests/server/test_server_cli.py
+++ b/tests/server/test_server_cli.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestServerStatus:
     """Test valence server status command."""


### PR DESCRIPTION
## Changes

Three inference-adjacent fixes plus lint cleanup:

### 1. TASK_TREE task type (inference.py, tree_index.py)
Tree builder was using `TASK_COMPILE` for routing, which triggered spurious schema validation warnings (expects `articles` key, tree responses have `nodes`). Added proper `TASK_TREE` task type with `nodes` as its required output field.

### 2. Small source guard (tree_index.py)
Sources under 200 chars now get a clear error instead of burning an inference call on content too small for meaningful tree indexing. Check runs after the "already indexed" check to preserve existing behavior.

### 3. CLI string error handling (http_client.py)
Some endpoints return `{"error": "string"}` instead of `{"error": {"code": "...", "message": "..."}}`. The CLI was crashing with `AttributeError: 'str' object has no attribute 'get'`. Now handles both formats.

### 4. Lint cleanup
Fixed 4 pre-existing unused import warnings in test files.

## Tests
- `test_too_small`: verifies tree builder rejects small sources
- `test_error_response_string_error`: verifies CLI handles string errors
- **1,637 tests passing** (2 new)