### PR TITLE
fix: cast source_ids to uuid[] in memory_recall ANY clause

### DIFF
--- a/src/valence/mcp/handlers/memory.py
+++ b/src/valence/mcp/handlers/memory.py
@@ -156,7 +156,7 @@ def memory_recall(
     if source_ids:
         with get_cursor() as cur:
             cur.execute(
-                "SELECT id, type, metadata FROM sources WHERE id = ANY(%s)",
+                "SELECT id, type, metadata FROM sources WHERE id = ANY(%s::uuid[])",
                 (source_ids,),
             )
             for row in cur.fetchall():


### PR DESCRIPTION
## Problem
`memory_recall` fails with:
```
psycopg2.errors.UndefinedFunction: operator does not exist: uuid = text
```

The `source_ids` list from retrieval contains string UUIDs, but the `sources.id` column is type `uuid`. PostgreSQL needs an explicit cast in the `ANY()` clause.

## Fix
One-line change: `ANY(%s)` → `ANY(%s::uuid[])`

## Testing
All 1623 tests pass, 10 skipped. Found via dogfooding — seeded memories into Valence and tried to recall them.