### PR TITLE
feat: archival-with-rank-floor instead of hard eviction

### DIFF
--- a/src/valence/core/compilation.py
+++ b/src/valence/core/compilation.py
@@ -910,7 +910,7 @@ async def _process_mutation_item(operation: str, article_id: str, payload: dict)
                     if asyncio.iscoroutine(result):
                         await result
                     logger.info(
-                        "Evicted low-usage article %s (score=%.3f < threshold=%.3f)",
+                        "Archived low-usage article %s (score=%.3f < threshold=%.3f)",
                         article_id,
                         usage_score,
                         threshold,

--- a/tests/core/test_forgetting.py
+++ b/tests/core/test_forgetting.py
@@ -1,9 +1,9 @@
-"""Tests for valence.core.forgetting module - article removal and organic eviction.
+"""Tests for valence.core.forgetting module - article removal and organic archival.
 
 Tests cover:
 - remove_source() deprecation
 - remove_article() deletion
-- evict_lowest() organic forgetting
+- archive_lowest() / evict_lowest() organic forgetting via archival
 - Edge cases (missing article, empty DB, capacity management)
 """
 
@@ -35,7 +35,6 @@ class TestRemoveArticle:
         from valence.core.forgetting import remove_article
 
         mock_cursor = MagicMock()
-        # First query: fetch article
         mock_cursor.fetchone.return_value = {
             "id": "abc-123",
             "title": "Test Article",
@@ -50,7 +49,6 @@ class TestRemoveArticle:
         assert result.success is True
         assert result.data["article_id"] == "abc-123"
         assert mock_cursor.execute.call_count == 2
-        # Second call should be DELETE
         delete_call = mock_cursor.execute.call_args_list[1]
         assert "DELETE FROM articles" in delete_call[0][0]
 
@@ -88,64 +86,38 @@ class TestRemoveArticle:
         assert result.success is False
         assert "required" in result.error.lower()
 
+
+class TestArchiveLowest:
+    """Test archive_lowest (and evict_lowest alias) organic forgetting."""
+
     @patch("valence.core.forgetting.get_cursor")
-    async def test_remove_article_with_title(self, mock_get_cursor):
-        """Test removal logs article title."""
-        from valence.core.forgetting import remove_article
+    async def test_no_overflow(self, mock_get_cursor):
+        """Test no archival when under capacity."""
+        from valence.core.forgetting import archive_lowest
 
         mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = {
-            "id": "test-id",
-            "title": "Important Article",
-            "usage_score": 10,
-        }
-        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
-        mock_cursor.__exit__ = Mock(return_value=False)
-        mock_get_cursor.return_value = mock_cursor
-
-        result = await remove_article("test-id")
-
-        assert result.success is True
-        # Title should be fetched (verified via fetchone call)
-        assert mock_cursor.fetchone.called
-
-
-class TestEvictLowest:
-    """Test evict_lowest organic forgetting."""
-
-    @patch("valence.core.forgetting.remove_article")
-    @patch("valence.core.forgetting.get_cursor")
-    async def test_evict_lowest_no_overflow(self, mock_get_cursor, mock_remove):
-        """Test no eviction when under capacity."""
-        from valence.core.forgetting import evict_lowest
-
-        mock_cursor = MagicMock()
-        # bounded_memory config
         mock_cursor.fetchone.side_effect = [
-            {"value": '{"max_articles": 100}'},  # config query
-            {"cnt": 50},  # count query
+            {"value": '{"max_articles": 100}'},
+            {"cnt": 50},
         ]
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=False)
         mock_get_cursor.return_value = mock_cursor
 
-        result = await evict_lowest(count=10)
+        result = await archive_lowest(count=10)
 
         assert result.success is True
         assert result.data == []
-        mock_remove.assert_not_called()
 
-    @patch("valence.core.forgetting.remove_article")
     @patch("valence.core.forgetting.get_cursor")
-    async def test_evict_lowest_evicts_articles(self, mock_get_cursor, mock_remove):
-        """Test articles are evicted when over capacity."""
-        from valence.core.forgetting import evict_lowest
-        from valence.core.response import ok
+    async def test_archives_articles(self, mock_get_cursor):
+        """Test articles are archived (not deleted) when over capacity."""
+        from valence.core.forgetting import archive_lowest
 
         mock_cursor = MagicMock()
         mock_cursor.fetchone.side_effect = [
-            {"value": '{"max_articles": 100}'},  # config
-            {"cnt": 110},  # count (10 over)
+            {"value": '{"max_articles": 100}'},
+            {"cnt": 110},
         ]
         mock_cursor.fetchall.return_value = [
             {"id": "low1"},
@@ -156,49 +128,44 @@ class TestEvictLowest:
         mock_cursor.__exit__ = Mock(return_value=False)
         mock_get_cursor.return_value = mock_cursor
 
-        # Mock successful removals
-        mock_remove.return_value = ok(data={"article_id": "test"})
-
-        result = await evict_lowest(count=10)
+        result = await archive_lowest(count=10)
 
         assert result.success is True
-        # Should evict 3 (min of count=10 and overflow=10, limited by candidates=3)
         assert len(result.data) == 3
-        assert mock_remove.call_count == 3
+        # Verify UPDATE (not DELETE) was used
+        update_call = mock_cursor.execute.call_args_list[-1]
+        sql = update_call[0][0]
+        assert "UPDATE articles" in sql
+        assert "SET status = 'archived'" in sql
+        assert "DELETE" not in sql
 
-    @patch("valence.core.forgetting.remove_article")
     @patch("valence.core.forgetting.get_cursor")
-    async def test_evict_lowest_respects_count(self, mock_get_cursor, mock_remove):
-        """Test eviction respects count parameter."""
-        from valence.core.forgetting import evict_lowest
-        from valence.core.response import ok
+    async def test_respects_count(self, mock_get_cursor):
+        """Test archival respects count parameter."""
+        from valence.core.forgetting import archive_lowest
 
         mock_cursor = MagicMock()
         mock_cursor.fetchone.side_effect = [
             {"value": '{"max_articles": 100}'},
-            {"cnt": 105},  # 5 over
+            {"cnt": 105},
         ]
-        # Return only 3 candidates (matching min of count and overflow)
         mock_cursor.fetchall.return_value = [{"id": f"id{i}"} for i in range(3)]
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=False)
         mock_get_cursor.return_value = mock_cursor
 
-        mock_remove.return_value = ok(data={"article_id": "test"})
-
-        result = await evict_lowest(count=3)
+        result = await archive_lowest(count=3)
 
         assert result.success is True
-        # Should evict min(count=3, overflow=5) = 3
         assert len(result.data) == 3
-        assert mock_remove.call_count == 3
+        # Verify LIMIT parameter
+        update_call = mock_cursor.execute.call_args_list[-1]
+        assert update_call[0][1] == (3,)
 
-    @patch("valence.core.forgetting.remove_article")
     @patch("valence.core.forgetting.get_cursor")
-    async def test_evict_lowest_skips_pinned(self, mock_get_cursor, mock_remove):
+    async def test_skips_pinned(self, mock_get_cursor):
         """Test query excludes pinned articles."""
-        from valence.core.forgetting import evict_lowest
-        from valence.core.response import ok
+        from valence.core.forgetting import archive_lowest
 
         mock_cursor = MagicMock()
         mock_cursor.fetchone.side_effect = [
@@ -210,26 +177,16 @@ class TestEvictLowest:
         mock_cursor.__exit__ = Mock(return_value=False)
         mock_get_cursor.return_value = mock_cursor
 
-        mock_remove.return_value = ok(data={"article_id": "test"})
+        await archive_lowest(count=5)
 
-        await evict_lowest(count=5)
+        update_call = mock_cursor.execute.call_args_list[-1]
+        sql = update_call[0][0]
+        assert "pinned = FALSE" in sql
 
-        # Check query excludes pinned
-        select_call = None
-        for call in mock_cursor.execute.call_args_list:
-            if "SELECT id" in str(call[0][0]):
-                select_call = call[0][0]
-                break
-
-        assert select_call is not None
-        assert "pinned = FALSE" in select_call
-
-    @patch("valence.core.forgetting.remove_article")
     @patch("valence.core.forgetting.get_cursor")
-    async def test_evict_lowest_orders_by_usage_score(self, mock_get_cursor, mock_remove):
-        """Test query orders by usage_score ascending."""
-        from valence.core.forgetting import evict_lowest
-        from valence.core.response import ok
+    async def test_orders_by_usage_score(self, mock_get_cursor):
+        """Test query orders by usage_score ascending (lowest first)."""
+        from valence.core.forgetting import archive_lowest
 
         mock_cursor = MagicMock()
         mock_cursor.fetchone.side_effect = [
@@ -241,90 +198,20 @@ class TestEvictLowest:
         mock_cursor.__exit__ = Mock(return_value=False)
         mock_get_cursor.return_value = mock_cursor
 
-        mock_remove.return_value = ok(data={"article_id": "test"})
+        await archive_lowest(count=5)
 
-        await evict_lowest(count=5)
+        update_call = mock_cursor.execute.call_args_list[-1]
+        sql = update_call[0][0]
+        assert "ORDER BY usage_score ASC" in sql
 
-        # Check query orders by usage_score ASC
-        select_call = None
-        for call in mock_cursor.execute.call_args_list:
-            if "SELECT id" in str(call[0][0]):
-                select_call = call[0][0]
-                break
-
-        assert select_call is not None
-        assert "ORDER BY usage_score ASC" in select_call
-
-    @patch("valence.core.forgetting.remove_article")
     @patch("valence.core.forgetting.get_cursor")
-    async def test_evict_lowest_handles_removal_failure(self, mock_get_cursor, mock_remove):
-        """Test eviction continues when some removals fail."""
-        from valence.core.forgetting import evict_lowest
-        from valence.core.response import err, ok
-
-        mock_cursor = MagicMock()
-        mock_cursor.fetchone.side_effect = [
-            {"value": '{"max_articles": 10}'},
-            {"cnt": 15},
-        ]
-        mock_cursor.fetchall.return_value = [
-            {"id": "id1"},
-            {"id": "id2"},
-            {"id": "id3"},
-        ]
-        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
-        mock_cursor.__exit__ = Mock(return_value=False)
-        mock_get_cursor.return_value = mock_cursor
-
-        # First removal fails, others succeed
-        mock_remove.side_effect = [
-            err("Failed"),
-            ok(data={"article_id": "id2"}),
-            ok(data={"article_id": "id3"}),
-        ]
-
-        result = await evict_lowest(count=5)
-
-        assert result.success is True
-        # Should have 2 successful evictions
-        assert len(result.data) == 2
-        assert "id2" in result.data
-        assert "id3" in result.data
-
-    @patch("valence.core.forgetting.remove_article")
-    @patch("valence.core.forgetting.get_cursor")
-    async def test_evict_lowest_default_max_articles(self, mock_get_cursor, mock_remove):
+    async def test_default_max_articles(self, mock_get_cursor):
         """Test default max_articles when config missing."""
-        from valence.core.forgetting import evict_lowest
-        from valence.core.response import ok
+        from valence.core.forgetting import archive_lowest
 
         mock_cursor = MagicMock()
         mock_cursor.fetchone.side_effect = [
             None,  # No config row
-            {"cnt": 10001},  # Over default 10000
-        ]
-        mock_cursor.fetchall.return_value = [{"id": "id1"}]
-        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
-        mock_cursor.__exit__ = Mock(return_value=False)
-        mock_get_cursor.return_value = mock_cursor
-
-        mock_remove.return_value = ok(data={"article_id": "id1"})
-
-        result = await evict_lowest(count=5)
-
-        assert result.success is True
-        assert len(result.data) == 1
-
-    @patch("valence.core.forgetting.remove_article")
-    @patch("valence.core.forgetting.get_cursor")
-    async def test_evict_lowest_invalid_config_json(self, mock_get_cursor, mock_remove):
-        """Test handles invalid JSON in config."""
-        from valence.core.forgetting import evict_lowest
-        from valence.core.response import ok
-
-        mock_cursor = MagicMock()
-        mock_cursor.fetchone.side_effect = [
-            {"value": "invalid json{"},  # Bad JSON
             {"cnt": 10001},
         ]
         mock_cursor.fetchall.return_value = [{"id": "id1"}]
@@ -332,19 +219,34 @@ class TestEvictLowest:
         mock_cursor.__exit__ = Mock(return_value=False)
         mock_get_cursor.return_value = mock_cursor
 
-        mock_remove.return_value = ok(data={"article_id": "id1"})
+        result = await archive_lowest(count=5)
 
-        result = await evict_lowest(count=5)
+        assert result.success is True
+        assert len(result.data) == 1
 
-        # Should fall back to default 10000
+    @patch("valence.core.forgetting.get_cursor")
+    async def test_invalid_config_json(self, mock_get_cursor):
+        """Test handles invalid JSON in config."""
+        from valence.core.forgetting import archive_lowest
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.side_effect = [
+            {"value": "invalid json{"},
+            {"cnt": 10001},
+        ]
+        mock_cursor.fetchall.return_value = [{"id": "id1"}]
+        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
+        mock_cursor.__exit__ = Mock(return_value=False)
+        mock_get_cursor.return_value = mock_cursor
+
+        result = await archive_lowest(count=5)
+
         assert result.success is True
 
-    @patch("valence.core.forgetting.remove_article")
     @patch("valence.core.forgetting.get_cursor")
-    async def test_evict_lowest_minimum_count(self, mock_get_cursor, mock_remove):
+    async def test_minimum_count(self, mock_get_cursor):
         """Test count is clamped to minimum 1."""
-        from valence.core.forgetting import evict_lowest
-        from valence.core.response import ok
+        from valence.core.forgetting import archive_lowest
 
         mock_cursor = MagicMock()
         mock_cursor.fetchone.side_effect = [
@@ -356,20 +258,16 @@ class TestEvictLowest:
         mock_cursor.__exit__ = Mock(return_value=False)
         mock_get_cursor.return_value = mock_cursor
 
-        mock_remove.return_value = ok(data={"article_id": "id1"})
-
-        result = await evict_lowest(count=0)
+        result = await archive_lowest(count=0)
 
         assert result.success is True
-        # Should still try to evict at least 1
-        assert mock_remove.called
+        # Should archive at least 1 (count clamped from 0 to 1)
+        assert len(result.data) == 1
 
-    @patch("valence.core.forgetting.remove_article")
     @patch("valence.core.forgetting.get_cursor")
-    async def test_evict_lowest_active_status_only(self, mock_get_cursor, mock_remove):
-        """Test only active articles are counted and evicted."""
-        from valence.core.forgetting import evict_lowest
-        from valence.core.response import ok
+    async def test_only_active_articles(self, mock_get_cursor):
+        """Test only active articles are counted and archived."""
+        from valence.core.forgetting import archive_lowest
 
         mock_cursor = MagicMock()
         mock_cursor.fetchone.side_effect = [
@@ -381,12 +279,20 @@ class TestEvictLowest:
         mock_cursor.__exit__ = Mock(return_value=False)
         mock_get_cursor.return_value = mock_cursor
 
-        mock_remove.return_value = ok(data={"article_id": "id1"})
+        await archive_lowest(count=5)
 
-        await evict_lowest(count=5)
-
-        # Check both queries filter by status='active'
         for call in mock_cursor.execute.call_args_list:
             sql = str(call[0][0])
-            if "FROM articles" in sql:
+            if "FROM articles" in sql and "SELECT COUNT" in sql:
                 assert "status = 'active'" in sql
+
+    async def test_evict_lowest_is_alias(self):
+        """Test evict_lowest delegates to archive_lowest."""
+        from valence.core.forgetting import evict_lowest
+
+        with patch("valence.core.forgetting.archive_lowest") as mock_archive:
+            from valence.core.response import ok
+
+            mock_archive.return_value = ok(data=[])
+            await evict_lowest(count=5)
+            mock_archive.assert_called_once_with(5)


### PR DESCRIPTION
Closes #505

Replace hard deletion with archival for organic forgetting:

- `evict_lowest()` now archives articles (`status='archived'`) instead of permanently deleting them
- Archived articles remain searchable with a rank floor cap of **0.1** on `final_score`
- `archive_lowest()` is the new primary function; `evict_lowest()` is a backwards-compatible alias
- Retrieval SQL updated: `status IN ('active', 'archived')`
- 15 tests rewritten

**-76 net lines** (single UPDATE+RETURNING replaces SELECT→loop→DELETE per article).