### PR TITLE
feat: add articles delete CLI command

### DIFF
--- a/src/valence/cli/commands/articles.py
+++ b/src/valence/cli/commands/articles.py
@@ -93,6 +93,10 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     split_p.add_argument("article_id", help="UUID of the article to split")
     split_p.set_defaults(func=cmd_articles_split)
 
+    delete_p = articles_sub.add_parser("delete", help="Permanently remove an article")
+    delete_p.add_argument("article_id", help="UUID of the article to delete")
+    delete_p.set_defaults(func=cmd_articles_delete)
+
 
 # ---------------------------------------------------------------------------
 # Command handlers
@@ -237,6 +241,22 @@ def cmd_articles_merge(args: argparse.Namespace) -> int:
 
     try:
         result = client.post("/articles/merge", body=body)
+        output_result(result)
+        return 0
+    except ValenceConnectionError as e:
+        output_error(str(e))
+        return 1
+    except ValenceAPIError as e:
+        output_error(e.message)
+        return 1
+
+
+def cmd_articles_delete(args: argparse.Namespace) -> int:
+    """Permanently remove an article."""
+    client = get_client()
+
+    try:
+        result = client.delete(f"/admin/forget/article/{args.article_id}")
         output_result(result)
         return 0
     except ValenceConnectionError as e:


### PR DESCRIPTION
Adds `valence articles delete <article_id>` using the existing `DELETE /admin/forget/article/{id}` endpoint. Mirrors `valence sources delete`.

Unblocks the OpenClaw plugin's `admin_forget` tool for articles (previously threw 'not available via CLI').

1,637 tests passing.